### PR TITLE
fix(lsp): avoid duplicate file watcher registrations

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -380,13 +380,6 @@ async function createClient(context: vscode.ExtensionContext): Promise<LanguageC
     ],
     synchronize: {
       configurationSection: ['vizsla'],
-      fileEvents: [
-        vscode.workspace.createFileSystemWatcher('**/*.v'),
-        vscode.workspace.createFileSystemWatcher('**/*.vh'),
-        vscode.workspace.createFileSystemWatcher('**/*.sv'),
-        vscode.workspace.createFileSystemWatcher('**/*.svh'),
-        vscode.workspace.createFileSystemWatcher('**/*.svi'),
-      ],
     },
     outputChannel: channel,
     traceOutputChannel: channel,

--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -121,6 +121,7 @@ pub(crate) struct GlobalState {
     // workspaces
     pub(crate) workspaces: Arc<Vec<Workspace>>,
     pub(crate) fetch_workspaces_task: ExclTask<(Arc<Vec<Workspace>>, Vec<anyhow::Error>)>,
+    pub(crate) registered_client_file_watcher_globs: Option<Vec<String>>,
 }
 
 impl GlobalState {
@@ -168,6 +169,7 @@ impl GlobalState {
 
             workspaces: Arc::from(vec![]),
             fetch_workspaces_task: ExclTask::default(),
+            registered_client_file_watcher_globs: None,
         }
     }
 

--- a/src/global_state/reload.rs
+++ b/src/global_state/reload.rs
@@ -12,6 +12,9 @@ use crate::{
     global_state::{DEFAULT_REQ_HANDLER, GlobalState, process_changes::DiagnosticInvalidation},
 };
 
