### PR TITLE
fix(build): pin linux x64 runner and add alpine packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Install Rust components
         working-directory: .
-        run: rustup component add rustfmt
+        run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,12 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Trust checkout directories
+        working-directory: .
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE/crates/slang"
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          # Keep the Linux x64 VSIX compatible with Ubuntu 22.04 glibc/libstdc++.
+          - os: ubuntu-22.04
             target: linux-x64
+          - os: ubuntu-22.04
+            target: alpine-x64
+            rust_target: x86_64-unknown-linux-musl
+          - os: ubuntu-22.04
+            target: alpine-arm64
+            rust_target: aarch64-unknown-linux-musl
           - os: ubuntu-24.04-arm
             target: linux-arm64
           - os: windows-latest
@@ -113,6 +120,11 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
+      - name: Setup Rust cross toolchain
+        if: matrix.rust_target
+        uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.rust_target }}
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,10 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends ca-certificates cmake git python3
 
+      - name: Install Rust components
+        working-directory: .
+        run: rustup component add rustfmt
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,12 +97,6 @@ jobs:
           # Keep the Linux x64 VSIX compatible with Ubuntu 22.04 glibc/libstdc++.
           - os: ubuntu-22.04
             target: linux-x64
-          - os: ubuntu-22.04
-            target: alpine-x64
-            rust_target: x86_64-unknown-linux-musl
-          - os: ubuntu-22.04
-            target: alpine-arm64
-            rust_target: aarch64-unknown-linux-musl
           - os: ubuntu-24.04-arm
             target: linux-arm64
           - os: windows-latest
@@ -120,11 +114,6 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-      - name: Setup Rust cross toolchain
-        if: matrix.rust_target
-        uses: taiki-e/setup-cross-toolchain-action@v1
-        with:
-          target: ${{ matrix.rust_target }}
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -148,6 +137,64 @@ jobs:
           echo "VIZSLA_BUILD_DATE=$(date -u +'%Y%m%dT%H%M%SZ')" >> "$GITHUB_ENV"
       - name: Package extension
         run: npm run package:debug -- ${{ matrix.target }}
+      - name: Upload dev VSIX
+        uses: actions/upload-artifact@v4
+        with:
+          name: vizsla-vscode-dev-${{ matrix.target }}-${{ steps.build-metadata.outputs.commit_hash }}
+          path: editors/vscode/vizsla-vscode-${{ matrix.target }}-debug.vsix
+          if-no-files-found: error
+          retention-days: 14
+
+  dev-alpine-package:
+    name: Dev Package (${{ matrix.target }})
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-22.04
+    container: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: alpine-x64
+            image: ghcr.io/blackdex/rust-musl:x86_64-musl-nightly
+          - target: alpine-arm64
+            image: ghcr.io/blackdex/rust-musl:aarch64-musl-nightly
+    defaults:
+      run:
+        working-directory: editors/vscode
+    steps:
+      - name: Install build dependencies
+        working-directory: .
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends ca-certificates cmake git python3
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: editors/vscode/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Set build metadata
+        id: build-metadata
+        shell: bash
+        working-directory: .
+        run: |
+          commit_hash="$(git rev-parse --short "$GITHUB_SHA")"
+          echo "VIZSLA_COMMIT_HASH=${commit_hash}" >> "$GITHUB_ENV"
+          echo "commit_hash=${commit_hash}" >> "$GITHUB_OUTPUT"
+          echo "VIZSLA_BUILD_DATE=$(date -u +'%Y%m%dT%H%M%SZ')" >> "$GITHUB_ENV"
+
+      - name: Package extension
+        run: npm run package:debug -- ${{ matrix.target }}
+
       - name: Upload dev VSIX
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          # Keep the Linux x64 VSIX compatible with Ubuntu 22.04 glibc/libstdc++.
+          - os: ubuntu-22.04
             target: linux-x64
+          - os: ubuntu-22.04
+            target: alpine-x64
+            rust_target: x86_64-unknown-linux-musl
+          - os: ubuntu-22.04
+            target: alpine-arm64
+            rust_target: aarch64-unknown-linux-musl
           - os: ubuntu-24.04-arm
             target: linux-arm64
           - os: windows-latest
