### PR TITLE
fix(hir): avoid dangling syntax nodes after parse eviction

### DIFF
--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -34,6 +34,29 @@ pub struct Semantics<'db, DB> {
     impl_: SemanticsImpl<'db>,
 }
 
+pub struct ParsedFile {
+    file_id: HirFileId,
+    tree: SyntaxTree,
+}
+
+impl ParsedFile {
+    pub fn file_id(&self) -> HirFileId {
+        self.file_id
+    }
+
+    pub fn syntax_tree(&self) -> &SyntaxTree {
+        &self.tree
+    }
+
+    pub fn root(&self) -> Option<SyntaxNode<'_>> {
+        self.tree.root()
+    }
+
+    pub fn compilation_unit(&self) -> Option<ast::CompilationUnit<'_>> {
+        ast::CompilationUnit::cast(self.root()?)
+    }
+}
+
 impl<DB: HirDb> Semantics<'_, DB> {
     pub fn new(db: &DB) -> Semantics<'_, DB> {
         let impl_ = SemanticsImpl::new(db);
@@ -109,6 +132,10 @@ impl<'db> SemanticsImpl<'db> {
 
     pub fn parse(&self, file_id: FileId) -> Option<ast::CompilationUnit<'_>> {
         ast::CompilationUnit::cast(self.parse_root(file_id)?)
+    }
+
+    pub fn parse_file(&self, file_id: FileId) -> ParsedFile {
+        ParsedFile { file_id: file_id.into(), tree: self.db.parse_src(file_id) }
     }
 
     pub fn find_file(&self, node: SyntaxNode) -> Option<HirFileId> {

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -6,7 +6,7 @@ use pathres::PathResolution;
 use rustc_hash::FxHashMap;
 use source_to_def::{Source2DefCache, Source2DefCtx};
 use syntax::{
-    SyntaxAncestors, SyntaxNode, SyntaxNodeExt,
+    SyntaxAncestors, SyntaxNode, SyntaxNodeExt, SyntaxTree,
     ast::{self, AstNode},
 };
 use utils::text_edit::TextSize;
@@ -77,6 +77,10 @@ pub struct SemanticsImpl<'db> {
     root2file_cache: RefCell<FxHashMap<SyntaxNode<'db>, HirFileId>>,
     source2def_cache: RefCell<Source2DefCache<'db>>,
     hir2def_cache: RefCell<Hir2DefCache>,
+
+    // SyntaxNode is a borrowed pointer into a SyntaxTree. Semantics returns nodes with its
+    // own lifetime, so it must retain the trees those nodes came from even if Salsa evicts them.
+    syntax_trees: RefCell<Vec<SyntaxTree>>,
 }
 
 impl<'db> SemanticsImpl<'db> {
@@ -86,16 +90,19 @@ impl<'db> SemanticsImpl<'db> {
             root2file_cache: Default::default(),
             source2def_cache: Default::default(),
             hir2def_cache: Default::default(),
+            syntax_trees: Default::default(),
         }
     }
 
     pub fn parse_root(&self, file_id: FileId) -> Option<SyntaxNode<'_>> {
         let tree = self.db.parse_src(file_id);
 
-        // Unsafe: we garentee that the root node is valid for the lifetime of the db
+        // Unsafe: we keep the SyntaxTree alive for the lifetime of this Semantics
+        // instance.
         let root = tree.root()?;
         let root_node: SyntaxNode<'db> =
             unsafe { std::mem::transmute::<SyntaxNode<'_>, SyntaxNode<'db>>(root) };
+        self.syntax_trees.borrow_mut().push(tree);
         self.cache_node2file(root_node, file_id.into());
         Some(root_node)
     }

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -116,8 +116,7 @@ impl<'db> SemanticsImpl<'db> {
         self.lookup_file_id(root_node)
     }
 
