### PR TITLE
feat(vscode): add TextMate grammars for verilog/systemverilog

### DIFF
--- a/editors/vscode/THIRD_PARTY_NOTICES.md
+++ b/editors/vscode/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,31 @@
+# Third-party notices
+
+## TextMate grammar: Verilog/SystemVerilog
+
+Source: `https://github.com/mshr-h/vscode-verilog-hdl-support` (files `syntaxes/verilog.tmLanguage.json` and `syntaxes/systemverilog.tmLanguage.json`)
+
+License (MIT):
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2016-2022 Masahiro H
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -43,6 +43,18 @@
         "configuration": "./language-configuration.json"
       }
     ],
+    "grammars": [
+      {
+        "language": "verilog",
+        "scopeName": "source.verilog",
+        "path": "./syntaxes/verilog.tmLanguage.json"
+      },
+      {
+        "language": "systemverilog",
+        "scopeName": "source.systemverilog",
+        "path": "./syntaxes/systemverilog.tmLanguage.json"
+      }
+    ],
     "configuration": {
       "title": "Vizsla Language Server",
       "properties": {

--- a/editors/vscode/syntaxes/systemverilog.tmLanguage.json
+++ b/editors/vscode/syntaxes/systemverilog.tmLanguage.json
@@ -1,0 +1,1418 @@
+{
+  "name": "SystemVerilog",
+  "scopeName": "source.systemverilog",
+  "fileTypes": [
+    "v",
+    "vh",
+    "sv",
+    "svh"
+  ],
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#typedef-enum-struct-union"
+    },
+    {
+      "include": "#typedef"
+    },
+    {
+      "include": "#functions"
+    },
+    {
+      "include": "#keywords"
+    },
+    {
+      "include": "#tables"
+    },
+    {
+      "include": "#function-task"
+    },
+    {
+      "include": "#module-declaration"
+    },
+    {
+      "include": "#class-declaration"
+    },
+    {
+      "include": "#enum-struct-union"
+    },
+    {
+      "include": "#sequence"
+    },
+    {
+      "include": "#all-types"
+    },
+    {
+      "include": "#module-parameters"
+    },
+    {
+      "include": "#module-no-parameters"
+    },
+    {
+      "include": "#port-net-parameter"
+    },
+    {
+      "include": "#system-tf"
+    },
+    {
+      "include": "#assertion"
+    },
+    {
+      "include": "#bind-directive"
+    },
+    {
+      "include": "#cast-operator"
+    },
+    {
+      "include": "#storage-scope"
+    },
+    {
+      "include": "#attributes"
+    },
+    {
+      "include": "#imports"
+    },
+    {
+      "include": "#operators"
+    },
+    {
+      "include": "#constants"
+    },
+    {
+      "include": "#identifiers"
+    },
+    {
+      "include": "#selects"
+    }
+  ],
+  "repository": {
+    "function-task": {
+      "begin": "[ \\t\\r\\n]*(?:\\b(virtual)[ \\t\\r\\n]+)?(?:\\b(function|task)\\b)(?:[ \\t\\r\\n]+\\b(static|automatic)\\b)?",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.modifier.systemverilog"
+        },
+        "2": {
+          "name": "storage.type.function.systemverilog"
+        },
+        "3": {
+          "name": "storage.modifier.systemverilog"
+        }
+      },
+      "end": ";",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.function.end.systemverilog"
+        }
+      },
+      "patterns": [
+        {
+          "match": "[ \\t\\r\\n]*(?:\\b([a-zA-Z_][a-zA-Z0-9_$]*)(::))?([a-zA-Z_][a-zA-Z0-9_$]*\\b[ \\t\\r\\n]+)?(?:\\b(signed|unsigned)\\b[ \\t\\r\\n]*)?(?:(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])[ \\t\\r\\n]*)?(?:\\b([a-zA-Z_][a-zA-Z0-9_$]*)\\b[ \\t\\r\\n]*)(?=\\(|;)",
+          "captures": {
+            "1": {
+              "name": "support.type.scope.systemverilog"
+            },
+            "2": {
+              "name": "keyword.operator.scope.systemverilog"
+            },
+            "3": {
+              "patterns": [
+                {
+                  "include": "#built-ins"
+                },
+                {
+                  "match": "[a-zA-Z_][a-zA-Z0-9_$]*",
+                  "name": "storage.type.user-defined.systemverilog"
+                }
+              ]
+            },
+            "4": {
+              "patterns": [
+                {
+                  "include": "#modifiers"
+                }
+              ]
+            },
+            "5": {
+              "patterns": [
+                {
+                  "include": "#selects"
+                }
+              ]
+            },
+            "6": {
+              "name": "entity.name.function.systemverilog"
+            }
+          }
+        },
+        {
+          "include": "#keywords"
+        },
+        {
+          "include": "#port-net-parameter"
+        },
+        {
+          "include": "#base-grammar"
+        },
+        {
+          "include": "#identifiers"
+        }
+      ],
+      "name": "meta.function.systemverilog"
+    },
+    "typedef": {
+      "begin": "[ \\t\\r\\n]*\\b(?:(typedef)[ \\t\\r\\n]+)(?:([a-zA-Z_][a-zA-Z0-9_$]*)(?:[ \\t\\r\\n]+\\b(signed|unsigned)\\b)?(?:[ \\t\\r\\n]*(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])?))?(?=[ \\t\\r\\n]*[a-zA-Z_\\\\])",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.systemverilog"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#built-ins"
+            },
+            {
+              "match": "\\bvirtual\\b",
+              "name": "storage.modifier.systemverilog"
+            }
+          ]
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#modifiers"
+            }
+          ]
+        },
+        "4": {
+          "patterns": [
+            {
+              "include": "#selects"
+            }
+          ]
+        }
+      },
+      "end": ";",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.typedef.end.systemverilog"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#identifiers"
+        },
+        {
+          "include": "#selects"
+        }
+      ],
+      "name": "meta.typedef.systemverilog"
+    },
+    "typedef-enum-struct-union": {
+      "begin": "[ \\t\\r\\n]*\\b(typedef)[ \\t\\r\\n]+(enum|struct|union(?:[ \\t\\r\\n]+tagged)?|class|interface[ \\t\\r\\n]+class)(?:[ \\t\\r\\n]+(?!packed|signed|unsigned)([a-zA-Z_][a-zA-Z0-9_$]*)?(?:[ \\t\\r\\n]*(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])?))?(?:[ \\t\\r\\n]+(packed))?(?:[ \\t\\r\\n]+(signed|unsigned))?(?=[ \\t\\r\\n]*(?:{|$))",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.systemverilog"
+        },
+        "2": {
+          "name": "keyword.control.systemverilog"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#built-ins"
+            }
+          ]
+        },
+        "4": {
+          "patterns": [
+            {
+              "include": "#selects"
+            }
+          ]
+        },
+        "5": {
+          "name": "storage.modifier.systemverilog"
+        },
+        "6": {
+          "name": "storage.modifier.systemverilog"
+        }
+      },
+      "end": "(?<=})[ \\t\\r\\n]*([a-zA-Z_][a-zA-Z0-9_$]*|(?<=^|[ \\t\\r\\n])\\\\[!-~]+(?=$|[ \\t\\r\\n]))(?:[ \\t\\r\\n]*(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])?)[ \\t\\r\\n]*[,;]",
+      "endCaptures": {
+        "1": {
+          "name": "storage.type.systemverilog"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#selects"
+            }
+          ]
+        }
+      },
+      "patterns": [
+        {
+          "include": "#port-net-parameter"
+        },
+        {
+          "include": "#keywords"
+        },
+        {
+          "include": "#base-grammar"
+        },
+        {
+          "include": "#identifiers"
+        }
+      ],
+      "name": "meta.typedef-enum-struct-union.systemverilog"
+    },
+    "enum-struct-union": {
+      "begin": "[ \\t\\r\\n]*\\b(enum|struct|union(?:[ \\t\\r\\n]+tagged)?|class|interface[ \\t\\r\\n]+class)(?:[ \\t\\r\\n]+(?!packed|signed|unsigned)([a-zA-Z_][a-zA-Z0-9_$]*)?(?:[ \\t\\r\\n]*(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])?))?(?:[ \\t\\r\\n]+(packed))?(?:[ \\t\\r\\n]+(signed|unsigned))?(?=[ \\t\\r\\n]*(?:{|$))",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.systemverilog"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#built-ins"
+            }
+          ]
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#selects"
+            }
+          ]
+        },
+        "4": {
+          "name": "storage.modifier.systemverilog"
+        },
+        "5": {
+          "name": "storage.modifier.systemverilog"
+        }
+      },
+      "end": "(?<=})[ \\t\\r\\n]*([a-zA-Z_][a-zA-Z0-9_$]*|(?<=^|[ \\t\\r\\n])\\\\[!-~]+(?=$|[ \\t\\r\\n]))(?:[ \\t\\r\\n]*(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])?)[ \\t\\r\\n]*[,;]",
+      "endCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#identifiers"
+            }
+          ]
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#selects"
+            }
+          ]
+        }
+      },
+      "patterns": [
+        {
+          "include": "#keywords"
+        },
+        {
+          "include": "#base-grammar"
+        },
+        {
+          "include": "#identifiers"
+        }
+      ],
+      "name": "meta.enum-struct-union.systemverilog"
+    },
+    "module-declaration": {
+      "begin": "[ \\t\\r\\n]*\\b((?:macro)?module|interface|program|package|modport)[ \\t\\r\\n]+(?:(static|automatic)[ \\t\\r\\n]+)?([a-zA-Z_][a-zA-Z0-9_$]*)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.systemverilog"
+        },
+        "2": {
+          "name": "storage.modifier.systemverilog"
+        },
+        "3": {
+          "name": "entity.name.type.module.systemverilog"
+        }
+      },
+      "end": ";",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.module.end.systemverilog"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#parameters"
+        },
+        {
+          "include": "#port-net-parameter"
+        },
+        {
+          "include": "#imports"
+        },
+        {
+          "include": "#base-grammar"
+        },
+        {
+          "include": "#system-tf"
+        },
+        {
+          "include": "#identifiers"
+        }
+      ],
+      "name": "meta.module.systemverilog"
+    },
+    "sequence": {
+      "match": "[ \\t\\r\\n]*\\b(sequence)[ \\t\\r\\n]+([a-zA-Z_][a-zA-Z0-9_$]*)\\b",
+      "captures": {
+        "1": {
+          "name": "keyword.control.systemverilog"
+        },
+        "2": {
+          "name": "entity.name.function.systemverilog"
+        }
+      },
+      "name": "meta.sequence.systemverilog"
+    },
+    "bind-directive": {
+      "match": "[ \\t\\r\\n]*\\b(bind)[ \\t\\r\\n]+([a-zA-Z_][a-zA-Z0-9_$\\.]*)\\b",
+      "captures": {
+        "1": {
+          "name": "keyword.control.systemverilog"
+        },
+        "2": {
+          "name": "entity.name.type.module.systemverilog"
+        }
+      },
+      "name": "meta.definition.systemverilog"
+    },
+    "assertion": {
+      "match": "\\b([a-zA-Z_][a-zA-Z0-9_$]*)[ \\t\\r\\n]*(:)[ \\t\\r\\n]*(assert|assume|cover|restrict)\\b",
+      "captures": {
+        "1": {
+          "name": "entity.name.goto-label.php"
+        },
+        "2": {
+          "name": "keyword.operator.systemverilog"
+        },
+        "3": {
+          "name": "keyword.sva.systemverilog"
+        }
+      }
+    },
+    "compiler-directives": {
+      "patterns": [
+        {
+          "match": "(`)(else|endif|endcelldefine|celldefine|nounconnected_drive|resetall|undefineall|end_keywords|__FILE__|__LINE__)\\b",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.directive.systemverilog"
+            },
+            "2": {
+              "name": "string.regexp.systemverilog"
+            }
+          }
+        },
+        {
+          "match": "(`)(ifdef|ifndef|elsif|define|undef|pragma)[ \\t\\r\\n]+([a-zA-Z_][a-zA-Z0-9_$]*)\\b",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.directive.systemverilog"
+            },
+            "2": {
+              "name": "string.regexp.systemverilog"
+            },
+            "3": {
+              "name": "variable.other.constant.preprocessor.systemverilog"
+            }
+          }
+        },
+        {
+          "match": "(`)(include|timescale|default_nettype|unconnected_drive|line|begin_keywords)\\b",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.directive.systemverilog"
+            },
+            "2": {
+              "name": "string.regexp.systemverilog"
+            }
+          }
+        },
+        {
+          "begin": "(`)(protected)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.directive.systemverilog"
+            },
+            "2": {
+              "name": "string.regexp.systemverilog"
+            }
+          },
+          "end": "(`)(endprotected)\\b",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.directive.systemverilog"
+            },
+            "2": {
+              "name": "string.regexp.systemverilog"
+            }
+          },
+          "name": "meta.crypto.systemverilog"
+        },
+        {
+          "match": "(`)([a-zA-Z_][a-zA-Z0-9_$]*)\\b",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.directive.systemverilog"
+            },
+            "2": {
+              "name": "variable.other.constant.preprocessor.systemverilog"
+            }
+          }
+        }
+      ],
+      "name": "meta.preprocessor.systemverilog"
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "match": "[ \\t\\r\\n]*\\b(edge|negedge|posedge|cell|config|defparam|design|disable|endgenerate|endspecify|event|generate|ifnone|incdir|instance|liblist|library|noshowcancelled|pulsestyle_onevent|pulsestyle_ondetect|scalared|showcancelled|specify|specparam|use|vectored)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.other.systemverilog"
+            }
+          }
+        },
+        {
+          "include": "#sv-control"
+        },
+        {
+          "include": "#sv-control-begin"
+        },
+        {
+          "include": "#sv-control-end"
+        },
+        {
+          "include": "#sv-definition"
+        },
+        {
+          "include": "#sv-cover-cross"
+        },
+        {
+          "include": "#sv-std"
+        },
+        {
+          "include": "#sv-option"
+        },
+        {
+          "include": "#sv-local"
+        },
+        {
+          "include": "#sv-rand"
+        }
+      ]
+    },
+    "sv-control": {
+      "match": "[ \\t\\r\\n]*\\b(initial|always|always_comb|always_ff|always_latch|final|assign|deassign|force|release|wait|forever|repeat|alias|while|for|if|iff|else|case|casex|casez|default|endcase|return|break|continue|do|foreach|clocking|coverpoint|property|bins|binsof|illegal_bins|ignore_bins|randcase|matches|solve|before|expect|cross|ref|srandom|struct|chandle|tagged|extern|throughout|timeprecision|timeunit|priority|type|union|wait_order|triggered|randsequence|context|pure|wildcard|new|forkjoin|unique|unique0|priority)\\b",
+      "captures": {
+        "1": {
+          "name": "keyword.control.systemverilog"
+        }
+      }
+    },
+    "sv-control-begin": {
+      "match": "[ \\t\\r\\n]*\\b(begin|fork)\\b(?:[ \\t\\r\\n]*(:)[ \\t\\r\\n]*([a-zA-Z_][a-zA-Z0-9_$]*))?",
+      "captures": {
+        "1": {
+          "name": "keyword.control.systemverilog"
+        },
+        "2": {
+          "name": "punctuation.definition.label.systemverilog"
+        },
+        "3": {
+          "name": "entity.name.section.systemverilog"
+        }
+      },
+      "name": "meta.item.begin.systemverilog"
+    },
+    "sv-control-end": {
+      "match": "[ \\t\\r\\n]*\\b(end|endmodule|endinterface|endprogram|endchecker|endclass|endpackage|endconfig|endfunction|endtask|endproperty|endsequence|endgroup|endprimitive|endclocking|endgenerate|join|join_any|join_none)\\b(?:[ \\t\\r\\n]*(:)[ \\t\\r\\n]*([a-zA-Z_][a-zA-Z0-9_$]*))?",
+      "captures": {
+        "1": {
+          "name": "keyword.control.systemverilog"
+        },
+        "2": {
+          "name": "punctuation.definition.label.systemverilog"
+        },
+        "3": {
+          "name": "entity.name.section.systemverilog"
+        }
+      },
+      "name": "meta.item.end.systemverilog"
+    },
+    "sv-std": {
+      "match": "\\b(std)\\b::",
+      "name": "support.class.systemverilog"
+    },
+    "sv-definition": {
+      "match": "[ \\t\\r\\n]*\\b(primitive|package|constraint|interface|covergroup|program)[ \\t\\r\\n]+\\b([a-zA-Z_][a-zA-Z0-9_$]*)\\b",
+      "captures": {
+        "1": {
+          "name": "keyword.control.systemverilog"
+        },
+        "2": {
+          "name": "entity.name.type.class.systemverilog"
+        }
+      },
+      "name": "meta.definition.systemverilog"
+    },
+    "sv-cover-cross": {
+      "match": "(([a-zA-Z_][a-zA-Z0-9_$]*)[ \\t\\r\\n]*(:))?[ \\t\\r\\n]*(coverpoint|cross)[ \\t\\r\\n]+([a-zA-Z_][a-zA-Z0-9_$]*)",
+      "captures": {
+        "2": {
+          "name": "entity.name.type.class.systemverilog"
+        },
+        "3": {
+          "name": "keyword.operator.other.systemverilog"
+        },
+        "4": {
+          "name": "keyword.control.systemverilog"
+        }
+      },
+      "name": "meta.definition.systemverilog"
+    },
+    "class-declaration": {
+      "begin": "[ \\t\\r\\n]*\\b(virtual[ \\t\\r\\n]+)?(class)(?:[ \\t\\r\\n]+(static|automatic))?[ \\t\\r\\n]+([a-zA-Z_][a-zA-Z0-9_$:]*)(?:[ \\t\\r\\n]+(extends|implements)[ \\t\\r\\n]+([a-zA-Z_][a-zA-Z0-9_$:]*))?",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.modifier.systemverilog"
+        },
+        "2": {
+          "name": "storage.type.class.systemverilog"
+        },
+        "3": {
+          "name": "storage.modifier.systemverilog"
+        },
+        "4": {
+          "name": "entity.name.type.class.systemverilog"
+        },
+        "5": {
+          "name": "keyword.control.systemverilog"
+        },
+        "6": {
+          "name": "entity.name.type.class.systemverilog"
+        }
+      },
+      "end": ";",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.class.end.systemverilog"
+        }
+      },
+      "patterns": [
+        {
+          "match": "[ \\t\\r\\n]+\\b(extends|implements)[ \\t\\r\\n]+([a-zA-Z_][a-zA-Z0-9_$:]*)(?:[ \\t\\r\\n]*,[ \\t\\r\\n]*([a-zA-Z_][a-zA-Z0-9_$:]*))*",
+          "captures": {
+            "1": {
+              "name": "keyword.control.systemverilog"
+            },
+            "2": {
+              "name": "entity.name.type.class.systemverilog"
+            },
+            "3": {
+              "name": "entity.name.type.class.systemverilog"
+            }
+          }
+        },
+        {
+          "match": "[ \\t\\r\\n]+\\b([a-zA-Z_][a-zA-Z0-9_$]*)[ \\t\\r\\n]*(#)\\(",
+          "captures": {
+            "1": {
+              "name": "storage.type.userdefined.systemverilog"
+            },
+            "2": {
+              "name": "keyword.operator.param.systemverilog"
+            }
+          },
+          "name": "meta.typedef.class.systemverilog"
+        },
+        {
+          "include": "#port-net-parameter"
+        },
+        {
+          "include": "#base-grammar"
+        },
+        {
+          "include": "#module-binding"
+        },
+        {
+          "include": "#identifiers"
+        }
+      ],
+      "name": "meta.class.systemverilog"
+    },
+    "system-tf": {
+      "match": "\\$[a-zA-Z0-9_$][a-zA-Z0-9_$]*\\b",
+      "name": "support.function.systemverilog"
+    },
+    "cast-operator": {
+      "match": "[ \\t\\r\\n]*([0-9]+|[a-zA-Z_][a-zA-Z0-9_$]*)(')(?=\\()",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#built-ins"
+            },
+            {
+              "include": "#constants"
+            },
+            {
+              "match": "[a-zA-Z_][a-zA-Z0-9_$]*",
+              "name": "storage.type.user-defined.systemverilog"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.operator.cast.systemverilog"
+        }
+      },
+      "name": "meta.cast.systemverilog"
+    },
+    "sv-option": {
+      "match": "[ \\t\\r\\n]*\\b(option)\\.",
+      "captures": {
+        "1": {
+          "name": "keyword.cover.systemverilog"
+        }
+      }
+    },
+    "sv-local": {
+      "match": "[ \\t\\r\\n]*\\b(const|static|protected|virtual|localparam|parameter|local)\\b",
+      "captures": {
+        "1": {
+          "name": "keyword.other.systemverilog"
+        }
+      }
+    },
+    "sv-rand": {
+      "match": "[ \\t\\r\\n]*\\b(?:rand|randc)\\b",
+      "name": "storage.type.rand.systemverilog"
+    },
+    "module-parameters": {
+      "begin": "[ \\t\\r\\n]*\\b(?:(bind)[ \\t\\r\\n]+([a-zA-Z_][a-zA-Z0-9_$\\.]*)[ \\t\\r\\n]+)?([a-zA-Z_][a-zA-Z0-9_$]*)[ \\t\\r\\n]+(?!intersect|and|or|throughout|within)(?=#[^#])",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.systemverilog"
+        },
+        "2": {
+          "name": "entity.name.type.module.systemverilog"
+        },
+        "3": {
+          "name": "entity.name.type.module.systemverilog"
+        }
+      },
+      "end": "\\)(?:[ \\t\\r\\n]*(;))?",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.module.instantiation.end.systemverilog"
+        }
+      },
+      "patterns": [
+        {
+          "match": "\\b([a-zA-Z_][a-zA-Z0-9_$]*)\\b(?=[ \\t\\r\\n]*\\()",
+          "name": "variable.other.module.systemverilog"
+        },
+        {
+          "include": "#module-binding"
+        },
+        {
+          "include": "#parameters"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#operators"
+        },
+        {
+          "include": "#constants"
+        },
+        {
+          "include": "#strings"
+        },
+        {
+          "include": "#port-net-parameter"
+        },
+        {
+          "match": "\\b([a-zA-Z_][a-zA-Z0-9_$]*)\\b(?=[ \\t\\r\\n]*$)",
+          "name": "variable.other.module.systemverilog"
+        },
+        {
+          "include": "#identifiers"
+        }
+      ],
+      "name": "meta.module.parameters.systemverilog"
+    },
+    "module-no-parameters": {
+      "begin": "[ \\t\\r\\n]*\\b(?:(bind|pullup|pulldown)[ \\t\\r\\n]+(?:([a-zA-Z_][a-zA-Z0-9_$\\.]*)[ \\t\\r\\n]+)?)?((?:\\b(?:and|nand|or|nor|xor|xnor|buf|not|bufif[01]|notif[01]|r?[npc]mos|r?tran|r?tranif[01])\\b|[a-zA-Z_][a-zA-Z0-9_$]*))[ \\t\\r\\n]+(?!intersect|and|or|throughout|within)([a-zA-Z_][a-zA-Z0-9_$]*)(?:[ \\t\\r\\n]*(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])?)[ \\t\\r\\n]*(?=\\(|$)(?!;)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.systemverilog"
+        },
+        "2": {
+          "name": "entity.name.type.module.systemverilog"
+        },
+        "3": {
+          "name": "entity.name.type.module.systemverilog"
+        },
+        "4": {
+          "name": "variable.other.module.systemverilog"
+        },
+        "5": {
+          "patterns": [
+            {
+              "include": "#selects"
+            }
+          ]
+        }
+      },
+      "end": "\\)(?:[ \\t\\r\\n]*(;))?",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.module.instantiation.end.systemverilog"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#module-binding"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#operators"
+        },
+        {
+          "include": "#constants"
+        },
+        {
+          "include": "#strings"
+        },
+        {
+          "include": "#port-net-parameter"
+        },
+        {
+          "match": "\\b([a-zA-Z_][a-zA-Z0-9_$]*)\\b(?=[ \\t\\r\\n]*(\\(|$))",
+          "name": "variable.other.module.systemverilog"
+        },
+        {
+          "include": "#identifiers"
+        }
+      ],
+      "name": "meta.module.no_parameters.systemverilog"
+    },
+    "functions": {
+      "match": "[ \\t\\r\\n]*\\b(?!while|for|if|iff|else|case|casex|casez)([a-zA-Z_][a-zA-Z0-9_$]*)(?=[ \\t\\r\\n]*\\()",
+      "name": "entity.name.function.systemverilog"
+    },
+    "all-types": {
+      "patterns": [
+        {
+          "include": "#built-ins"
+        },
+        {
+          "include": "#modifiers"
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "match": "(\\b[1-9][0-9_]*)?'([sS]?[bB][ \\t\\r\\n]*[0-1xXzZ?][0-1_xXzZ?]*|[sS]?[oO][ \\t\\r\\n]*[0-7xXzZ?][0-7_xXzZ?]*|[sS]?[dD][ \\t\\r\\n]*[0-9xXzZ?][0-9_xXzZ?]*|[sS]?[hH][ \\t\\r\\n]*[0-9a-fA-FxXzZ?][0-9a-fA-F_xXzZ?]*)((e|E)(\\+|-)?[0-9]+)?(?!'|\\w)",
+          "name": "constant.numeric.systemverilog"
+        },
+        {
+          "match": "'[01xXzZ]",
+          "name": "constant.numeric.bit.systemverilog"
+        },
+        {
+          "match": "\\b(?:\\d[\\d_\\.]*(?<!\\.)(?:e|E)(?:\\+|-)?[0-9]+)\\b",
+          "name": "constant.numeric.exp.systemverilog"
+        },
+        {
+          "match": "\\b(?:\\d[\\d_\\.]*(?!(?:[\\d\\.]|[ \\t\\r\\n]*(?:e|E|fs|ps|ns|us|ms|s))))\\b",
+          "name": "constant.numeric.decimal.systemverilog"
+        },
+        {
+          "match": "\\b(?:\\d[\\d\\.]*[ \\t\\r\\n]*(?:fs|ps|ns|us|ms|s))\\b",
+          "name": "constant.numeric.time.systemverilog"
+        },
+        {
+          "include": "#compiler-directives"
+        },
+        {
+          "match": "\\b(?:this|super|null)\\b",
+          "name": "constant.language.systemverilog"
+        },
+        {
+          "match": "\\b([A-Z][A-Z0-9_]*)\\b",
+          "name": "constant.other.net.systemverilog"
+        },
+        {
+          "match": "\\b(?<!\\.)([A-Z0-9_]+)(?!\\.)\\b",
+          "name": "constant.numeric.parameter.uppercase.systemverilog"
+        },
+        {
+          "match": "\\.\\*",
+          "name": "keyword.operator.quantifier.regexp"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "match": "\\b(?:dist|inside|with|intersect|and|or|throughout|within|first_match)\\b|:=|:/|\\|->|\\|=>|->>|\\*>|#-#|#=#|&&&",
+          "name": "keyword.operator.logical.systemverilog"
+        },
+        {
+          "match": "@|##|#|->|<->",
+          "name": "keyword.operator.channel.systemverilog"
+        },
+        {
+          "match": "\\+=|-=|/=|\\*=|%=|&=|\\|=|\\^=|>>>=|>>=|<<<=|<<=|<=|=",
+          "name": "keyword.operator.assignment.systemverilog"
+        },
+        {
+          "match": "\\+\\+",
+          "name": "keyword.operator.increment.systemverilog"
+        },
+        {
+          "match": "--",
+          "name": "keyword.operator.decrement.systemverilog"
+        },
+        {
+          "match": "\\+|-|\\*\\*|\\*|/|%",
+          "name": "keyword.operator.arithmetic.systemverilog"
+        },
+        {
+          "match": "!|&&|\\|\\|",
+          "name": "keyword.operator.logical.systemverilog"
+        },
+        {
+          "match": "<<<|<<|>>>|>>",
+          "name": "keyword.operator.bitwise.shift.systemverilog"
+        },
+        {
+          "match": "~&|~\\||~|\\^~|~\\^|&|\\||\\^|{|'{|}|:|\\?",
+          "name": "keyword.operator.bitwise.systemverilog"
+        },
+        {
+          "match": "<=|<|>=|>|==\\?|!=\\?|===|!==|==|!=",
+          "name": "keyword.operator.comparison.systemverilog"
+        }
+      ]
+    },
+    "comments": {
+      "patterns": [
+        {
+          "begin": "/\\*",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.systemverilog"
+            }
+          },
+          "end": "\\*/",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.systemverilog"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#fixme-todo"
+            }
+          ],
+          "name": "comment.block.systemverilog"
+        },
+        {
+          "begin": "//",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.systemverilog"
+            }
+          },
+          "end": "$\\n?",
+          "patterns": [
+            {
+              "include": "#fixme-todo"
+            }
+          ],
+          "name": "comment.line.double-slash.systemverilog"
+        }
+      ]
+    },
+    "fixme-todo": {
+      "patterns": [
+        {
+          "match": "(?i:fixme)",
+          "name": "invalid.broken.fixme.systemverilog"
+        },
+        {
+          "match": "(?i:todo)",
+          "name": "invalid.unimplemented.todo.systemverilog"
+        }
+      ]
+    },
+    "port-net-parameter": {
+      "patterns": [
+        {
+          "match": ",?[ \\t\\r\\n]*(?:\\b(output|input|inout|ref)\\b[ \\t\\r\\n]*)?(?:\\b(localparam|parameter|var|supply[01]|tri|triand|trior|trireg|tri[01]|uwire|wire|wand|wor)\\b[ \\t\\r\\n]*)?(?:\\b([a-zA-Z_][a-zA-Z0-9_$]*)(::))?(?:([a-zA-Z_][a-zA-Z0-9_$]*)\\b[ \\t\\r\\n]*)?(?:\\b(signed|unsigned)\\b[ \\t\\r\\n]*)?(?:(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])[ \\t\\r\\n]*)?(?<!(?<!#)[:&|=+\\-*/%?><^!~\\(][ \\t\\r\\n]*)\\b([a-zA-Z_][a-zA-Z0-9_$]*)\\b[ \\t\\r\\n]*(\\[[a-zA-Z0-9_:$\\.\\-\\+\\*/%`' \\t\\r\\n\\[\\]\\(\\)]*\\])?[ \\t\\r\\n]*(?=,|;|=|\\)|/|$)",
+          "captures": {
+            "1": {
+              "name": "support.type.direction.systemverilog"
+            },
+            "2": {
+              "name": "storage.type.net.systemverilog"
+            },
+            "3": {
+              "name": "support.type.scope.systemverilog"
+            },
+            "4": {
+              "name": "keyword.operator.scope.systemverilog"
+            },
+            "5": {
+              "patterns": [
+                {
+                  "include": "#built-ins"
+                },
+                {
+                  "match": "[a-zA-Z_][a-zA-Z0-9_$]*",
+                  "name": "storage.type.user-defined.systemverilog"
+                }
+              ]
+            },
+            "6": {
+              "patterns": [
+                {
+                  "include": "#modifiers"
+                }
+              ]
+            },
+            "7": {
+              "patterns": [
+                {
+                  "include": "#selects"
+                }
+              ]
+            },
+            "8": {
+              "patterns": [
+                {
+                  "include": "#constants"
+                },
+                {
+                  "include": "#identifiers"
+                }
+              ]
+            },
+            "9": {
+              "patterns": [
+                {
+                  "include": "#selects"
+                }
+              ]
+            }
+          },
+          "name": "meta.port-net-parameter.declaration.systemverilog"
+        }
+      ]
+    },
+    "base-grammar": {
+      "patterns": [
+        {
+          "include": "#all-types"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#operators"
+        },
+        {
+          "include": "#constants"
+        },
+        {
+          "include": "#strings"
+        },
+        {
+          "match": "[ \\t\\r\\n]*\\b([a-zA-Z_][a-zA-Z0-9_$]*)[ \\t\\r\\n]+[a-zA-Z_][a-zA-Z0-9_,= \\t\\n]*",
+          "captures": {
+            "1": {
+              "name": "storage.type.interface.systemverilog"
+            }
+          }
+        },
+        {
+          "include": "#storage-scope"
+        }
+      ]
+    },
+    "built-ins": {
+      "patterns": [
+        {
+          "match": "[ \\t\\r\\n]*\\b(bit|logic|reg)\\b",
+          "name": "storage.type.vector.systemverilog"
+        },
+        {
+          "match": "[ \\t\\r\\n]*\\b(byte|shortint|int|longint|integer|time|genvar)\\b",
+          "name": "storage.type.atom.systemverilog"
+        },
+        {
+          "match": "[ \\t\\r\\n]*\\b(shortreal|real|realtime)\\b",
+          "name": "storage.type.notint.systemverilog"
+        },
+        {
+          "match": "[ \\t\\r\\n]*\\b(supply[01]|tri|triand|trior|trireg|tri[01]|uwire|wire|wand|wor)\\b",
+          "name": "storage.type.net.systemverilog"
+        },
+        {
+          "match": "[ \\t\\r\\n]*\\b(genvar|var|void|signed|unsigned|string|const|process)\\b",
+          "name": "storage.type.built-in.systemverilog"
+        },
+        {
+          "match": "[ \\t\\r\\n]*\\b(uvm_(?:root|transaction|component|monitor|driver|test|env|object|agent|sequence_base|sequence_item|sequence_state|sequencer|sequencer_base|sequence|component_registry|analysis_imp|analysis_port|analysis_export|config_db|active_passive_enum|phase|verbosity|tlm_analysis_fifo|tlm_fifo|report_server|objection|recorder|domain|reg_field|reg_block|reg|bitstream_t|radix_enum|printer|packer|comparer|scope_stack))\\b",
+          "name": "storage.type.uvm.systemverilog"
+        }
+      ]
+    },
+    "modifiers": {
+      "match": "[ \\t\\r\\n]*\\b(?:(?:un)?signed|packed|small|medium|large|supply[01]|strong[01]|pull[01]|weak[01]|highz[01])\\b",
+      "name": "storage.modifier.systemverilog"
+    },
+    "storage-scope": {
+      "match": "\\b([a-zA-Z_][a-zA-Z0-9_$]*)(::)",
+      "captures": {
+        "1": {
+          "name": "support.type.scope.systemverilog"
+        },
+        "2": {
+          "name": "keyword.operator.scope.systemverilog"
+        }
+      },
+      "name": "meta.scope.systemverilog"
+    },
+    "strings": {
+      "patterns": [
+        {
+          "begin": "`?\"",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.systemverilog"
+            }
+          },
+          "end": "\"`?",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.systemverilog"
+            }
+          },
+          "name": "string.quoted.double.systemverilog",
+          "patterns": [
+            {
+              "match": "\\\\(?:[nt\\\\\"vfa]|[0-7]{3}|x[0-9a-fA-F]{2})",
+              "name": "constant.character.escape.systemverilog"
+            },
+            {
+              "match": "(?x)%\n(\\d+\\$)?                              # field (argument #)\n['\\-+0 #]*                            # flags\n[,;:_]?                               # separator character\n((-?\\d+)|\\*(-?\\d+\\$)?)?               # minimum field width\n(\\.((-?\\d+)|\\*(-?\\d+\\$)?)?)?          # precision\n(hh|h|ll|l|j|z|t|L)?                  # length modifier\n[xXhHdDoObBcClLvVmMpPsStTuUzZeEfFgG%] # conversion type",
+              "name": "constant.character.format.placeholder.systemverilog"
+            },
+            {
+              "match": "%",
+              "name": "invalid.illegal.placeholder.systemverilog"
+            },
+            {
+              "include": "#fixme-todo"
+            }
+          ]
+        },
+        {
+          "begin": "(?<=include)[ \\t\\r\\n]*(<)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.begin.systemverilog"
+            }
+          },
+          "end": ">",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.systemverilog"
+            }
+          },
+          "name": "string.quoted.other.lt-gt.include.systemverilog"
+        }
+      ]
+    },
+    "module-binding": {
+      "begin": "\\.([a-zA-Z_][a-zA-Z0-9_$]*)[ \\t\\r\\n]*\\(",
+      "beginCaptures": {
+        "1": {
+          "name": "support.function.port.systemverilog"
+        }
+      },
+      "end": "\\),?",
+      "patterns": [
+        {
+          "include": "#constants"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#operators"
+        },
+        {
+          "include": "#strings"
+        },
+        {
+          "include": "#constants"
+        },
+        {
+          "include": "#storage-scope"
+        },
+        {
+          "include": "#cast-operator"
+        },
+        {
+          "include": "#system-tf"
+        },
+        {
+          "match": "\\bvirtual\\b",
+          "name": "storage.modifier.systemverilog"
+        },
+        {
+          "include": "#identifiers"
+        }
+      ],
+      "name": "meta.port.binding.systemverilog"
+    },
+    "parameters": {
+      "begin": "[ \\t\\r\\n]*(#)[ \\t\\r\\n]*(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.operator.channel.systemverilog"
+        },
+        "2": {
+          "name": "punctuation.section.parameters.begin"
+        }
+      },
+      "end": "(\\))[ \\t\\r\\n]*(?=;|\\(|[a-zA-Z_]|\\\\|$)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.parameters.end"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#port-net-parameter"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#constants"
+        },
+        {
+          "include": "#operators"
+        },
+        {
+          "include": "#strings"
+        },
+        {
+          "include": "#system-tf"
+        },
+        {
+          "include": "#functions"
+        },
+        {
+          "match": "\\bvirtual\\b",
+          "name": "storage.modifier.systemverilog"
+        },
+        {
+          "include": "#module-binding"
+        }
+      ],
+      "name": "meta.parameters.systemverilog"
+    },
+    "identifiers": {
+      "patterns": [
+        {
+          "match": "\\b[a-zA-Z_][a-zA-Z0-9_$]*\\b",
+          "name": "variable.other.identifier.systemverilog"
+        },
+        {
+          "match": "(?<=^|[ \\t\\r\\n])\\\\[!-~]+(?=$|[ \\t\\r\\n])",
+          "name": "string.regexp.identifier.systemverilog"
+        }
+      ]
+    },
+    "selects": {
+      "begin": "\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.slice.brackets.begin"
+        }
+      },
+      "end": "\\]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.slice.brackets.end"
+        }
+      },
+      "patterns": [
+        {
+          "match": "\\$(?![a-z])",
+          "name": "constant.language.systemverilog"
+        },
+        {
+          "include": "#system-tf"
+        },
+        {
+          "include": "#constants"
+        },
+        {
+          "include": "#operators"
+        },
+        {
+          "include": "#cast-operator"
+        },
+        {
+          "include": "#storage-scope"
+        },
+        {
+          "match": "[a-zA-Z_][a-zA-Z0-9_$]*",
+          "name": "variable.other.identifier.systemverilog"
+        }
+      ],
+      "name": "meta.brackets.select.systemverilog"
+    },
+    "attributes": {
+      "begin": "(?<!@[ \\t\\r\\n]?)\\(\\*",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.attribute.rounds.begin"
+        }
+      },
+      "end": "\\*\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.attribute.rounds.end"
+        }
+      },
+      "patterns": [
+        {
+          "match": "([a-zA-Z_][a-zA-Z0-9_$]*)(?:[ \\t\\r\\n]*(=)[ \\t\\r\\n]*)?",
+          "captures": {
+            "1": {
+              "name": "keyword.control.systemverilog"
+            },
+            "2": {
+              "name": "keyword.operator.assignment.systemverilog"
+            }
+          }
+        },
+        {
+          "include": "#constants"
+        },
+        {
+          "include": "#strings"
+        }
+      ],
+      "name": "meta.attribute.systemverilog"
+    },
+    "imports": {
+      "match": "[ \\t\\r\\n]*\\b(import|export)[ \\t\\r\\n]+([a-zA-Z_][a-zA-Z0-9_$]*|\\*)[ \\t\\r\\n]*(::)[ \\t\\r\\n]*([a-zA-Z_][a-zA-Z0-9_$]*|\\*)[ \\t\\r\\n]*(,|;)",
+      "captures": {
+        "1": {
+          "name": "keyword.control.systemverilog"
+        },
+        "2": {
+          "name": "support.type.scope.systemverilog"
+        },
+        "3": {
+          "name": "keyword.operator.scope.systemverilog"
+        },
+        "4": {
+          "patterns": [
+            {
+              "include": "#operators"
+            },
+            {
+              "include": "#identifiers"
+            }
+          ]
+        }
+      },
+      "name": "meta.import.systemverilog"
+    },
+    "tables": {
+      "begin": "[ \\t\\r\\n]*\\b(table)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.table.systemverilog.begin"
+        }
+      },
+      "end": "[ \\t\\r\\n]*\\b(endtable)\\b",
+      "endCaptures": {
+        "1": {
+          "name": "keyword.table.systemverilog.end"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "match": "\\b[01xXbBrRfFpPnN]\\b",
+          "name": "constant.language.systemverilog"
+        },
+        {
+          "match": "[-*?]",
+          "name": "constant.language.systemverilog"
+        },
+        {
+          "match": "\\(([01xX?]{2})\\)",
+          "captures": {
+            "1": {
+              "name": "constant.language.systemverilog"
+            }
+          }
+        },
+        {
+          "match": ":",
+          "name": "punctuation.definition.label.systemverilog"
+        },
+        {
+          "include": "#operators"
+        },
+        {
+          "include": "#constants"
+        },
+        {
+          "include": "#strings"
+        },
+        {
+          "include": "#identifiers"
+        }
+      ],
+      "name": "meta.table.systemverilog"
+    }
+  }
+}