@@ -39,6 +46,12 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
+
+      - name: Setup Rust cross toolchain
+        if: matrix.rust_target
+        uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.rust_target }}
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,11 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Trust checkout directories
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE/crates/slang"
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
           apt-get install -y --no-install-recommends ca-certificates cmake git python3
 
       - name: Install Rust components
-        run: rustup component add rustfmt
+        run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,9 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends ca-certificates cmake git python3
 
+      - name: Install Rust components
+        run: rustup component add rustfmt
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,6 @@ jobs:
           # Keep the Linux x64 VSIX compatible with Ubuntu 22.04 glibc/libstdc++.
           - os: ubuntu-22.04
             target: linux-x64
-          - os: ubuntu-22.04
-            target: alpine-x64
-            rust_target: x86_64-unknown-linux-musl
-          - os: ubuntu-22.04
-            target: alpine-arm64
-            rust_target: aarch64-unknown-linux-musl
           - os: ubuntu-24.04-arm
             target: linux-arm64
           - os: windows-latest
@@ -46,12 +40,6 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-
-      - name: Setup Rust cross toolchain
-        if: matrix.rust_target
-        uses: taiki-e/setup-cross-toolchain-action@v1
-        with:
-          target: ${{ matrix.rust_target }}
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -87,9 +75,60 @@ jobs:
           path: editors/vscode/vizsla-vscode-${{ matrix.target }}.vsix
           if-no-files-found: error
 
+  build-alpine-package:
+    name: Package ${{ matrix.target }}
+    runs-on: ubuntu-22.04
+    container: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: alpine-x64
+            image: ghcr.io/blackdex/rust-musl:x86_64-musl-nightly
+          - target: alpine-arm64
+            image: ghcr.io/blackdex/rust-musl:aarch64-musl-nightly
+    steps:
+      - name: Install build dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends ca-certificates cmake git python3
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: editors/vscode/package-lock.json
+
+      - name: Install JS dependencies
+        working-directory: editors/vscode
+        run: npm ci
+
+      - name: Set build metadata
+        shell: bash
+        run: |
+          echo "VIZSLA_COMMIT_HASH=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
+          echo "VIZSLA_BUILD_DATE=$(date -u +'%Y%m%dT%H%M%SZ')" >> "$GITHUB_ENV"
+
+      - name: Build VSIX
+        working-directory: editors/vscode
+        run: npm run package:${{ matrix.target }}
+
+      - name: Upload VSIX
+        uses: actions/upload-artifact@v4
+        with:
+          name: vizsla-vscode-${{ github.event_name == 'workflow_dispatch' && 'beta' || 'stable' }}-${{ matrix.target }}
+          path: editors/vscode/vizsla-vscode-${{ matrix.target }}.vsix
+          if-no-files-found: error
+
   publish:
     name: Publish ${{ github.event_name == 'workflow_dispatch' && 'beta' || 'stable' }} release
-    needs: [build-and-package]
+    needs: [build-and-package, build-alpine-package]
     runs-on: ubuntu-latest
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && 'beta' || github.ref_name }}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -347,6 +347,8 @@
     "compile": "npm run clean && npm run typecheck && npm run bundle",
     "test": "npm run compile && node --import tsx --test \"test/**/*.test.ts\"",
     "package:debug": "npm run compile && tsx scripts/package.ts --debug",
+    "package:alpine-arm64": "npm run compile && tsx scripts/package.ts alpine-arm64",
+    "package:alpine-x64": "npm run compile && tsx scripts/package.ts alpine-x64",
     "package:darwin-arm64": "npm run compile && tsx scripts/package.ts darwin-arm64",
     "package:darwin-x64": "npm run compile && tsx scripts/package.ts darwin-x64",
     "package:linux-x64": "npm run compile && tsx scripts/package.ts linux-x64",

--- a/editors/vscode/scripts/package.ts
+++ b/editors/vscode/scripts/package.ts
@@ -15,6 +15,11 @@ const binName = 'vizsla';
 
 type BuildProfile = 'debug' | 'release';
 
