### PR TITLE
fix(syntax): avoid cwd includes for pathless parses

### DIFF
--- a/crates/base-db/src/source_db.rs
+++ b/crates/base-db/src/source_db.rs
@@ -84,7 +84,9 @@ fn parse_src(db: &dyn SourceDb, file_id: FileId) -> SyntaxTree {
 
     match db.file_kind(file_id) {
         SourceFileKind::SystemVerilog | SourceFileKind::IncludeHeader => {
-            SyntaxTree::from_text(&text, "", "")
+            // HIR source maps are local to the queried file; project-aware include
+            // expansion belongs to parse_src_for_compilation.
+            SyntaxTree::from_text_no_include_expansion(&text, "", "")
         }
         SourceFileKind::LibraryMap => SyntaxTree::from_library_map_text(&text, "", ""),
         SourceFileKind::ProjectManifest => SyntaxTree::from_text("", "", ""),

--- a/crates/syntax/src/ptr.rs
+++ b/crates/syntax/src/ptr.rs
@@ -100,3 +100,38 @@ impl SyntaxElementPtr {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use slang::ast::{self, AstNode};
+
+    use crate::has_text_range::HasTextRange;
+
+    #[test]
+    fn no_include_expansion_parse_does_not_expand_cwd_includes() {
+        let include_rel = "target/vizsla_pathless_include_test_defs.svh";
+        std::fs::create_dir_all("target").expect("target directory");
+        std::fs::write(include_rel, "typedef logic cwd_include_t;\n").expect("include fixture");
+
+        let text = format!("`include \"{include_rel}\"\nmodule top;\nendmodule\n");
+        let tree = slang::SyntaxTree::from_text_no_include_expansion(&text, "", "");
+        let root = tree.root().expect("root syntax node");
+        let unit = ast::CompilationUnit::cast(root).expect("compilation unit");
+        let mut saw_root_module = false;
+
+        for member in unit.members().children() {
+            match member {
+                ast::Member::TypedefDeclaration(_) => {
+                    panic!("parse with include expansion disabled must not read includes");
+                }
+                ast::Member::ModuleDeclaration(module) => {
+                    saw_root_module = true;
+                    assert!(module.syntax().text_range().is_some());
+                }
+                _ => {}
+            }
+        }
+
+        assert!(saw_root_module);
+    }
+}


### PR DESCRIPTION
Closes https://github.com/pascal-lab/vizsla/issues/34, https://github.com/pascal-lab/vizsla/issues/43.

Pathless parses are intended for local syntax/HIR analysis of the current buffer, but slang could resolve `include` files relative to the process cwd. That injected include-buffer syntax into the tree, producing nodes without current-file ranges and later panicking in syntax pointer creation.