--- a/editors/vscode/syntaxes/verilog.tmLanguage.json
+++ b/editors/vscode/syntaxes/verilog.tmLanguage.json
@@ -1,0 +1,306 @@
+{
+  "fileTypes": [
+    "v",
+    "vh"
+  ],
+  "keyEquivalent": "^~V",
+  "name": "Verilog",
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#module_pattern"
+    },
+    {
+      "include": "#keywords"
+    },
+    {
+      "include": "#constants"
+    },
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#operators"
+    }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "begin": "(^[ \\t]+)?(?=//)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.whitespace.comment.leading.verilog"
+            }
+          },
+          "end": "(?!\\G)",
+          "patterns": [
+            {
+              "begin": "//",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.definition.comment.verilog"
+                }
+              },
+              "end": "\\n",
+              "name": "comment.line.double-slash.verilog"
+            }
+          ]
+        },
+        {
+          "begin": "/\\*",
+          "end": "\\*/",
+          "name": "comment.block.c-style.verilog"
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "match": "`(?!(celldefine|endcelldefine|default_nettype|define|undef|ifdef|ifndef|else|endif|include|resetall|timescale|unconnected_drive|nounconnected_drive))[a-z_A-Z][a-zA-Z0-9_$]*",
+          "name": "variable.other.constant.verilog"
+        },
+        {
+          "match": "[0-9]*'[bBoOdDhH][a-fA-F0-9_xXzZ]+\\b",
+          "name": "constant.numeric.sized_integer.verilog"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "constant.numeric.integer.verilog"
+            },
+            "2": {
+              "name": "punctuation.separator.range.verilog"
+            },
+            "3": {
+              "name": "constant.numeric.integer.verilog"
+            }
+          },
+          "match": "\\b(\\d+)(:)(\\d+)\\b",
+          "name": "meta.block.numeric.range.verilog"
+        },
+        {
+          "match": "\\b\\d[\\d_]*(?i:e\\d+)?\\b",
+          "name": "constant.numeric.integer.verilog"
+        },
+        {
+          "match": "\\b\\d+\\.\\d+(?i:e\\d+)?\\b",
+          "name": "constant.numeric.real.verilog"
+        },
+        {
+          "match": "#\\d+",
+          "name": "constant.numeric.delay.verilog"
+        },
+        {
+          "match": "\\b[01xXzZ]+\\b",
+          "name": "constant.numeric.logic.verilog"
+        }
+      ]
+    },
+    "instantiation_patterns": {
+      "patterns": [
+        {
+          "include": "#keywords"
+        },
+        {
+          "begin": "^\\s*(?!always|and|assign|output|input|inout|wire|module)([a-zA-Z][a-zA-Z0-9_]*)\\s+([a-zA-Z][a-zA-Z0-9_]*)(?<!begin|if)\\s*(?=\\(|$)",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.tag.module.reference.verilog"
+            },
+            "2": {
+              "name": "entity.name.tag.module.identifier.verilog"
+            }
+          },
+          "end": ";",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.terminator.expression.verilog"
+            }
+          },
+          "name": "meta.block.instantiation.parameterless.verilog",
+          "patterns": [
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#constants"
+            },
+            {
+              "include": "#strings"
+            }
+          ]
+        },
+        {
+          "begin": "^\\s*([a-zA-Z][a-zA-Z0-9_]*)\\s*(#)(?=\\s*\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.tag.module.reference.verilog"
+            }
+          },
+          "end": ";",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.terminator.expression.verilog"
+            }
+          },
+          "name": "meta.block.instantiation.with.parameters.verilog",
+          "patterns": [
+            {
+              "include": "#parenthetical_list"
+            },
+            {
+              "match": "[a-zA-Z][a-zA-Z0-9_]*",
+              "name": "entity.name.tag.module.identifier.verilog"
+            }
+          ]
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "match": "\\b(always|and|assign|attribute|begin|buf|bufif0|bufif1|case[xz]?|cmos|deassign|default|defparam|disable|edge|else|end(attribute|case|function|generate|module|primitive|specify|table|task)?|event|for|force|forever|fork|function|generate|genvar|highz(01)|if(none)?|initial|inout|input|integer|join|localparam|medium|module|large|macromodule|nand|negedge|nmos|nor|not|notif(01)|or|output|parameter|pmos|posedge|primitive|pull0|pull1|pulldown|pullup|rcmos|real|realtime|reg|release|repeat|rnmos|rpmos|rtran|rtranif(01)|scalared|signed|small|specify|specparam|strength|strong0|strong1|supply0|supply1|table|task|time|tran|tranif(01)|tri(01)?|tri(and|or|reg)|unsigned|vectored|wait|wand|weak(01)|while|wire|wor|xnor|xor)\\b",
+          "name": "keyword.other.verilog"
+        },
+        {
+          "match": "^\\s*`((cell)?define|default_(decay_time|nettype|trireg_strength)|delay_mode_(path|unit|zero)|ifdef|ifndef|include|end(if|celldefine)|else|(no)?unconnected_drive|resetall|timescale|undef)\\b",
+          "name": "keyword.other.compiler.directive.verilog"
+        },
+        {
+          "match": "\\$(f(open|close)|readmem(b|h)|timeformat|printtimescale|stop|finish|(s|real)?time|realtobits|bitstoreal|rtoi|itor|(f)?(display|write(h|b)))\\b",
+          "name": "support.function.system.console.tasks.verilog"
+        },
+        {
+          "match": "\\$(random|dist_(chi_square|erlang|exponential|normal|poisson|t|uniform))\\b",
+          "name": "support.function.system.random_number.tasks.verilog"
+        },
+        {
+          "match": "\\$((a)?sync\\$((n)?and|(n)or)\\$(array|plane))\\b",
+          "name": "support.function.system.pld_modeling.tasks.verilog"
+        },
+        {
+          "match": "\\$(q_(initialize|add|remove|full|exam))\\b",
+          "name": "support.function.system.stochastic.tasks.verilog"
+        },
+        {
+          "match": "\\$(hold|nochange|period|recovery|setup(hold)?|skew|width)\\b",
+          "name": "support.function.system.timing.tasks.verilog"
+        },
+        {
+          "match": "\\$(dump(file|vars|off|on|all|limit|flush))\\b",
+          "name": "support.function.system.vcd.tasks.verilog"
+        },
+        {
+          "match": "\\$(countdrivers|list|input|scope|showscopes|(no)?(key|log)|reset(_count|_value)?|(inc)?save|restart|showvars|getpattern|sreadmem(b|h)|scale)",
+          "name": "support.function.non-standard.tasks.verilog"
+        }
+      ]
+    },
+    "module_pattern": {
+      "patterns": [
+        {
+          "begin": "\\b(module)\\s+([a-zA-Z][a-zA-Z0-9_]*)",
+          "beginCaptures": {
+            "1": {
+              "name": "storage.type.module.verilog"
+            },
+            "2": {
+              "name": "entity.name.type.module.verilog"
+            }
+          },
+          "end": "\\bendmodule\\b",
+          "endCaptures": {
+            "0": {
+              "name": "storage.type.module.verilog"
+            }
+          },
+          "name": "meta.block.module.verilog",
+          "patterns": [
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "include": "#constants"
+            },
+            {
+              "include": "#strings"
+            },
+            {
+              "include": "#instantiation_patterns"
+            },
+            {
+              "include": "#operators"
+            }
+          ]
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "match": "\\+|-|\\*|/|%|(<|>)=?|(!|=)?==?|!|&&?|\\|\\|?|\\^?~|~\\^?",
+          "name": "keyword.operator.verilog"
+        }
+      ]
+    },
+    "parenthetical_list": {
+      "patterns": [
+        {
+          "begin": "\\(",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.section.list.verilog"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.list.verilog"
+            }
+          },
+          "name": "meta.block.parenthetical_list.verilog",
+          "patterns": [
+            {
+              "include": "#parenthetical_list"
+            },
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "include": "#constants"
+            },
+            {
+              "include": "#strings"
+            }
+          ]
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "begin": "\"",
+          "end": "\"",
+          "name": "string.quoted.double.verilog",
+          "patterns": [
+            {
+              "match": "\\\\.",
+              "name": "constant.character.escape.verilog"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "scopeName": "source.verilog",
+  "uuid": "7F4396B3-A33E-44F0-8502-98CA6C25971F"
+}


### PR DESCRIPTION
Adds baseline Verilog/SystemVerilog syntax highlighting in VS Code by vendoring a third-party TextMate grammar (MIT, from https://github.com/mshr-h/vscode-verilog-hdl-support) and wiring it via `contributes.grammars`. 