### PR TITLE
fix(lsp): sync cleared document contents

### DIFF
--- a/src/global_state/handlers/notification.rs
+++ b/src/global_state/handlers/notification.rs
@@ -1,4 +1,4 @@
-use std::{mem, ops::Range};
+use std::ops::Range;
 
 use lsp_types::{
     DidChangeConfigurationParams, DidChangeTextDocumentParams, DidChangeWatchedFilesParams,
@@ -67,14 +67,11 @@ pub(crate) fn handle_did_change_text_document(
             }
         };
 
-        let text = apply_document_changes(
+        if let Some(text) = update_document_text(
             state.config.position_encoding(),
-            mem::take(data),
+            data,
             params.content_changes,
-        );
-
-        if *data != text {
-            *data = text.clone();
+        ) {
             set_vfs_file_contents(state, &path, text)?;
         }
     }
@@ -207,9 +204,24 @@ fn set_vfs_file_contents(
     vfs.0.file_id(path).ok_or_else(|| anyhow::format_err!("loaded file has no FileId: {path}"))
 }
 
+fn update_document_text(
+    encoding: PositionEncoding,
+    data: &mut String,
+    content_changes: Vec<lsp_types::TextDocumentContentChangeEvent>,
+) -> Option<String> {
+    let text = apply_document_changes(encoding, data, content_changes);
+
+    if *data == text {
+        None
+    } else {
+        *data = text.clone();
+        Some(text)
+    }
+}
+
 fn apply_document_changes(
     encoding: PositionEncoding,
-    file_contents: String,
+    file_contents: &str,
     content_changes: Vec<lsp_types::TextDocumentContentChangeEvent>,
 ) -> String {
     // Skip to the last full document change and peek at the first content change
@@ -219,10 +231,10 @@ fn apply_document_changes(
                 let (full_doc_changes, rest) = content_changes.split_at(idx + 1);
                 match full_doc_changes.last() {
                     Some(full_doc_change) => (full_doc_change.text.clone(), rest),
-                    None => (file_contents.clone(), rest),
+                    None => (file_contents.to_owned(), rest),
                 }
             }
-            None => (file_contents.clone(), &content_changes[..]),
+            None => (file_contents.to_owned(), &content_changes[..]),
         }
     };
 
@@ -259,4 +271,45 @@ fn apply_document_changes(
         }
     }
     text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::update_document_text;
+    use lsp_types::TextDocumentContentChangeEvent;
+    use utils::lines::PositionEncoding;
+
+    #[test]
+    fn clearing_document_updates_mem_doc_and_vfs_text() {
+        let mut text = "module top;\nendmodule\n".to_owned();
+        let vfs_text = update_document_text(
+            PositionEncoding::Utf8,
+            &mut text,
+            vec![TextDocumentContentChangeEvent {
+                range: None,
+                range_length: None,
+                text: String::new(),
+            }],
+        );
+
+        assert_eq!(text, "");
+        assert_eq!(vfs_text.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn unchanged_document_skips_vfs_update() {
+        let mut text = "module top;\nendmodule\n".to_owned();
+        let vfs_text = update_document_text(
+            PositionEncoding::Utf8,
+            &mut text,
+            vec![TextDocumentContentChangeEvent {
+                range: None,
+                range_length: None,
+                text: "module top;\nendmodule\n".to_owned(),
+            }],
+        );
+
+        assert_eq!(text, "module top;\nendmodule\n");
+        assert!(vfs_text.is_none());
+    }
 }

--- a/src/global_state/handlers/notification.rs
+++ b/src/global_state/handlers/notification.rs
@@ -67,11 +67,9 @@ pub(crate) fn handle_did_change_text_document(
             }
         };
 
-        if let Some(text) = update_document_text(
-            state.config.position_encoding(),
-            data,
-            params.content_changes,
-        ) {
+        if let Some(text) =
+            update_document_text(state.config.position_encoding(), data, params.content_changes)
+        {
             set_vfs_file_contents(state, &path, text)?;
         }
     }
@@ -275,9 +273,10 @@ fn apply_document_changes(
 
 #[cfg(test)]
 mod tests {
-    use super::update_document_text;
     use lsp_types::TextDocumentContentChangeEvent;
     use utils::lines::PositionEncoding;
+
+    use super::update_document_text;
 
     #[test]
     fn clearing_document_updates_mem_doc_and_vfs_text() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -386,6 +386,54 @@ fn code_action_titles(actions: &[CodeActionOrCommand]) -> Vec<String> {
 }
 
 #[test]
+fn clearing_open_document_updates_analysis_state() {
+    let text = "module stale_after_clear;\nendmodule\n";
+    let (_temp_dir, client, server_thread, uri) =
+        setup_diagnostics_test(ClientCapabilities::default(), UserConfig::default(), text);
+
+    client
+        .sender
+        .send(Message::Notification(Notification::new(
+            DidChangeTextDocument::METHOD.to_string(),
+            DidChangeTextDocumentParams {
+                text_document: VersionedTextDocumentIdentifier { uri: uri.clone(), version: 2 },
+                content_changes: vec![TextDocumentContentChangeEvent {
+                    range: None,
+                    range_length: None,
+                    text: String::new(),
+                }],
+            },
+        )))
+        .unwrap();
+
+    let symbols_id = lsp_server::RequestId::from(180);
+    client
+        .sender
+        .send(Message::Request(Request::new(
+            symbols_id.clone(),
+            DocumentSymbolRequest::METHOD.to_string(),
+            DocumentSymbolParams {
+                text_document: TextDocumentIdentifier { uri },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: Default::default(),
+            },
+        )))
+        .unwrap();
+
+    let symbols: Option<DocumentSymbolResponse> =
+        recv_response(&client, symbols_id, "documentSymbol");
+    let symbol_count = match symbols {
+        Some(DocumentSymbolResponse::Nested(symbols)) => symbols.len(),
+        Some(DocumentSymbolResponse::Flat(symbols)) => symbols.len(),
+        None => 0,
+    };
+
+    assert_eq!(symbol_count, 0, "cleared documents must not expose stale symbols");
+
+    shutdown_test_server(&client, server_thread);
+}
+
+#[test]
 fn code_action_request_returns_ordered_connection_refactor_without_diagnostics() {
     let text = "\
 module ca_leaf(input clk, input rst_n, output done);


### PR DESCRIPTION
Closes https://github.com/pascal-lab/vizsla/issues/19.

`mem::take(data)` clears `data` before the new text is compared. If the edit clears the file, the computed new text is also empty, so the handler compares empty string to empty string and skips the `set_vfs_file_contents(...)` function, which leaves analysis with stale file contents.