+const cargoTargets: Partial<Record<PlatformFolder, string>> = {
+  'alpine-arm64': 'aarch64-unknown-linux-musl',
+  'alpine-x64': 'x86_64-unknown-linux-musl',
+};
+
 function findExtensionRoot(startDir: string): string {
   let currentDir = path.resolve(startDir);
 
@@ -90,8 +95,26 @@ function cargoProfileDir(profile: BuildProfile): string {
   return profile === 'release' ? 'release' : 'debug';
 }
 
-function cargoBuildArgs(profile: BuildProfile): string[] {
-  return profile === 'release' ? ['build', '--release'] : ['build'];
+function cargoBuildArgs(profile: BuildProfile, cargoTarget?: string): string[] {
+  const args = ['build'];
+  if (profile === 'release') {
+    args.push('--release');
+  }
+  if (cargoTarget) {
+    args.push('--target', cargoTarget);
+  }
+
+  return args;
+}
+
+function cargoOutputDir(profile: BuildProfile, cargoTarget?: string): string {
+  const pathParts = [repoRoot, 'target'];
+  if (cargoTarget) {
+    pathParts.push(cargoTarget);
+  }
+  pathParts.push(cargoProfileDir(profile));
+
+  return path.join(...pathParts);
 }
 
 function ensureTargetServerBinary(
@@ -101,7 +124,8 @@ function ensureTargetServerBinary(
 ): string {
   const serverOutDir = path.join(vscodeDir, 'server', target);
   const hostTarget = hostPlatformFolder();
-  if (target !== hostTarget) {
+  const cargoTarget = cargoTargets[target];
+  if (target !== hostTarget && !cargoTarget) {
     const serverPath = path.join(serverOutDir, binFile);
     if (!fs.existsSync(serverPath)) {
       throw new Error(
@@ -113,9 +137,13 @@ function ensureTargetServerBinary(
     return serverPath;
   }
 
-  run('cargo', cargoBuildArgs(profile), repoRoot);
+  if (cargoTarget) {
+    run('rustup', ['target', 'add', cargoTarget], repoRoot);
+  }
 
-  const sourcePath = path.join(repoRoot, 'target', cargoProfileDir(profile), binFile);
+  run('cargo', cargoBuildArgs(profile, cargoTarget), repoRoot);
+
+  const sourcePath = path.join(cargoOutputDir(profile, cargoTarget), binFile);
   const destPath = path.join(serverOutDir, binFile);
   fs.mkdirSync(serverOutDir, { recursive: true });
   fs.copyFileSync(sourcePath, destPath);

--- a/editors/vscode/src/platform.ts
+++ b/editors/vscode/src/platform.ts
@@ -1,6 +1,8 @@
 import * as path from 'node:path';
 
 export const SUPPORTED_PLATFORM_FOLDERS = [
+  'alpine-arm64',
+  'alpine-x64',
   'darwin-arm64',
   'darwin-x64',
   'linux-arm64',

--- a/editors/vscode/test/platform.test.ts
+++ b/editors/vscode/test/platform.test.ts
@@ -11,6 +11,8 @@ import {
 } from '../src/platform';
 
 test('maps supported Node platform and architecture pairs to VS Code target folders', () => {
+  assert.equal(getPlatformFolder('alpine', 'arm64'), 'alpine-arm64');
+  assert.equal(getPlatformFolder('alpine', 'x64'), 'alpine-x64');
   assert.equal(getPlatformFolder('darwin', 'arm64'), 'darwin-arm64');
   assert.equal(getPlatformFolder('darwin', 'x64'), 'darwin-x64');
   assert.equal(getPlatformFolder('linux', 'arm64'), 'linux-arm64');
@@ -25,6 +27,8 @@ test('rejects unsupported platform and architecture pairs', () => {
 });
 
 test('checks package targets with a type guard', () => {
+  assert.equal(isPlatformFolder('alpine-arm64'), true);
+  assert.equal(isPlatformFolder('alpine-x64'), true);
   assert.equal(isPlatformFolder('linux-x64'), true);
   assert.equal(isPlatformFolder('linux-riscv64'), false);
 });


### PR DESCRIPTION
Closes https://github.com/pascal-lab/vizsla/issues/28.

This PR pin the `linux-x64` VSIX build runner to `ubuntu-22.04` to avoid depending on newer glibc/libstdc++ symbols from `ubuntu-latest`, and add `alpine-x64` and `alpine-arm64` VSIX package targets.