-    pub fn container_for_node(&self, node: SyntaxNode) -> Option<ContainerId> {
-        let file_id = self.find_file(node)?;
+    pub fn container_for_node(&self, file_id: HirFileId, node: SyntaxNode) -> Option<ContainerId> {
         self.with_ctx(|ctx| Some(ctx.find_container(InFile::new(file_id, node))))
     }
 
@@ -144,14 +143,16 @@ impl<'db> SemanticsImpl<'db> {
 }
 
 impl SemanticsImpl<'_> {
-    pub fn block_to_def(&self, block: ast::BlockStatement) -> Option<BlockId> {
-        let file_id = self.find_file(block.syntax())?;
+    pub fn block_to_def(&self, file_id: HirFileId, block: ast::BlockStatement) -> Option<BlockId> {
         let block_src = BlockSrc::from(block);
         self.with_ctx(|ctx| ctx.block_to_def(InFile::new(file_id, block_src)))
     }
 
-    pub fn subroutine_to_def(&self, subroutine: ast::FunctionDeclaration) -> Option<SubroutineId> {
-        let file_id = self.find_file(subroutine.syntax())?;
+    pub fn subroutine_to_def(
+        &self,
+        file_id: HirFileId,
+        subroutine: ast::FunctionDeclaration,
+    ) -> Option<SubroutineId> {
         let subroutine_src = SubroutineSrc::from(subroutine);
         self.with_ctx(|ctx| ctx.subroutine_to_def(InFile::new(file_id, subroutine_src)))
     }

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -3,7 +3,6 @@ use std::{cell::RefCell, ops};
 use hir_to_def::Hir2DefCache;
 use itertools::{Either, Itertools};
 use pathres::PathResolution;
-use rustc_hash::FxHashMap;
 use source_to_def::{Source2DefCache, Source2DefCtx};
 use syntax::{
     SyntaxAncestors, SyntaxNode, SyntaxNodeExt, SyntaxTree,
@@ -96,67 +95,25 @@ pub struct SemanticsImpl<'db> {
     pub db: &'db dyn HirDb,
 
     // s2d_cache
-    // Root -> HirFileId
-    root2file_cache: RefCell<FxHashMap<SyntaxNode<'db>, HirFileId>>,
     source2def_cache: RefCell<Source2DefCache>,
     hir2def_cache: RefCell<Hir2DefCache>,
-
-    // SyntaxNode is a borrowed pointer into a SyntaxTree. Semantics returns nodes with its
-    // own lifetime, so it must retain the trees those nodes came from even if Salsa evicts them.
-    syntax_trees: RefCell<Vec<SyntaxTree>>,
 }
 
 impl<'db> SemanticsImpl<'db> {
     fn new(db: &'db dyn HirDb) -> Self {
         SemanticsImpl {
             db,
-            root2file_cache: Default::default(),
             source2def_cache: Default::default(),
             hir2def_cache: Default::default(),
-            syntax_trees: Default::default(),
         }
-    }
-
-    pub fn parse_root(&self, file_id: FileId) -> Option<SyntaxNode<'_>> {
-        let tree = self.db.parse_src(file_id);
-
-        // Unsafe: we keep the SyntaxTree alive for the lifetime of this Semantics
-        // instance.
-        let root = tree.root()?;
-        let root_node: SyntaxNode<'db> =
-            unsafe { std::mem::transmute::<SyntaxNode<'_>, SyntaxNode<'db>>(root) };
-        self.syntax_trees.borrow_mut().push(tree);
-        self.cache_node2file(root_node, file_id.into());
-        Some(root_node)
-    }
-
-    pub fn parse(&self, file_id: FileId) -> Option<ast::CompilationUnit<'_>> {
-        ast::CompilationUnit::cast(self.parse_root(file_id)?)
     }
 
     pub fn parse_file(&self, file_id: FileId) -> ParsedFile {
         ParsedFile { file_id: file_id.into(), tree: self.db.parse_src(file_id) }
     }
 
-    pub fn find_file(&self, node: SyntaxNode) -> Option<HirFileId> {
-        let root_node = node.find_root();
-        self.lookup_file_id(root_node)
-    }
-
     pub fn container_for_node(&self, file_id: HirFileId, node: SyntaxNode) -> Option<ContainerId> {
         self.with_ctx(|ctx| Some(ctx.find_container(InFile::new(file_id, node))))
-    }
-
-    fn cache_node2file(&self, root_node: SyntaxNode<'db>, file_id: HirFileId) {
-        debug_assert!(root_node.parent().is_none());
-        let mut cache = self.root2file_cache.borrow_mut();
-        let prev = cache.insert(root_node, file_id);
-        debug_assert!(prev.is_none() || prev == Some(file_id))
-    }
-
-    fn lookup_file_id(&self, root_node: SyntaxNode) -> Option<HirFileId> {
-        let cache = self.root2file_cache.borrow();
-        cache.get(&root_node).copied()
     }
 
     fn with_ctx<F: FnOnce(&mut Source2DefCtx<'_, '_>) -> T, T>(&self, f: F) -> T {

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -75,7 +75,7 @@ pub struct SemanticsImpl<'db> {
     // s2d_cache
     // Root -> HirFileId
     root2file_cache: RefCell<FxHashMap<SyntaxNode<'db>, HirFileId>>,
-    source2def_cache: RefCell<Source2DefCache<'db>>,
+    source2def_cache: RefCell<Source2DefCache>,
     hir2def_cache: RefCell<Hir2DefCache>,
 
     // SyntaxNode is a borrowed pointer into a SyntaxTree. Semantics returns nodes with its

--- a/crates/hir/src/semantics/pathres.rs
+++ b/crates/hir/src/semantics/pathres.rs
@@ -9,6 +9,7 @@ use crate::{
     container::{
         ContainerId, InBlock, InContainer, InFile, InGenerateBlock, InModule, InSubroutine,
     },
+    file::HirFileId,
     hir_def::{
         block::BlockId,
         declaration::Declaration,
@@ -28,9 +29,9 @@ use crate::{
 impl SemanticsImpl<'_> {
     pub fn nameres_ident(
         &self,
+        file_id: HirFileId,
         SyntaxTokenWithParent { parent, tok }: SyntaxTokenWithParent,
     ) -> Option<PathResolution> {
-        let file_id = self.find_file(parent)?;
         let ident = lower_ident_opt(Some(tok))?;
         self.with_ctx(|ctx| {
             let container = ctx.find_container(InFile::new(file_id, parent));

--- a/crates/hir/src/semantics/resolver.rs
+++ b/crates/hir/src/semantics/resolver.rs
@@ -4,6 +4,7 @@ use utils::get::Get;
 use super::SemanticsImpl;
 use crate::{
     container::{ContainerId, InContainer, InFile, InModule},
+    file::HirFileId,
     hir_def::{
         expr::{ExprId, ExprSrc},
         module::instantiation::{
@@ -15,10 +16,10 @@ use crate::{
 impl SemanticsImpl<'_> {
     pub fn resolve_instance(
         &self,
+        file_id: HirFileId,
         instance: ast::HierarchicalInstance,
     ) -> Option<InModule<InstanceId>> {
         let db = self.db;
-        let file_id = self.find_file(instance.syntax())?;
         let ContainerId::ModuleId(module_id) =
             self.find_container(InFile::new(file_id, instance.syntax()))
         else {
@@ -33,10 +34,10 @@ impl SemanticsImpl<'_> {
 
     pub fn resolve_instantiation(
         &self,
+        file_id: HirFileId,
         instantiation: ast::HierarchyInstantiation,
     ) -> Option<InModule<InstantiationId>> {
         let db = self.db;
-        let file_id = self.find_file(instantiation.syntax())?;
         let ContainerId::ModuleId(module_id) =
             self.find_container(InFile::new(file_id, instantiation.syntax()))
         else {
@@ -51,10 +52,10 @@ impl SemanticsImpl<'_> {
 
     pub fn resolve_named_port_conn(
         &self,
+        file_id: HirFileId,
         conn: ast::PortConnection,
     ) -> Option<InModule<PortConnId>> {
         let db = self.db;
-        let file_id = self.find_file(conn.syntax())?;
         let ContainerId::ModuleId(module_id) =
             self.find_container(InFile::new(file_id, conn.syntax()))
         else {
@@ -67,9 +68,12 @@ impl SemanticsImpl<'_> {
         Some(InModule::new(module_id, conn_id))
     }
 
-    pub fn resolve_expr(&self, expr: ast::Expression) -> Option<InContainer<ExprId>> {
+    pub fn resolve_expr(
+        &self,
+        file_id: HirFileId,
+        expr: ast::Expression,
+    ) -> Option<InContainer<ExprId>> {
         let db = self.db;
-        let file_id = self.find_file(expr.syntax())?;
         let container_id = self.find_container(InFile::new(file_id, expr.syntax()));
         let src_map = container_id.to_container_src_map(db);
 

--- a/crates/hir/src/semantics/source_to_def.rs
+++ b/crates/hir/src/semantics/source_to_def.rs
@@ -3,6 +3,7 @@ use syntax::{
     SyntaxAncestors, SyntaxNode,
     ast::{self, AstNode},
     match_ast,
+    ptr::SyntaxNodePtr,
 };
 use utils::get::{Get, GetRef};
 
@@ -25,13 +26,13 @@ use crate::{
 };
 
 #[derive(Default, Debug)]
-pub(super) struct Source2DefCache<'db> {
-    container_map: FxHashMap<InFile<SyntaxNode<'db>>, ContainerId>,
+pub(super) struct Source2DefCache {
+    container_map: FxHashMap<InFile<SyntaxNodePtr>, ContainerId>,
 }
 
 pub(super) struct Source2DefCtx<'db, 'cache> {
     pub(super) db: &'db dyn HirDb,
-    pub(super) source_cache: &'cache mut Source2DefCache<'db>,
+    pub(super) source_cache: &'cache mut Source2DefCache,
     pub(super) hir_cache: &'cache mut Hir2DefCache,
 }
 
@@ -242,8 +243,7 @@ impl Source2DefCtx<'_, '_> {
         &mut self,
         InFile { value: node, file_id }: InFile<SyntaxNode>,
     ) -> ContainerId {
-        let node = unsafe { std::mem::transmute::<SyntaxNode<'_>, SyntaxNode<'_>>(node) };
-        let in_file = InFile::new(file_id, node);
+        let in_file = InFile::new(file_id, SyntaxNodePtr::from_node(node));
 
         if let Some(container_id) = self.source_cache.container_map.get(&in_file) {
             return *container_id;

--- a/crates/ide/src/code_action.rs
+++ b/crates/ide/src/code_action.rs
@@ -4,7 +4,7 @@ use hir::{
         declaration::Declaration,
         module::{Module, ModuleId, port::Ports},
     },
-    semantics::Semantics,
+    semantics::{ParsedFile, Semantics},
 };
 use ide_db::root_db::RootDb;
 use smol_str::SmolStr;
@@ -382,7 +382,7 @@ struct CodeActionCtx<'a> {
     file_id: FileId,
     range: TextRange,
     diagnostics: CodeActionDiagnostics,
-    compilation_unit: CompilationUnit<'a>,
+    parsed_file: ParsedFile,
 }
 
 impl<'a> CodeActionCtx<'a> {
@@ -392,16 +392,21 @@ impl<'a> CodeActionCtx<'a> {
         range: TextRange,
         diagnostics: CodeActionDiagnostics,
     ) -> Option<Self> {
-        let compilation_unit = CompilationUnit::cast(sema.parse_root(file_id)?)?;
-        Some(Self { sema, file_id, range, diagnostics, compilation_unit })
+        let parsed_file = sema.parse_file(file_id);
+        parsed_file.compilation_unit()?;
+        Some(Self { sema, file_id, range, diagnostics, parsed_file })
     }
 
     fn offset(&self) -> TextSize {
         self.range.start()
     }
 
-    fn find_node_at_offset<N: AstNode<'a>>(&self) -> Option<N> {
-        self.sema.find_node_at_offset(self.compilation_unit.syntax(), self.offset())
+    fn find_node_at_offset<'b, N: AstNode<'b>>(&'b self) -> Option<N> {
+        self.sema.find_node_at_offset(self.compilation_unit()?.syntax(), self.offset())
+    }
+
+    fn compilation_unit(&self) -> Option<CompilationUnit<'_>> {
+        self.parsed_file.compilation_unit()
     }
 }
 

--- a/crates/ide/src/code_action/handlers/add_instance_parens.rs
+++ b/crates/ide/src/code_action/handlers/add_instance_parens.rs
@@ -19,7 +19,7 @@ pub(super) fn add_instance_parens(
         return None;
     }
 
-    let token = ctx.compilation_unit.syntax().token_before_offset(ctx.range.end())?;
+    let token = ctx.compilation_unit()?.syntax().token_before_offset(ctx.range.end())?;
     if !token.kind().name_like() || token.text_range()?.end() != ctx.range.end() {
         return None;
     }

--- a/crates/ide/src/code_action/handlers/add_missing_connections.rs
+++ b/crates/ide/src/code_action/handlers/add_missing_connections.rs
@@ -29,9 +29,11 @@ pub(super) fn add_missing_connections(
 
     let sema = ctx.sema;
     let db = sema.db;
+    let file_id = ctx.file_id.into();
 
     let ast_instance = ctx.find_node_at_offset::<ast::HierarchicalInstance>()?;
-    let InModule { value: instance_id, module_id } = sema.resolve_instance(ast_instance)?;
+    let InModule { value: instance_id, module_id } =
+        sema.resolve_instance(file_id, ast_instance)?;
     let module = db.module(module_id);
     let instance = module.get(instance_id);
     let open_paren = ast_instance.open_paren()?.text_range_in(ast_instance.syntax())?;

--- a/crates/ide/src/code_action/handlers/add_missing_parameters.rs
+++ b/crates/ide/src/code_action/handlers/add_missing_parameters.rs
@@ -30,10 +30,11 @@ pub(super) fn add_missing_parameters(
 
     let sema = ctx.sema;
     let db = sema.db;
+    let file_id = ctx.file_id.into();
 
     let ast_instantiation = ctx.find_node_at_offset::<ast::HierarchyInstantiation>()?;
     let InModule { value: instantiation_id, module_id } =
-        sema.resolve_instantiation(ast_instantiation)?;
+        sema.resolve_instantiation(file_id, ast_instantiation)?;
     let module = db.module(module_id);
     let instantiation = module.get(instantiation_id);
 

--- a/crates/ide/src/code_lens.rs
+++ b/crates/ide/src/code_lens.rs
@@ -95,9 +95,11 @@ pub(crate) fn code_lens_resolve(db: &RootDb, mut kind: CodeLensKind) -> CodeLens
 
             let mut ranges = Vec::new();
             for (file_id, tokens) in ReferencesCtx::new(&sema, &def, ref_config).search() {
+                let parsed_file = sema.parse_file(file_id);
                 for instantiation in tokens
                     .into_iter()
-                    .filter_map(|tok| ast::HierarchyInstantiation::cast(tok.token.parent))
+                    .filter_map(|tok| tok.to_token(parsed_file.syntax_tree()))
+                    .filter_map(|tok| ast::HierarchyInstantiation::cast(tok.parent))
                 {
                     for instance in instantiation.instances().children() {
                         if let Some(range) = instance.decl().and_then(|decl| {

--- a/crates/ide/src/completion/context.rs
+++ b/crates/ide/src/completion/context.rs
@@ -103,7 +103,8 @@ pub(crate) fn completion_context(
     trigger: Option<TriggerChar>,
 ) -> CompletionContext {
     let sema = Semantics::new(db);
-    let Some(root) = sema.parse_root(file_id) else {
+    let parsed_file = sema.parse_file(file_id);
+    let Some(root) = parsed_file.root() else {
         return CompletionContext {
             replacement: TextRange::empty(offset),
             prefix: String::new(),

--- a/crates/ide/src/completion/engine/expr.rs
+++ b/crates/ide/src/completion/engine/expr.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use hir::{
     container::{ContainerId, ContainerParent, InContainer, InSubroutine},
     db::HirDb,
+    file::HirFileId,
     hir_def::{
         lower_ident_opt,
         module::ModuleId,
@@ -58,6 +59,7 @@ fn complete_expression_impl(
     ctx: &CompletionContext,
 ) -> Vec<CompletionCandidate> {
     let sema = Semantics::new(db);
+    let file_id = position.file_id.into();
     let Some(root) = sema.parse_root(position.file_id) else {
         return Vec::new();
     };
@@ -65,15 +67,16 @@ fn complete_expression_impl(
     let mut names: BTreeMap<String, NameKind> = BTreeMap::new();
     let mut current_module_id = None;
 
-    if let Some(container_id) = container_id_at_offset(&sema, root, position.offset) {
+    if let Some(container_id) = container_id_at_offset(&sema, file_id, root, position.offset) {
         current_module_id = module_id_for_container(db, container_id);
         for container_id in ContainerParent::start_from(db, container_id) {
             collect_container_names(db, container_id, &mut names);
         }
     }
 
-    let expected_ty = current_module_id
-        .and_then(|module_id| expected_type_at_offset(db, &sema, root, position.offset, module_id));
+    let expected_ty = current_module_id.and_then(|module_id| {
+        expected_type_at_offset(db, &sema, file_id, root, position.offset, module_id)
+    });
 
     let mut candidates: Vec<_> = names
         .into_iter()
@@ -97,12 +100,13 @@ fn complete_expression_impl(
 
 fn container_id_at_offset(
     sema: &Semantics<'_, RootDb>,
+    file_id: HirFileId,
     root: SyntaxNode<'_>,
     offset: TextSize,
 ) -> Option<ContainerId> {
     let elem = root.covering_element(utils::line_index::TextRange::empty(offset));
     let node = elem.as_node().or_else(|| elem.parent())?;
-    sema.container_for_node(node)
+    sema.container_for_node(file_id, node)
 }
 
 fn collect_container_names(
@@ -255,18 +259,20 @@ fn expression_candidate_matches_expected_type(
 fn expected_type_at_offset(
     db: &RootDb,
     sema: &Semantics<'_, RootDb>,
+    file_id: HirFileId,
     root: SyntaxNode<'_>,
     offset: TextSize,
     _current_module_id: ModuleId,
 ) -> Option<Ty> {
-    expected_type_for_assignment_rhs(db, sema, root, offset)
-        .or_else(|| expected_type_for_declarator_initializer(db, sema, root, offset))
+    expected_type_for_assignment_rhs(db, sema, file_id, root, offset)
+        .or_else(|| expected_type_for_declarator_initializer(db, sema, file_id, root, offset))
         .filter(|ty| type_class(db, ty).is_some())
 }
 
 fn expected_type_for_assignment_rhs(
     db: &RootDb,
     sema: &Semantics<'_, RootDb>,
+    file_id: HirFileId,
     root: SyntaxNode<'_>,
     offset: TextSize,
 ) -> Option<Ty> {
@@ -281,13 +287,14 @@ fn expected_type_for_assignment_rhs(
         return None;
     }
 
-    let res = sema.expr_to_def(sema.resolve_expr(assignment.left())?)?;
+    let res = sema.expr_to_def(sema.resolve_expr(file_id, assignment.left())?)?;
     Some(type_of_path_resolution(db, res).ty)
 }
 
 fn expected_type_for_declarator_initializer(
     db: &RootDb,
     sema: &Semantics<'_, RootDb>,
+    file_id: HirFileId,
     root: SyntaxNode<'_>,
     offset: TextSize,
 ) -> Option<Ty> {
@@ -300,7 +307,7 @@ fn expected_type_for_declarator_initializer(
     }
 
     let ident = lower_ident_opt(declarator.name())?;
-    let container_id = sema.container_for_node(declarator.syntax())?;
+    let container_id = sema.container_for_node(file_id, declarator.syntax())?;
     let res = sema.name_to_def(InContainer::new(container_id, ident))?;
     Some(type_of_path_resolution(db, res).ty)
 }

--- a/crates/ide/src/completion/engine/expr.rs
+++ b/crates/ide/src/completion/engine/expr.rs
@@ -60,7 +60,8 @@ fn complete_expression_impl(
 ) -> Vec<CompletionCandidate> {
     let sema = Semantics::new(db);
     let file_id = position.file_id.into();
-    let Some(root) = sema.parse_root(position.file_id) else {
+    let parsed_file = sema.parse_file(position.file_id);
+    let Some(root) = parsed_file.root() else {
         return Vec::new();
     };
 

--- a/crates/ide/src/completion/engine/member.rs
+++ b/crates/ide/src/completion/engine/member.rs
@@ -22,7 +22,8 @@ pub(super) fn complete_member_access(
 ) -> Vec<CompletionCandidate> {
     let sema = Semantics::new(db);
     let file_id = position.file_id.into();
-    let Some(root) = sema.parse_root(position.file_id) else {
+    let parsed_file = sema.parse_file(position.file_id);
+    let Some(root) = parsed_file.root() else {
         return Vec::new();
     };
 

--- a/crates/ide/src/completion/engine/member.rs
+++ b/crates/ide/src/completion/engine/member.rs
@@ -1,4 +1,5 @@
 use hir::{
+    file::HirFileId,
     semantics::Semantics,
     type_infer::{TyMember, members_of_ty, type_of_expr, type_of_path_resolution},
 };
@@ -20,17 +21,18 @@ pub(super) fn complete_member_access(
     ctx: &CompletionContext,
 ) -> Vec<CompletionCandidate> {
     let sema = Semantics::new(db);
+    let file_id = position.file_id.into();
     let Some(root) = sema.parse_root(position.file_id) else {
         return Vec::new();
     };
 
     let members = member_access_at_offset(root, position.offset)
-        .and_then(|access| members_for_expr(db, &sema, access.left()))
-        .or_else(|| members_for_incomplete_access(db, &sema, root, position.offset))
-        .or_else(|| members_for_incomplete_scoped_access(db, &sema, root, position.offset))
+        .and_then(|access| members_for_expr(db, &sema, file_id, access.left()))
+        .or_else(|| members_for_incomplete_access(db, &sema, file_id, root, position.offset))
+        .or_else(|| members_for_incomplete_scoped_access(db, &sema, file_id, root, position.offset))
         .or_else(|| {
             scoped_name_at_offset(root, position.offset)
-                .and_then(|scoped| members_for_scoped_name(db, &sema, scoped))
+                .and_then(|scoped| members_for_scoped_name(db, &sema, file_id, scoped))
         });
     let Some(members) = members else {
         return Vec::new();
@@ -73,6 +75,7 @@ fn scoped_name_at_offset(
 fn members_for_incomplete_scoped_access(
     db: &RootDb,
     sema: &Semantics<'_, RootDb>,
+    file_id: HirFileId,
     root: SyntaxNode<'_>,
     offset: utils::text_edit::TextSize,
 ) -> Option<Vec<TyMember>> {
@@ -81,7 +84,7 @@ fn members_for_incomplete_scoped_access(
         return None;
     }
     let left = root.token_before_offset(separator.text_range()?.start())?;
-    let res = sema.nameres_ident(left)?;
+    let res = sema.nameres_ident(file_id, left)?;
     let members = members_of_ty(db, &type_of_path_resolution(db, res).ty);
     (!members.is_empty()).then_some(members)
 }
@@ -89,6 +92,7 @@ fn members_for_incomplete_scoped_access(
 fn members_for_incomplete_access(
     db: &RootDb,
     sema: &Semantics<'_, RootDb>,
+    file_id: HirFileId,
     root: SyntaxNode<'_>,
     offset: utils::text_edit::TextSize,
 ) -> Option<Vec<TyMember>> {
@@ -100,7 +104,7 @@ fn members_for_incomplete_access(
     let dot_start = dot.text_range()?.start();
     let expr = expr_before_dot(dot.parent, dot_start)?;
 
-    members_for_expr(db, sema, expr)
+    members_for_expr(db, sema, file_id, expr)
 }
 
 fn expr_before_dot(
@@ -117,9 +121,10 @@ fn expr_before_dot(
 fn members_for_expr(
     db: &RootDb,
     sema: &Semantics<'_, RootDb>,
+    file_id: HirFileId,
     expr: ast::Expression<'_>,
 ) -> Option<Vec<TyMember>> {
-    let ty = type_of_expr(db, sema.resolve_expr(expr)?).ty;
+    let ty = type_of_expr(db, sema.resolve_expr(file_id, expr)?).ty;
     let members = members_of_ty(db, &ty);
     (!members.is_empty()).then_some(members)
 }
@@ -127,8 +132,9 @@ fn members_for_expr(
 fn members_for_scoped_name(
     db: &RootDb,
     sema: &Semantics<'_, RootDb>,
+    file_id: HirFileId,
     scoped: ast::ScopedName<'_>,
 ) -> Option<Vec<TyMember>> {
     let left = ast::Expression::cast(scoped.left().syntax())?;
-    members_for_expr(db, sema, left)
+    members_for_expr(db, sema, file_id, left)
 }

--- a/crates/ide/src/completion/engine/named.rs
+++ b/crates/ide/src/completion/engine/named.rs
@@ -23,7 +23,8 @@ pub(super) fn complete_named_port_names(
     ctx: &CompletionContext,
 ) -> Vec<CompletionCandidate> {
     let sema = Semantics::new(db);
-    let Some(root) = sema.parse_root(position.file_id) else {
+    let parsed_file = sema.parse_file(position.file_id);
+    let Some(root) = parsed_file.root() else {
         return Vec::new();
     };
     let Some(instantiation) =
@@ -68,7 +69,8 @@ pub(super) fn complete_named_param_names(
     ctx: &CompletionContext,
 ) -> Vec<CompletionCandidate> {
     let sema = Semantics::new(db);
-    let Some(root) = sema.parse_root(position.file_id) else {
+    let parsed_file = sema.parse_file(position.file_id);
+    let Some(root) = parsed_file.root() else {
         return Vec::new();
     };
     let Some(instantiation) =
@@ -112,7 +114,8 @@ pub(super) fn complete_named_port_conn_expr(
 ) -> Vec<CompletionCandidate> {
     let sema = Semantics::new(db);
     let file_id = position.file_id.into();
-    let Some(root) = sema.parse_root(position.file_id) else {
+    let parsed_file = sema.parse_file(position.file_id);
+    let Some(root) = parsed_file.root() else {
         return Vec::new();
     };
     let Some(conn) = sema.find_node_at_offset::<ast::NamedPortConnection>(root, position.offset)
@@ -159,7 +162,8 @@ pub(super) fn complete_named_param_assign_expr(
 ) -> Vec<CompletionCandidate> {
     let sema = Semantics::new(db);
     let file_id = position.file_id.into();
-    let Some(root) = sema.parse_root(position.file_id) else {
+    let parsed_file = sema.parse_file(position.file_id);
+    let Some(root) = parsed_file.root() else {
         return Vec::new();
     };
     let Some(assign) = sema.find_node_at_offset::<ast::NamedParamAssignment>(root, position.offset)

--- a/crates/ide/src/completion/engine/named.rs
+++ b/crates/ide/src/completion/engine/named.rs
@@ -111,6 +111,7 @@ pub(super) fn complete_named_port_conn_expr(
     ctx: &CompletionContext,
 ) -> Vec<CompletionCandidate> {
     let sema = Semantics::new(db);
+    let file_id = position.file_id.into();
     let Some(root) = sema.parse_root(position.file_id) else {
         return Vec::new();
     };
@@ -127,7 +128,8 @@ pub(super) fn complete_named_port_conn_expr(
         return Vec::new();
     };
 
-    let Some(current_module_id) = sema.resolve_instantiation(instantiation).map(|it| it.module_id)
+    let Some(current_module_id) =
+        sema.resolve_instantiation(file_id, instantiation).map(|it| it.module_id)
     else {
         return Vec::new();
     };
@@ -156,6 +158,7 @@ pub(super) fn complete_named_param_assign_expr(
     ctx: &CompletionContext,
 ) -> Vec<CompletionCandidate> {
     let sema = Semantics::new(db);
+    let file_id = position.file_id.into();
     let Some(root) = sema.parse_root(position.file_id) else {
         return Vec::new();
     };
@@ -172,7 +175,8 @@ pub(super) fn complete_named_param_assign_expr(
         return Vec::new();
     };
 
-    let Some(current_module_id) = sema.resolve_instantiation(instantiation).map(|it| it.module_id)
+    let Some(current_module_id) =
+        sema.resolve_instantiation(file_id, instantiation).map(|it| it.module_id)
     else {
         return Vec::new();
     };

--- a/crates/ide/src/completion/engine/paren_list.rs
+++ b/crates/ide/src/completion/engine/paren_list.rs
@@ -70,14 +70,12 @@ fn complete_parameter_port_list_with_typedefs(
     ctx: &CompletionContext,
 ) -> Vec<CompletionCandidate> {
     let sema = Semantics::new(db);
+    let file_id = position.file_id.into();
     let Some(root) = sema.parse_root(position.file_id) else {
         return Vec::new();
     };
     let Some(module) = sema.find_node_at_offset::<ast::ModuleDeclaration>(root, position.offset)
     else {
-        return Vec::new();
-    };
-    let Some(file_id) = sema.find_file(module.syntax()) else {
         return Vec::new();
     };
     let (_, file_src_map) = db.hir_file_with_source_map(file_id);
@@ -114,6 +112,7 @@ fn complete_port_connections(
     ctx: &CompletionContext,
 ) -> Vec<CompletionCandidate> {
     let sema = Semantics::new(db);
+    let file_id = position.file_id.into();
     let Some(root) = sema.parse_root(position.file_id) else {
         return Vec::new();
     };
@@ -132,7 +131,8 @@ fn complete_port_connections(
     let Some(instantiation) = enclosing_instantiation(instance.syntax()) else {
         return Vec::new();
     };
-    let Some(current_module_id) = sema.resolve_instantiation(instantiation).map(|it| it.module_id)
+    let Some(current_module_id) =
+        sema.resolve_instantiation(file_id, instantiation).map(|it| it.module_id)
     else {
         return Vec::new();
     };
@@ -193,6 +193,7 @@ fn complete_param_value_assignment(
     ctx: &CompletionContext,
 ) -> Vec<CompletionCandidate> {
     let sema = Semantics::new(db);
+    let file_id = position.file_id.into();
     let Some(root) = sema.parse_root(position.file_id) else {
         return Vec::new();
     };
@@ -208,7 +209,8 @@ fn complete_param_value_assignment(
         return Vec::new();
     };
 
-    let Some(current_module_id) = sema.resolve_instantiation(instantiation).map(|it| it.module_id)
+    let Some(current_module_id) =
+        sema.resolve_instantiation(file_id, instantiation).map(|it| it.module_id)
     else {
         return Vec::new();
     };

--- a/crates/ide/src/completion/engine/paren_list.rs
+++ b/crates/ide/src/completion/engine/paren_list.rs
@@ -71,7 +71,8 @@ fn complete_parameter_port_list_with_typedefs(
 ) -> Vec<CompletionCandidate> {
     let sema = Semantics::new(db);
     let file_id = position.file_id.into();
-    let Some(root) = sema.parse_root(position.file_id) else {
+    let parsed_file = sema.parse_file(position.file_id);
+    let Some(root) = parsed_file.root() else {
         return Vec::new();
     };
     let Some(module) = sema.find_node_at_offset::<ast::ModuleDeclaration>(root, position.offset)
@@ -113,7 +114,8 @@ fn complete_port_connections(
 ) -> Vec<CompletionCandidate> {
     let sema = Semantics::new(db);
     let file_id = position.file_id.into();
-    let Some(root) = sema.parse_root(position.file_id) else {
+    let parsed_file = sema.parse_file(position.file_id);
+    let Some(root) = parsed_file.root() else {
         return Vec::new();
     };
 
@@ -194,7 +196,8 @@ fn complete_param_value_assignment(
 ) -> Vec<CompletionCandidate> {
     let sema = Semantics::new(db);
     let file_id = position.file_id.into();
-    let Some(root) = sema.parse_root(position.file_id) else {
+    let parsed_file = sema.parse_file(position.file_id);
+    let Some(root) = parsed_file.root() else {
         return Vec::new();
     };
 

--- a/crates/ide/src/completion/engine/port_list.rs
+++ b/crates/ide/src/completion/engine/port_list.rs
@@ -6,7 +6,7 @@ use hir::{
 };
 use ide_db::root_db::RootDb;
 use span::FilePosition;
-use syntax::ast::{self, AstNode};
+use syntax::ast;
 use utils::get::Get;
 
 use super::candidate::CompletionCandidate;
@@ -54,14 +54,12 @@ fn complete_function_port_list(
 
 fn visible_typedefs_in_module_header(db: &RootDb, position: FilePosition) -> Vec<String> {
     let sema = Semantics::new(db);
+    let file_id = position.file_id.into();
     let Some(root) = sema.parse_root(position.file_id) else {
         return Vec::new();
     };
     let module = sema.find_node_at_offset::<ast::ModuleDeclaration>(root, position.offset);
     let Some(module) = module else {
-        return Vec::new();
-    };
-    let Some(file_id) = sema.find_file(module.syntax()) else {
         return Vec::new();
     };
     let (_, file_src_map) = db.hir_file_with_source_map(file_id);
@@ -98,14 +96,12 @@ fn complete_non_ansi_port_list(
     ctx: &CompletionContext,
 ) -> Vec<CompletionCandidate> {
     let sema = Semantics::new(db);
+    let file_id = position.file_id.into();
     let Some(root) = sema.parse_root(position.file_id) else {
         return Vec::new();
     };
     let module = sema.find_node_at_offset::<ast::ModuleDeclaration>(root, position.offset);
     let Some(module) = module else {
-        return Vec::new();
-    };
-    let Some(file_id) = sema.find_file(module.syntax()) else {
         return Vec::new();
     };
     let (_, file_src_map) = db.hir_file_with_source_map(file_id);

--- a/crates/ide/src/completion/engine/port_list.rs
+++ b/crates/ide/src/completion/engine/port_list.rs
@@ -55,7 +55,8 @@ fn complete_function_port_list(
 fn visible_typedefs_in_module_header(db: &RootDb, position: FilePosition) -> Vec<String> {
     let sema = Semantics::new(db);
     let file_id = position.file_id.into();
-    let Some(root) = sema.parse_root(position.file_id) else {
+    let parsed_file = sema.parse_file(position.file_id);
+    let Some(root) = parsed_file.root() else {
         return Vec::new();
     };
     let module = sema.find_node_at_offset::<ast::ModuleDeclaration>(root, position.offset);
@@ -97,7 +98,8 @@ fn complete_non_ansi_port_list(
 ) -> Vec<CompletionCandidate> {
     let sema = Semantics::new(db);
     let file_id = position.file_id.into();
-    let Some(root) = sema.parse_root(position.file_id) else {
+    let parsed_file = sema.parse_file(position.file_id);
+    let Some(root) = parsed_file.root() else {
         return Vec::new();
     };
     let module = sema.find_node_at_offset::<ast::ModuleDeclaration>(root, position.offset);

--- a/crates/ide/src/definitions.rs
+++ b/crates/ide/src/definitions.rs
@@ -2,6 +2,7 @@ use base_db::intern::Lookup;
 use hir::{
     container::{ContainerId, InContainer, InFile, InModule, InSubroutine},
     db::HirDb,
+    file::HirFileId,
     hir_def::{
         block::{BlockId, BlockLoc},
         expr::declarator::DeclId,
@@ -421,13 +422,14 @@ impl_from! { DefinitionClass =>
 impl DefinitionClass {
     pub(crate) fn resolve(
         sema: &Semantics<'_, RootDb>,
+        file_id: HirFileId,
         tp @ SyntaxTokenWithParent { parent, tok }: SyntaxTokenWithParent,
     ) -> Option<Self> {
         if !tok.kind().name_like() {
             return None;
         }
 
-        if let Some(def) = resolve_member_or_scoped_name(sema, tp) {
+        if let Some(def) = resolve_member_or_scoped_name(sema, file_id, tp) {
             return Some(def);
         }
 
@@ -439,7 +441,7 @@ impl DefinitionClass {
                 let port = sema.nameres_named_port_conn(it).map(Definition::from);
 
                 if it.open_paren().is_none() && it.close_paren().is_none() {
-                    let local = sema.nameres_ident(tp).map(Definition::from);
+                    let local = sema.nameres_ident(file_id, tp).map(Definition::from);
 
                     match (port, local) {
                         (Some(port), Some(local)) => Self::PortConnShorthand { port, local },
@@ -450,7 +452,7 @@ impl DefinitionClass {
                     port?.into()
                 }
             },
-            _ => Definition::from(sema.nameres_ident(tp)?).into(),
+            _ => Definition::from(sema.nameres_ident(file_id, tp)?).into(),
         };
 
         Some(res)
@@ -468,6 +470,7 @@ impl DefinitionClass {
 
 fn resolve_member_or_scoped_name(
     sema: &Semantics<'_, RootDb>,
+    file_id: HirFileId,
     SyntaxTokenWithParent { parent, tok }: SyntaxTokenWithParent,
 ) -> Option<DefinitionClass> {
     if let Some(access) =
@@ -475,7 +478,7 @@ fn resolve_member_or_scoped_name(
         && access.name() == Some(tok)
     {
         let expr = ast::Expression::cast(access.syntax())?;
-        let res = sema.expr_to_def(sema.resolve_expr(expr)?)?;
+        let res = sema.expr_to_def(sema.resolve_expr(file_id, expr)?)?;
         return Some(Definition::from(res).into());
     }
 
@@ -486,7 +489,7 @@ fn resolve_member_or_scoped_name(
     }
 
     let expr = ast::Expression::cast(scoped.syntax())?;
-    let res = sema.expr_to_def(sema.resolve_expr(expr)?)?;
+    let res = sema.expr_to_def(sema.resolve_expr(file_id, expr)?)?;
     Some(Definition::from(res).into())
 }
 
@@ -541,7 +544,8 @@ mod tests {
         let file = sema.parse(file_id).unwrap();
         let port_decl_name_offset = TextSize::from(text.find("input a").unwrap() as u32 + 6);
         let token = file.syntax().token_at_offset(port_decl_name_offset).left_biased().unwrap();
-        let DefinitionClass::Definition(def) = DefinitionClass::resolve(&sema, token).unwrap()
+        let DefinitionClass::Definition(def) =
+            DefinitionClass::resolve(&sema, file_id.into(), token).unwrap()
         else {
             panic!("expected plain definition");
         };

--- a/crates/ide/src/definitions.rs
+++ b/crates/ide/src/definitions.rs
@@ -541,7 +541,8 @@ mod tests {
         let (host, file_id) = host_with_file(text);
         let db = host.raw_db();
         let sema = Semantics::<RootDb>::new(db);
-        let file = sema.parse(file_id).unwrap();
+        let parsed_file = sema.parse_file(file_id);
+        let file = parsed_file.compilation_unit().unwrap();
         let port_decl_name_offset = TextSize::from(text.find("input a").unwrap() as u32 + 6);
         let token = file.syntax().token_at_offset(port_decl_name_offset).left_biased().unwrap();
         let DefinitionClass::Definition(def) =

--- a/crates/ide/src/document_highlight.rs
+++ b/crates/ide/src/document_highlight.rs
@@ -32,7 +32,8 @@ pub(crate) fn document_highlight(
 ) -> Option<Vec<DocumentHighlight>> {
     let sema = Semantics::new(db);
     let hir_file_id = file_id.into();
-    let root = sema.parse_root(file_id)?;
+    let parsed_file = sema.parse_file(file_id);
+    let root = parsed_file.root()?;
     let token = root.token_at_offset(offset).pick_bext_token(token_precedence)?;
 
     handle_ctrl_flow_kw(&sema, hir_file_id, token).or_else(|| {

--- a/crates/ide/src/document_highlight.rs
+++ b/crates/ide/src/document_highlight.rs
@@ -1,4 +1,4 @@
-use hir::{container::InFile, semantics::Semantics};
+use hir::{container::InFile, file::HirFileId, semantics::Semantics};
 use ide_db::root_db::RootDb;
 use span::FilePosition;
 use syntax::{SyntaxNodeExt, SyntaxTokenWithParent, TokenKind, token::TokenKindExt};
@@ -31,11 +31,12 @@ pub(crate) fn document_highlight(
     config: DocumentHighlightConfig,
 ) -> Option<Vec<DocumentHighlight>> {
     let sema = Semantics::new(db);
+    let hir_file_id = file_id.into();
     let root = sema.parse_root(file_id)?;
     let token = root.token_at_offset(offset).pick_bext_token(token_precedence)?;
 
-    handle_ctrl_flow_kw(&sema, token).or_else(|| {
-        let def = match DefinitionClass::resolve(&sema, token)? {
+    handle_ctrl_flow_kw(&sema, hir_file_id, token).or_else(|| {
+        let def = match DefinitionClass::resolve(&sema, hir_file_id, token)? {
             DefinitionClass::Definition(def) => def,
             DefinitionClass::PortConnShorthand { local, .. } => local,
         };
@@ -53,10 +54,11 @@ fn token_precedence(kind: TokenKind) -> usize {
 
 fn handle_ctrl_flow_kw(
     sema: &Semantics<'_, RootDb>,
+    file_id: HirFileId,
     tp: SyntaxTokenWithParent,
 ) -> Option<Vec<DocumentHighlight>> {
-    let cur_file_id = sema.find_file(tp.parent)?.file_id();
-    let highlights = references::handle_ctrl_flow_kw(sema, tp)?
+    let cur_file_id = file_id.file_id();
+    let highlights = references::handle_ctrl_flow_kw(sema, file_id, tp)?
         .into_iter()
         .filter_map(|mut r| r.refs.remove(&cur_file_id))
         .flatten()

--- a/crates/ide/src/document_highlight.rs
+++ b/crates/ide/src/document_highlight.rs
@@ -89,9 +89,7 @@ fn highlight_refs<'a>(
         .remove(&file_id)
         .unwrap_or_default()
         .into_iter()
-        .filter_map(|tok| {
-            Some(DocumentHighlight { range: tok.range()?, category: tok.category() })
-        });
+        .map(|tok| DocumentHighlight { range: tok.range(), category: tok.category() });
 
     Some(defs.chain(refs).collect())
 }

--- a/crates/ide/src/formatting.rs
+++ b/crates/ide/src/formatting.rs
@@ -172,7 +172,8 @@ pub fn format_on_type(
     }
 
     let sema = Semantics::new(db);
-    let Some(root) = sema.parse_root(file_id) else {
+    let parsed_file = sema.parse_file(file_id);
+    let Some(root) = parsed_file.root() else {
         return Ok(None);
     };
 

--- a/crates/ide/src/goto_declaration.rs
+++ b/crates/ide/src/goto_declaration.rs
@@ -15,10 +15,11 @@ pub(crate) fn goto_declaration(
     FilePosition { file_id, offset }: FilePosition,
 ) -> Option<RangeInfo<Vec<NavTarget>>> {
     let sema = Semantics::new(db);
+    let hir_file_id = file_id.into();
     let root = sema.parse_root(file_id)?;
     let token = root.token_at_offset(offset).pick_bext_token(goto_definition::token_precedence)?;
 
-    let origins = match DefinitionClass::resolve(&sema, token)? {
+    let origins = match DefinitionClass::resolve(&sema, hir_file_id, token)? {
         DefinitionClass::Definition(definition) => definition.declaration_origins(),
         DefinitionClass::PortConnShorthand { port, .. } => port.declaration_origins(),
     };

--- a/crates/ide/src/goto_declaration.rs
+++ b/crates/ide/src/goto_declaration.rs
@@ -16,7 +16,8 @@ pub(crate) fn goto_declaration(
 ) -> Option<RangeInfo<Vec<NavTarget>>> {
     let sema = Semantics::new(db);
     let hir_file_id = file_id.into();
-    let root = sema.parse_root(file_id)?;
+    let parsed_file = sema.parse_file(file_id);
+    let root = parsed_file.root()?;
     let token = root.token_at_offset(offset).pick_bext_token(goto_definition::token_precedence)?;
 
     let origins = match DefinitionClass::resolve(&sema, hir_file_id, token)? {

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -1,4 +1,4 @@
-use hir::{container::InFile, semantics::Semantics};
+use hir::{container::InFile, file::HirFileId, semantics::Semantics};
 use ide_db::root_db::RootDb;
 use itertools::Itertools;
 use span::{FilePosition, RangeInfo};
@@ -18,11 +18,12 @@ pub(crate) fn goto_definition(
     FilePosition { file_id, offset }: FilePosition,
 ) -> Option<RangeInfo<Vec<NavTarget>>> {
     let sema = Semantics::new(db);
+    let hir_file_id = file_id.into();
     let root = sema.parse_root(file_id)?;
     let token = root.token_at_offset(offset).pick_bext_token(token_precedence)?;
 
-    let navs = handle_ctrl_flow_kw(&sema, token).or_else(|| {
-        DefinitionClass::resolve(&sema, token)?
+    let navs = handle_ctrl_flow_kw(&sema, hir_file_id, token).or_else(|| {
+        DefinitionClass::resolve(&sema, hir_file_id, token)?
             .origins()
             .into_iter()
             .unique()
@@ -36,9 +37,9 @@ pub(crate) fn goto_definition(
 
 fn handle_ctrl_flow_kw(
     sema: &Semantics<RootDb>,
-    tp @ SyntaxTokenWithParent { parent, .. }: SyntaxTokenWithParent,
+    file_id: HirFileId,
+    tp @ SyntaxTokenWithParent { .. }: SyntaxTokenWithParent,
 ) -> Option<Vec<NavTarget>> {
-    let file_id = sema.find_file(parent)?;
     let kind = tp.kind();
 
     match kind {

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -19,7 +19,8 @@ pub(crate) fn goto_definition(
 ) -> Option<RangeInfo<Vec<NavTarget>>> {
     let sema = Semantics::new(db);
     let hir_file_id = file_id.into();
-    let root = sema.parse_root(file_id)?;
+    let parsed_file = sema.parse_file(file_id);
+    let root = parsed_file.root()?;
     let token = root.token_at_offset(offset).pick_bext_token(token_precedence)?;
 
     let navs = handle_ctrl_flow_kw(&sema, hir_file_id, token).or_else(|| {

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -1,4 +1,4 @@
-use hir::{container::InContainer, hir_def::expr::Expr, semantics::Semantics};
+use hir::{container::InContainer, file::HirFileId, hir_def::expr::Expr, semantics::Semantics};
 use ide_db::root_db::RootDb;
 use span::{FilePosition, RangeInfo};
 use syntax::{
@@ -28,10 +28,12 @@ pub(crate) fn hover(
     _config: HoverConfig,
 ) -> Option<RangeInfo<Markup>> {
     let sema = Semantics::new(db);
+    let hir_file_id = file_id.into();
     let root = sema.parse_root(file_id)?;
     let token = root.token_at_offset(offset).pick_bext_token(token_precedence)?;
 
-    let res = handle_literal(&sema, token).or_else(|| handle_definition(&sema, token))?;
+    let res = handle_literal(&sema, hir_file_id, token)
+        .or_else(|| handle_definition(&sema, hir_file_id, token))?;
     Some(RangeInfo::new(token.text_range()?, res))
 }
 
@@ -45,6 +47,7 @@ pub(crate) fn token_precedence(kind: TokenKind) -> usize {
 
 fn handle_literal(
     sema: &Semantics<RootDb>,
+    file_id: HirFileId,
     SyntaxTokenWithParent { parent, tok }: SyntaxTokenWithParent,
 ) -> Option<Markup> {
     if !tok.kind().is_literal() {
@@ -52,7 +55,7 @@ fn handle_literal(
     }
 
     let expr = ast::Expression::cast(parent)?;
-    let InContainer { value: expr_id, cont_id } = sema.resolve_expr(expr)?;
+    let InContainer { value: expr_id, cont_id } = sema.resolve_expr(file_id, expr)?;
     let container = cont_id.to_container(sema.db);
     let Expr::Literal(literal) = container.get(expr_id) else {
         return None;
@@ -61,8 +64,12 @@ fn handle_literal(
     render::render_literal(literal)
 }
 
-fn handle_definition(sema: &Semantics<RootDb>, tp: SyntaxTokenWithParent) -> Option<Markup> {
-    let def = DefinitionClass::resolve(sema, tp)?;
+fn handle_definition(
+    sema: &Semantics<RootDb>,
+    file_id: HirFileId,
+    tp: SyntaxTokenWithParent,
+) -> Option<Markup> {
+    let def = DefinitionClass::resolve(sema, file_id, tp)?;
     let mut res = Markup::new();
 
     match def {

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -29,7 +29,8 @@ pub(crate) fn hover(
 ) -> Option<RangeInfo<Markup>> {
     let sema = Semantics::new(db);
     let hir_file_id = file_id.into();
-    let root = sema.parse_root(file_id)?;
+    let parsed_file = sema.parse_file(file_id);
+    let root = parsed_file.root()?;
     let token = root.token_at_offset(offset).pick_bext_token(token_precedence)?;
 
     let res = handle_literal(&sema, hir_file_id, token)

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -1,4 +1,4 @@
-use hir::semantics::Semantics;
+use hir::{file::HirFileId, semantics::Semantics};
 use ide_db::root_db::RootDb;
 use itertools::Itertools;
 use nohash_hasher::IntMap;
@@ -59,11 +59,12 @@ pub(crate) fn references(
     config: ReferencesConfig,
 ) -> Option<Vec<References>> {
     let sema = Semantics::new(db);
+    let hir_file_id = file_id.into();
     let root = sema.parse_root(file_id)?;
     let token = root.token_at_offset(offset).pick_bext_token(token_precedence)?;
 
-    handle_ctrl_flow_kw(&sema, token).or_else(|| {
-        let def = match DefinitionClass::resolve(&sema, token)? {
+    handle_ctrl_flow_kw(&sema, hir_file_id, token).or_else(|| {
+        let def = match DefinitionClass::resolve(&sema, hir_file_id, token)? {
             DefinitionClass::Definition(def) => def,
             DefinitionClass::PortConnShorthand { local, .. } => local,
         };
@@ -72,10 +73,10 @@ pub(crate) fn references(
 }
 
 pub(crate) fn handle_ctrl_flow_kw(
-    sema: &Semantics<'_, RootDb>,
-    tp @ SyntaxTokenWithParent { parent, .. }: SyntaxTokenWithParent,
+    _sema: &Semantics<'_, RootDb>,
+    file_id: HirFileId,
+    tp @ SyntaxTokenWithParent { .. }: SyntaxTokenWithParent,
 ) -> Option<Vec<References>> {
-    let file_id = sema.find_file(parent)?;
     let kind = tp.kind();
 
     let mut refs = vec![];

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -107,10 +107,7 @@ fn search_refs<'a>(
         .search()
         .into_iter()
         .map(|(file_id, tokens)| {
-            let res = tokens
-                .into_iter()
-                .filter_map(|token| Some((token.range()?, token.category())))
-                .collect();
+            let res = tokens.into_iter().map(|token| (token.range(), token.category())).collect();
             (file_id, res)
         })
         .collect();

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -60,7 +60,8 @@ pub(crate) fn references(
 ) -> Option<Vec<References>> {
     let sema = Semantics::new(db);
     let hir_file_id = file_id.into();
-    let root = sema.parse_root(file_id)?;
+    let parsed_file = sema.parse_file(file_id);
+    let root = parsed_file.root()?;
     let token = root.token_at_offset(offset).pick_bext_token(token_precedence)?;
 
     handle_ctrl_flow_kw(&sema, hir_file_id, token).or_else(|| {

--- a/crates/ide/src/references/search.rs
+++ b/crates/ide/src/references/search.rs
@@ -14,7 +14,7 @@ use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use syntax::{
     SyntaxNode, SyntaxNodeExt, SyntaxTokenWithParent, has_text_range::HasTextRange,
-    token::TokenKindExt,
+    ptr::SyntaxTokenPtr, token::TokenKindExt,
 };
 use triomphe::Arc;
 use utils::{
@@ -135,18 +135,30 @@ pub(crate) struct ReferencesCtx<'a, 'b> {
     scope: SearchScope,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct ReferenceToken<'a> {
-    pub token: SyntaxTokenWithParent<'a>,
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ReferenceToken {
+    ptr: SyntaxTokenPtr,
+    category: ReferenceCategory,
 }
 
-impl ReferenceToken<'_> {
-    pub fn range(&self) -> Option<TextRange> {
-        self.token.text_range()
+impl ReferenceToken {
+    pub fn new(token: SyntaxTokenWithParent) -> Self {
+        Self {
+            ptr: SyntaxTokenPtr::from_token(token),
+            category: ReferenceCategory::from_tok(token),
+        }
+    }
+
+    pub fn range(&self) -> TextRange {
+        self.ptr.range()
     }
 
     pub fn category(&self) -> ReferenceCategory {
-        ReferenceCategory::from_tok(self.token)
+        self.category
+    }
+
+    pub fn to_token<'a>(&self, tree: &'a syntax::SyntaxTree) -> Option<SyntaxTokenWithParent<'a>> {
+        self.ptr.to_token(tree)
     }
 }
 
@@ -162,7 +174,7 @@ impl<'a, 'b> ReferencesCtx<'a, 'b> {
         Self { sema, def, scope }
     }
 
-    pub(crate) fn search(&self) -> IntMap<FileId, Vec<ReferenceToken<'a>>> {
+    pub(crate) fn search(&self) -> IntMap<FileId, Vec<ReferenceToken>> {
         let sema = self.sema;
         let db = sema.db;
         let mut res: IntMap<_, Vec<_>> = IntMap::default();
@@ -194,7 +206,7 @@ impl<'a, 'b> ReferencesCtx<'a, 'b> {
                 .for_each(|token| {
                     res.entry(file_id)
                         .or_insert_with(|| Vec::with_capacity(Self::FILE_REF_CAPACITY))
-                        .push(ReferenceToken { token })
+                        .push(ReferenceToken::new(token))
                 });
         }
 

--- a/crates/ide/src/references/search.rs
+++ b/crates/ide/src/references/search.rs
@@ -157,7 +157,7 @@ impl ReferenceToken {
         self.category
     }
 
-    pub fn to_token<'a>(&self, tree: &'a syntax::SyntaxTree) -> Option<SyntaxTokenWithParent<'a>> {
+    pub fn to_token<'a>(self, tree: &'a syntax::SyntaxTree) -> Option<SyntaxTokenWithParent<'a>> {
         self.ptr.to_token(tree)
     }
 }

--- a/crates/ide/src/references/search.rs
+++ b/crates/ide/src/references/search.rs
@@ -199,9 +199,11 @@ impl<'a, 'b> ReferencesCtx<'a, 'b> {
         for (text, file_id, range) in self.scope_files() {
             self.sema.db.unwind_if_cancelled();
 
-            let root = LazyCell::new(|| sema.parse_root(file_id));
+            let parsed_file = LazyCell::new(|| sema.parse_file(file_id));
             Self::match_text(&text, finder, range)
-                .filter_map(|offset| Self::filter_token((*root)?, file_id, &def_ranges, offset))
+                .filter_map(|offset| {
+                    Self::filter_token((*parsed_file).root()?, file_id, &def_ranges, offset)
+                })
                 .filter(|tp| self.classify_and_filter(sema, file_id.into(), tp))
                 .for_each(|token| {
                     res.entry(file_id)
@@ -246,12 +248,12 @@ impl<'a, 'b> ReferencesCtx<'a, 'b> {
         })
     }
 
-    fn filter_token(
-        node: SyntaxNode<'a>,
+    fn filter_token<'tree>(
+        node: SyntaxNode<'tree>,
         file_id: FileId,
         names: &[InFile<TextRange>],
         offset: TextSize,
-    ) -> Option<SyntaxTokenWithParent<'a>> {
+    ) -> Option<SyntaxTokenWithParent<'tree>> {
         let tok = node.token_at_offset(offset).find(|tok| tok.kind().name_like())?;
         let tok_range = tok.text_range()?;
 
@@ -265,11 +267,11 @@ impl<'a, 'b> ReferencesCtx<'a, 'b> {
         }
     }
 
-    fn classify_and_filter(
+    fn classify_and_filter<'tree>(
         &self,
-        sema: &'a Semantics<'a, RootDb>,
+        sema: &Semantics<'_, RootDb>,
         file_id: hir::file::HirFileId,
-        tp: &SyntaxTokenWithParent<'a>,
+        tp: &SyntaxTokenWithParent<'tree>,
     ) -> bool {
         let Some(def) = DefinitionClass::resolve(sema, file_id, *tp) else {
             return false;

--- a/crates/ide/src/references/search.rs
+++ b/crates/ide/src/references/search.rs
@@ -190,7 +190,7 @@ impl<'a, 'b> ReferencesCtx<'a, 'b> {
             let root = LazyCell::new(|| sema.parse_root(file_id));
             Self::match_text(&text, finder, range)
                 .filter_map(|offset| Self::filter_token((*root)?, file_id, &def_ranges, offset))
-                .filter(|tp| self.classify_and_filter(sema, tp))
+                .filter(|tp| self.classify_and_filter(sema, file_id.into(), tp))
                 .for_each(|token| {
                     res.entry(file_id)
                         .or_insert_with(|| Vec::with_capacity(Self::FILE_REF_CAPACITY))
@@ -256,9 +256,10 @@ impl<'a, 'b> ReferencesCtx<'a, 'b> {
     fn classify_and_filter(
         &self,
         sema: &'a Semantics<'a, RootDb>,
+        file_id: hir::file::HirFileId,
         tp: &SyntaxTokenWithParent<'a>,
     ) -> bool {
-        let Some(def) = DefinitionClass::resolve(sema, *tp) else {
+        let Some(def) = DefinitionClass::resolve(sema, file_id, *tp) else {
             return false;
         };
 

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -102,7 +102,7 @@ pub(crate) fn rename(
 
 fn edits_from_refs(
     sema: &Semantics<'_, RootDb>,
-    (file_id, toks): (FileId, Vec<ReferenceToken<'_>>),
+    (file_id, toks): (FileId, Vec<ReferenceToken>),
     def: &Definition,
     old_name: &str,
     new_name: &str,
@@ -110,9 +110,11 @@ fn edits_from_refs(
     let mut text_edit = TextEdit::builder();
     let text = sema.db.file_text(file_id);
     let hir_file_id = file_id.into();
+    let parsed_file = sema.parse_file(file_id);
 
-    for ReferenceToken { token } in toks.into_iter() {
-        let Some(range) = token.text_range() else {
+    for token_ref in toks.into_iter() {
+        let range = token_ref.range();
+        let Some(token) = token_ref.to_token(parsed_file.syntax_tree()) else {
             continue;
         };
         let SyntaxTokenWithParent { parent, tok } = token;

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -48,10 +48,11 @@ pub(crate) fn prepare_rename(
     FilePosition { file_id, offset }: FilePosition,
 ) -> RenameResult<TextRange> {
     let sema = Semantics::new(db);
+    let hir_file_id = file_id.into();
     let root = sema.parse_root(file_id).ok_or(RenameError::NoRefFound)?;
     let token = pick_token(root, offset)?;
     let text_range = token.text_range().ok_or(RenameError::NoRefFound)?;
-    DefinitionClass::resolve(&sema, token).ok_or(RenameError::NoDefFound)?;
+    DefinitionClass::resolve(&sema, hir_file_id, token).ok_or(RenameError::NoDefFound)?;
     Ok(text_range)
 }
 
@@ -62,12 +63,14 @@ pub(crate) fn rename(
     new_name: &str,
 ) -> RenameResult<SourceChange> {
     let sema = Semantics::new(db);
+    let hir_file_id = file_id.into();
     let root = sema.parse_root(file_id).ok_or(RenameError::NoRefFound)?;
     let token = pick_token(root, offset)?;
-    let def = match DefinitionClass::resolve(&sema, token).ok_or(RenameError::NoDefFound)? {
-        DefinitionClass::Definition(def) => def,
-        DefinitionClass::PortConnShorthand { local, .. } => local,
-    };
+    let def =
+        match DefinitionClass::resolve(&sema, hir_file_id, token).ok_or(RenameError::NoDefFound)? {
+            DefinitionClass::Definition(def) => def,
+            DefinitionClass::PortConnShorthand { local, .. } => local,
+        };
 
     let old_name = lower_ident(Some(token.tok)).ok_or(RenameError::NoRefFound)?;
     let mut source_changes = SourceChange::default();
@@ -106,6 +109,7 @@ fn edits_from_refs(
 ) -> (FileId, TextEdit) {
     let mut text_edit = TextEdit::builder();
     let text = sema.db.file_text(file_id);
+    let hir_file_id = file_id.into();
 
     for ReferenceToken { token } in toks.into_iter() {
         let Some(range) = token.text_range() else {
@@ -129,7 +133,7 @@ fn edits_from_refs(
                     }
                     (None, None) => {
                         if let Some(port_conn) = ast::PortConnection::cast(it.syntax()) {
-                            if let Some(ref_container) = sema.resolve_named_port_conn(port_conn)
+                            if let Some(ref_container) = sema.resolve_named_port_conn(hir_file_id, port_conn)
                                 && def
                                     .container_id(sema.db)
                                     .is_some_and(|id| id == ref_container.module_id.into())

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -49,7 +49,8 @@ pub(crate) fn prepare_rename(
 ) -> RenameResult<TextRange> {
     let sema = Semantics::new(db);
     let hir_file_id = file_id.into();
-    let root = sema.parse_root(file_id).ok_or(RenameError::NoRefFound)?;
+    let parsed_file = sema.parse_file(file_id);
+    let root = parsed_file.root().ok_or(RenameError::NoRefFound)?;
     let token = pick_token(root, offset)?;
     let text_range = token.text_range().ok_or(RenameError::NoRefFound)?;
     DefinitionClass::resolve(&sema, hir_file_id, token).ok_or(RenameError::NoDefFound)?;
@@ -64,7 +65,8 @@ pub(crate) fn rename(
 ) -> RenameResult<SourceChange> {
     let sema = Semantics::new(db);
     let hir_file_id = file_id.into();
-    let root = sema.parse_root(file_id).ok_or(RenameError::NoRefFound)?;
+    let parsed_file = sema.parse_file(file_id);
+    let root = parsed_file.root().ok_or(RenameError::NoRefFound)?;
     let token = pick_token(root, offset)?;
     let def =
         match DefinitionClass::resolve(&sema, hir_file_id, token).ok_or(RenameError::NoDefFound)? {

--- a/crates/ide/src/render.rs
+++ b/crates/ide/src/render.rs
@@ -153,7 +153,8 @@ fn render_side_comments(sema: &Semantics<'_, RootDb>, origin: &DefinitionOrigin)
     let db = sema.db;
     let InFile { value: range, file_id } = origin.range(db)?;
 
-    let root = sema.parse_root(file_id.file_id())?;
+    let parsed_file = sema.parse_file(file_id.file_id());
+    let root = parsed_file.root()?;
     let elem = root.elem_at_exact_range(range)?;
     let mut offset = elem.text_range()?.end();
 

--- a/crates/ide/src/selection_ranges.rs
+++ b/crates/ide/src/selection_ranges.rs
@@ -14,7 +14,8 @@ pub(crate) fn selection_ranges(
     FilePosition { file_id, offset }: FilePosition,
 ) -> Vec<TextRange> {
     let sema = Semantics::new(db);
-    let Some(root) = sema.parse_root(file_id) else {
+    let parsed_file = sema.parse_file(file_id);
+    let Some(root) = parsed_file.root() else {
         return vec![TextRange::empty(offset)];
     };
 

--- a/crates/ide/src/semantic_tokens.rs
+++ b/crates/ide/src/semantic_tokens.rs
@@ -126,7 +126,8 @@ pub(crate) fn semantic_tokens(
     range: Option<TextRange>,
 ) -> Vec<SemaToken> {
     let sema = Semantics::new(db);
-    let Some(root) = sema.parse_root(file_id) else {
+    let parsed_file = sema.parse_file(file_id);
+    let Some(root) = parsed_file.root() else {
         return Vec::new();
     };
     let file_id = HirFileId(file_id);

--- a/crates/ide/src/signature_help.rs
+++ b/crates/ide/src/signature_help.rs
@@ -68,7 +68,8 @@ pub(crate) fn signature_help(
 ) -> Option<SignatureHelp> {
     let sema = Semantics::new(db);
     let hir_file_id = file_id.into();
-    let root = sema.parse_root(file_id)?;
+    let parsed_file = sema.parse_file(file_id);
+    let root = parsed_file.root()?;
     let token = root.token_at_offset(offset).left_biased()?;
 
     for node in SyntaxAncestors::start_from(token.parent) {

--- a/crates/ide/src/signature_help.rs
+++ b/crates/ide/src/signature_help.rs
@@ -2,6 +2,7 @@ use hir::{
     container::{InContainer, InModule},
     db::HirDb,
     display::HirDisplay,
+    file::HirFileId,
     hir_def::{
         declaration::Declaration,
         module::{
@@ -66,6 +67,7 @@ pub(crate) fn signature_help(
     config: SignatureHelpConfig,
 ) -> Option<SignatureHelp> {
     let sema = Semantics::new(db);
+    let hir_file_id = file_id.into();
     let root = sema.parse_root(file_id)?;
     let token = root.token_at_offset(offset).left_biased()?;
 
@@ -73,7 +75,7 @@ pub(crate) fn signature_help(
         match_ast! { node,
             ast::HierarchicalInstance[it] => {
                 if it.close_paren().is_none_or(|tok| tok != token.tok) {
-                    return sig_help_for_instance(&sema, it, offset, config);
+                    return sig_help_for_instance(&sema, hir_file_id, it, offset, config);
                 }
             },
             ast::HierarchyInstantiation[it] => {
@@ -90,7 +92,7 @@ pub(crate) fn signature_help(
                         .and_then(|close_paren| close_paren.text_range_in(params.syntax()))
                         .is_some_and(|range| offset <= range.start())
                 {
-                        return sig_help_for_instantiation(&sema, it, offset, config);
+                        return sig_help_for_instantiation(&sema, hir_file_id, it, offset, config);
                     }
             },
             _ => {},
@@ -102,6 +104,7 @@ pub(crate) fn signature_help(
 
 fn sig_help_for_instance(
     sema: &Semantics<'_, RootDb>,
+    file_id: HirFileId,
     instance: ast::HierarchicalInstance,
     offset: TextSize,
     config: SignatureHelpConfig,
@@ -109,7 +112,8 @@ fn sig_help_for_instance(
     let db = sema.db;
 
     let active_param = 'blk: {
-        let Some(InModule { value: instance_id, module_id }) = sema.resolve_instance(instance)
+        let Some(InModule { value: instance_id, module_id }) =
+            sema.resolve_instance(file_id, instance)
         else {
             break 'blk None;
         };
@@ -221,6 +225,7 @@ fn sig_help_for_instance(
 
 fn sig_help_for_instantiation(
     sema: &Semantics<'_, RootDb>,
+    file_id: HirFileId,
     instantiation: ast::HierarchyInstantiation,
     offset: TextSize,
     config: SignatureHelpConfig,
@@ -229,7 +234,7 @@ fn sig_help_for_instantiation(
 
     let active_param = 'blk: {
         let Some(InModule { value: instantiation_id, module_id }) =
-            sema.resolve_instantiation(instantiation)
+            sema.resolve_instantiation(file_id, instantiation)
         else {
             break 'blk None;
         };

--- a/crates/ide/src/verilog_2005.rs
+++ b/crates/ide/src/verilog_2005.rs
@@ -107,7 +107,7 @@ fn setup_with_path(text: &str, path: &str) -> (AnalysisHost, FileId) {
 }
 
 #[test]
-fn semantics_nodes_survive_parse_lru_eviction() {
+fn parsed_file_nodes_survive_parse_lru_eviction() {
     let mut file_set = FileSet::default();
     let files = [
         (FileId(0), "/a.sv", "module a;\n  wire x;\nendmodule\n"),
@@ -129,7 +129,8 @@ fn semantics_nodes_survive_parse_lru_eviction() {
     db.apply_change(change);
 
     let sema = Semantics::new(&db);
-    let root = sema.parse_root(FileId(0)).expect("a.sv should parse");
+    let parsed_file = sema.parse_file(FileId(0));
+    let root = parsed_file.root().expect("a.sv should parse");
     let child_count = root.child_count();
     assert!(child_count > 0);
 

--- a/crates/ide/src/verilog_2005.rs
+++ b/crates/ide/src/verilog_2005.rs
@@ -4,7 +4,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use base_db::{change::Change, source_root::SourceRoot};
+use base_db::{change::Change, source_db::SourceDb, source_root::SourceRoot};
+use hir::semantics::Semantics;
+use ide_db::root_db::RootDb;
 use insta::assert_snapshot;
 use span::FilePosition;
 use triomphe::Arc;
@@ -102,6 +104,40 @@ fn setup_with_path(text: &str, path: &str) -> (AnalysisHost, FileId) {
     let mut host = AnalysisHost::default();
     host.apply_change(change);
     (host, file_id)
+}
+
+#[test]
+fn semantics_nodes_survive_parse_lru_eviction() {
+    let mut file_set = FileSet::default();
+    let files = [
+        (FileId(0), "/a.sv", "module a;\n  wire x;\nendmodule\n"),
+        (FileId(1), "/b.sv", "module b;\nendmodule\n"),
+        (FileId(2), "/c.sv", "module c;\nendmodule\n"),
+    ];
+
+    let mut change = Change::new();
+    for (file_id, path, text) in files {
+        file_set.insert(file_id, VfsPath::new_virtual_path(path.to_owned()));
+        change.add_changed_file(ChangedFile {
+            file_id,
+            change_kind: ChangeKind::Create(Arc::from(text), LineEnding::Unix),
+        });
+    }
+    change.set_roots(vec![SourceRoot::new_local(file_set)]);
+
+    let mut db = RootDb::new(Some(1));
+    db.apply_change(change);
+
+    let sema = Semantics::new(&db);
+    let root = sema.parse_root(FileId(0)).expect("a.sv should parse");
+    let child_count = root.child_count();
+    assert!(child_count > 0);
+
+    let _ = db.parse_src(FileId(1));
+    let _ = db.parse_src(FileId(2));
+
+    assert_eq!(root.child_count(), child_count);
+    assert!(root.first_token().is_some());
 }
 
 fn setup_marked(text: &str) -> (AnalysisHost, FileId, String, HashMap<String, TextSize>) {

--- a/crates/syntax/src/ptr.rs
+++ b/crates/syntax/src/ptr.rs
@@ -51,7 +51,9 @@ impl SyntaxTokenPtr {
     }
 
     pub fn to_token<'a>(&self, tree: &'a SyntaxTree) -> Option<SyntaxTokenWithParent<'a>> {
-        tree.root()?.elem_at_exact_range(self.range)?.as_tok_with_parent()
+        tree.root()?.token_at_offset(self.range.start()).find(|token| {
+            token.kind() == self.kind && token.text_range().is_some_and(|range| range == self.range)
+        })
     }
 
     pub fn kind(&self) -> TokenKind {


### PR DESCRIPTION
Should be merged after #29.

Previously, semantics APIs returned borrowed syntax nodes detached from their owning `SyntaxTree`. Under Salsa LRU eviction this could leave cached nodes pointing to evicted trees, causing unsound behavior. This PR makes syntax tree ownership explicit by introducing `ParsedFile`, which owns the underlying `SyntaxTree` for the lifetime of semantic operations.

It also removes implicit file lookup from syntax nodes and switches several caches and reference paths from borrowed syntax nodes/tokens to stable syntax pointers.
