### PR TITLE
build: add slang submodule and winapi for Windows build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # will have compiled files and executables
 debug/
 target/
+build/
 
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "crates/tree-sitter-verilog"]
-	path = crates/tree-sitter-verilog
-	url = https://github.com/BryanHeBY/tree-sitter-verilog.git
+[submodule "crates/slang"]
+	path = crates/slang
+	url = https://github.com/hongjr03/slang.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,3 +108,6 @@ debug = 0
 [profile.release-lto]
 inherits = "release"
 lto = true
+
+[target.'cfg(target_os = "windows")'.dependencies]
+winapi = { version = "0.3.9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,9 @@ syntax = { path = "./crates/syntax/", version = "0.0.0" }
 utils = { path = "./crates/utils", version = "0.0.0" }
 vfs = { path = "./crates/vfs", version = "0.0.0" }
 vfs-notify = { path = "./crates/vfs-notify/", version = "0.0.0" }
+slang = { path = "./crates/slang", version = "0.0.1" }
+parking_lot = "0.12.1"
+
 
 anyhow = "1.0.75"
 bitflags = "2.9.0"
@@ -75,7 +78,6 @@ rustc-hash = "2.1.1"
 salsa = "0.17.0-pre.2"
 serde = { version = "1.0.189", features = ["derive"] }
 serde_json = "1.0.107"
-slang = { version = "0.0.1", path = "/Users/jiayanw/slang" }
 smallvec = { version = "1.10.0", features = [
   "const_new",
   "union",

--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -5,7 +5,9 @@ edition.workspace = true
 
 [dependencies]
 base-db.workspace = true
-hashbrown = { version = "0.12.3", features = ["inline-more"], default-features = false }
+hashbrown = { version = "0.12.3", features = [
+    "inline-more",
+], default-features = false }
 itertools.workspace = true
 la-arena.workspace = true
 proc-macro-utils.workspace = true
@@ -17,3 +19,4 @@ syntax.workspace = true
 triomphe.workspace = true
 utils.workspace = true
 vfs.workspace = true
+slang.workspace = true


### PR DESCRIPTION
Introduces the slang submodule (replacing the tree-sitter-verilog to avoid repeated Git warnings) and prepares it for [multi-platform builds](https://github.com/hongjr03/slang/commit/b6e546744c4a5d857253108d27ff27f3683845db). Together with [PR #2](https://github.com/roife/vizsla/pull/2/files#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6b)
, this enables automatic cross-platform builds of the VS Code extension. Adds the Windows-specific winapi dependency to ensure successful compilation on Windows.