### PR TITLE
fix(hir): inherit ANSI port header type

### DIFF
--- a/crates/hir/src/hir_def/expr/data_ty.rs
+++ b/crates/hir/src/hir_def/expr/data_ty.rs
@@ -191,9 +191,7 @@ impl DataTy {
     pub(crate) fn is_ast_missing(ty: ast::DataType) -> bool {
         match ty {
             ast::DataType::ImplicitType(ty) => {
-                ty.signing().is_none()
-                    && ty.dimensions().children().count() == 0
-                    && ty.placeholder().is_none()
+                ty.signing().is_none() && ty.dimensions().children().count() == 0
             }
             _ => false,
         }

--- a/crates/ide/src/signature_help.rs
+++ b/crates/ide/src/signature_help.rs
@@ -188,8 +188,11 @@ fn sig_help_for_instance(
                     let header = InModule::new(target_module_id, port_decl.header)
                         .display_signature(db)
                         .unwrap_or_else(|_| "<missing-header>".to_string());
-                    buf.push_str(&header);
-                    buf.push(' ');
+                    let header = header.trim_end();
+                    buf.push_str(header);
+                    if !header.is_empty() {
+                        buf.push(' ');
+                    }
                 }
                 let header_size = buf.len();
 

--- a/crates/ide/src/verilog_2005.rs
+++ b/crates/ide/src/verilog_2005.rs
@@ -870,6 +870,36 @@ endmodule
 }
 
 #[test]
+fn verilog_2005_ansi_ports_inherit_implicit_header_type() {
+    let text = r#"
+module child(
+    input rst,
+    output io_vgaclk,
+    output [7:0] a, b, c
+);
+endmodule
+
+module top;
+  child u(/*marker:rst*/rst, io_vgaclk, a, b, c);
+endmodule
+"#;
+    let (host, file_id, _clean_text, markers) = setup_marked(text);
+    let signature = host
+        .make_analysis()
+        .signature_help(
+            position(file_id, &markers, "rst"),
+            crate::signature_help::SignatureHelpConfig { params_only: false },
+        )
+        .unwrap()
+        .expect("signature help expected for ordered port connection");
+
+    assert_eq!(
+        signature.label,
+        "module child(input rst, output io_vgaclk, output [7:0] a, output [7:0] b, output [7:0] c)"
+    );
+}
+
+#[test]
 fn verilog_2005_direct_generate_subroutine_resolves_locally() {
     let text = r#"
 module direct_generate_subroutine_ctx;


### PR DESCRIPTION
Closes https://github.com/pascal-lab/vizsla/issues/23.

Slang treats an `ImplicitType` as totally empty when it has neither signing nor dimensions. A parser placeholder can still be present for omitted syntax. See https://github.com/roife/slang/blob/2b59467291ff0abca1613b5208fcde0521513457/source/ast/symbols/PortSymbols.cpp#L91-L98

So there's no need checking `placeholder`.