+const CLIENT_FILE_WATCHER_REGISTRATION_ID: &str = "workspace/didChangeWatchedFiles";
+const CLIENT_FILE_WATCHER_METHOD: &str = "workspace/didChangeWatchedFiles";
+
 #[derive(Debug)]
 pub(crate) enum FetchWorkspaceProgress {
     Begin,
@@ -87,51 +90,12 @@ impl GlobalState {
 
         self.workspaces = workspaces.clone();
 
-        if let FilesWatcher::Client = self.config.files().watcher {
-            let registration_options = lsp_types::DidChangeWatchedFilesRegistrationOptions {
-                watchers: self
-                    .workspaces
-                    .iter()
-                    .flat_map(|ws| ws.to_roots())
-                    .filter(|it| !it.is_lib)
-                    .flat_map(|root| {
-                        root.load_paths().into_iter().flat_map(|it| {
-                            [
-                                format!("{it}/**/*.v"),
-                                format!("{it}/**/*.sv"),
-                                format!("{it}/**/*.vh"),
-                                format!("{it}/**/*.svh"),
-                                format!("{it}/**/*.svi"),
-                                format!("{it}/**/{}", MANIFEST_FILE_NAME),
-                            ]
-                        })
-                    })
-                    .map(|glob_pattern| lsp_types::FileSystemWatcher {
-                        glob_pattern: lsp_types::GlobPattern::String(glob_pattern),
-                        kind: None,
-                    })
-                    .collect(),
-            };
-
-            match serde_json::to_value(registration_options) {
-                Ok(register_options) => {
-                    let registration = lsp_types::Registration {
-                        id: "workspace/didChangeWatchedFiles".to_string(),
-                        method: "workspace/didChangeWatchedFiles".to_string(),
-                        register_options: Some(register_options),
-                    };
-
-                    self.send_request::<lsp_types::request::RegisterCapability>(
-                        lsp_types::RegistrationParams { registrations: vec![registration] },
-                        DEFAULT_REQ_HANDLER,
-                    );
-                }
-                Err(error) => {
-                    tracing::error!(
-                        "failed to serialize file watcher registration options: {error:#}"
-                    );
-                }
-            }
+        if matches!(self.config.files().watcher, FilesWatcher::Client)
+            && self.config.cli_did_change_watched_files_dyn_reg()
+        {
+            self.register_client_file_watchers(self.client_file_watcher_globs());
+        } else {
+            self.unregister_client_file_watchers();
         }
 
         let files_config = self.config.files();
@@ -176,6 +140,89 @@ impl GlobalState {
         self.invalidate_diagnostics(DiagnosticInvalidation::WorkspaceChanged);
         // TODO: update LRU capacity
     }
+
+    fn client_file_watcher_globs(&self) -> Vec<String> {
+        let mut globs = self
+            .workspaces
+            .iter()
+            .flat_map(|ws| ws.to_roots())
+            .filter(|it| !it.is_lib)
+            .flat_map(|root| {
+                root.load_paths().into_iter().flat_map(|it| {
+                    [
+                        format!("{it}/**/*.v"),
+                        format!("{it}/**/*.sv"),
+                        format!("{it}/**/*.vh"),
+                        format!("{it}/**/*.svh"),
+                        format!("{it}/**/*.svi"),
+                        format!("{it}/**/{}", MANIFEST_FILE_NAME),
+                    ]
+                })
+            })
+            .collect_vec();
+        globs.sort();
+        globs.dedup();
+        globs
+    }
+
+    fn register_client_file_watchers(&mut self, globs: Vec<String>) {
+        if self.registered_client_file_watcher_globs.as_ref() == Some(&globs) {
+            tracing::debug!("client file watcher registration unchanged");
+            return;
+        }
+
+        self.unregister_client_file_watchers();
+
+        if globs.is_empty() {
+            return;
+        }
+
+        let registration_options = lsp_types::DidChangeWatchedFilesRegistrationOptions {
+            watchers: globs
+                .iter()
+                .cloned()
+                .map(|glob_pattern| lsp_types::FileSystemWatcher {
+                    glob_pattern: lsp_types::GlobPattern::String(glob_pattern),
+                    kind: None,
+                })
+                .collect(),
+        };
+
+        match serde_json::to_value(registration_options) {
+            Ok(register_options) => {
+                let registration = lsp_types::Registration {
+                    id: CLIENT_FILE_WATCHER_REGISTRATION_ID.to_string(),
+                    method: CLIENT_FILE_WATCHER_METHOD.to_string(),
+                    register_options: Some(register_options),
+                };
+
+                self.send_request::<lsp_types::request::RegisterCapability>(
+                    lsp_types::RegistrationParams { registrations: vec![registration] },
+                    DEFAULT_REQ_HANDLER,
+                );
+                self.registered_client_file_watcher_globs = Some(globs);
+            }
+            Err(error) => {
+                tracing::error!("failed to serialize file watcher registration options: {error:#}");
+            }
+        }
+    }
+
+    fn unregister_client_file_watchers(&mut self) {
+        if self.registered_client_file_watcher_globs.take().is_none() {
+            return;
+        }
+
+        self.send_request::<lsp_types::request::UnregisterCapability>(
+            lsp_types::UnregistrationParams {
+                unregisterations: vec![lsp_types::Unregistration {
+                    id: CLIENT_FILE_WATCHER_REGISTRATION_ID.to_string(),
+                    method: CLIENT_FILE_WATCHER_METHOD.to_string(),
+                }],
+            },
+            DEFAULT_REQ_HANDLER,
+        );
+    }
 }
 
 pub(crate) fn should_refresh_for_change(path: &AbsPath, has_structure_change: bool) -> bool {
@@ -192,4 +239,87 @@ pub(crate) fn should_refresh_for_change(path: &AbsPath, has_structure_change: bo
     }
 
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use lsp_server::{Connection, Message, Request as LspRequest};
+    use utils::paths::AbsPathBuf;
+
+    use super::*;
+    use crate::{Opt, config::user_config::UserConfig};
+
+    fn test_state() -> (GlobalState, Connection) {
+        let root_path = AbsPathBuf::assert_utf8(std::env::current_dir().unwrap());
+        let config = Config::new(
+            Opt {
+                process_name: "vizsla-test".to_string(),
+                log: "error".to_string(),
+                log_filename: None,
+            },
+            root_path.clone(),
+            lsp_types::ClientCapabilities::default(),
+            vec![root_path],
+            UserConfig::default(),
+            Vec::new(),
+        );
+
+        let (server, client) = Connection::memory();
+        (GlobalState::new(server.sender, config), client)
+    }
+
+    fn drain_client_requests(client: &Connection) -> Vec<LspRequest> {
+        client
+            .receiver
+            .try_iter()
+            .filter_map(|message| match message {
+                Message::Request(request) => Some(request),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn unchanged_client_file_watchers_are_not_reregistered() {
+        let (mut state, client) = test_state();
+        let globs = vec!["/workspace/**/*.sv".to_string()];
+
+        state.register_client_file_watchers(globs.clone());
+        state.register_client_file_watchers(globs);
+
+        let methods =
+            drain_client_requests(&client).into_iter().map(|request| request.method).collect_vec();
+        assert_eq!(methods, vec!["client/registerCapability"]);
+    }
+
+    #[test]
+    fn changed_client_file_watchers_unregister_before_registering_again() {
+        let (mut state, client) = test_state();
+
+        state.register_client_file_watchers(vec!["/workspace/**/*.sv".to_string()]);
+        state.register_client_file_watchers(vec!["/other-workspace/**/*.sv".to_string()]);
+
+        let methods =
+            drain_client_requests(&client).into_iter().map(|request| request.method).collect_vec();
+        assert_eq!(
+            methods,
+            vec![
+                "client/registerCapability",
+                "client/unregisterCapability",
+                "client/registerCapability",
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_client_file_watchers_unregister_existing_registration() {
+        let (mut state, client) = test_state();
+
+        state.register_client_file_watchers(vec!["/workspace/**/*.sv".to_string()]);
+        state.register_client_file_watchers(Vec::new());
+
+        let methods =
+            drain_client_requests(&client).into_iter().map(|request| request.method).collect_vec();
+        assert_eq!(methods, vec!["client/registerCapability", "client/unregisterCapability"]);
+    }
 }


### PR DESCRIPTION
Closes https://github.com/pascal-lab/vizsla/issues/20.

The server reregisters `workspace/didChangeWatchedFiles` everytime user switching workspace with the same registration id. However, VS Code client overwrites the stored registration without disposing the previous one, so it LEAKS and can still fire after the client has stopped.