### PR TITLE
fix(syntax): keep HIR parses single-file

### DIFF
--- a/crates/base-db/src/compilation_plan.rs
+++ b/crates/base-db/src/compilation_plan.rs
@@ -74,9 +74,11 @@ fn include_buffers_for_plan_with_roots(
     plan: &CompilationPlan,
     include_roots: bool,
 ) -> Vec<SyntaxTreeBuffer> {
-    let root_files = include_roots
-        .then(|| plan.roots.iter().copied().collect::<FxHashSet<_>>())
-        .unwrap_or_default();
+    let root_files = if include_roots {
+        plan.roots.iter().copied().collect::<FxHashSet<_>>()
+    } else {
+        FxHashSet::default()
+    };
     let mut seen_files = PathIdentitySet::default();
     let mut seen_buffer_paths = FxHashSet::default();
     let mut buffers = Vec::new();

--- a/crates/base-db/src/compilation_plan.rs
+++ b/crates/base-db/src/compilation_plan.rs
@@ -1,7 +1,7 @@
 use rustc_hash::FxHashSet;
 use syntax::SyntaxTreeBuffer;
 use utils::{
-    path_identity::{PathIdentityIndex, PathIdentitySet, path_alias_paths},
+    path_identity::{PathIdentityIndex, PathIdentitySet},
     paths::{AbsPathBuf, Utf8Path},
 };
 use vfs::FileId;
@@ -59,6 +59,24 @@ pub fn include_buffers_for_plan(
     db: &dyn SourceRootDb,
     plan: &CompilationPlan,
 ) -> Vec<SyntaxTreeBuffer> {
+    include_buffers_for_plan_with_roots(db, plan, false)
+}
+
+pub fn compilation_source_buffers_for_plan(
+    db: &dyn SourceRootDb,
+    plan: &CompilationPlan,
+) -> Vec<SyntaxTreeBuffer> {
+    include_buffers_for_plan_with_roots(db, plan, true)
+}
+
+fn include_buffers_for_plan_with_roots(
+    db: &dyn SourceRootDb,
+    plan: &CompilationPlan,
+    include_roots: bool,
+) -> Vec<SyntaxTreeBuffer> {
+    let root_files = include_roots
+        .then(|| plan.roots.iter().copied().collect::<FxHashSet<_>>())
+        .unwrap_or_default();
     let mut seen_files = PathIdentitySet::default();
     let mut seen_buffer_paths = FxHashSet::default();
     let mut buffers = Vec::new();
@@ -73,7 +91,12 @@ pub fn include_buffers_for_plan(
                 && db.file_path(file_id).is_some_and(|path| {
                     plan.include_dirs.iter().any(|include_dir| path.starts_with(include_dir))
                 });
-        if !include_header_in_include_path && !plan.include_only.contains(&file_id) {
+        let semantic_root = root_files.contains(&file_id)
+            && matches!(db.file_kind(file_id), SourceFileKind::SystemVerilog);
+        if !semantic_root
+            && !include_header_in_include_path
+            && !plan.include_only.contains(&file_id)
+        {
             continue;
         }
 
@@ -85,12 +108,9 @@ pub fn include_buffers_for_plan(
             continue;
         }
 
-        let text = db.file_text(file_id).to_string();
-        for alias_path in path_alias_paths(&path) {
-            let path = alias_path.to_string();
-            if seen_buffer_paths.insert(path.clone()) {
-                buffers.push(SyntaxTreeBuffer { path, text: text.clone() });
-            }
+        let path = path.to_string();
+        if seen_buffer_paths.insert(path.clone()) {
+            buffers.push(SyntaxTreeBuffer { path, text: db.file_text(file_id).to_string() });
         }
     }
 

--- a/crates/base-db/src/source_db.rs
+++ b/crates/base-db/src/source_db.rs
@@ -86,7 +86,12 @@ fn parse_src(db: &dyn SourceDb, file_id: FileId) -> SyntaxTree {
         SourceFileKind::SystemVerilog | SourceFileKind::IncludeHeader => {
             // HIR source maps are local to the queried file; project-aware include
             // expansion belongs to parse_src_for_compilation.
-            SyntaxTree::from_text_no_include_expansion(&text, "", "")
+            SyntaxTree::from_text_with_options(
+                &text,
+                "",
+                "",
+                &syntax::SyntaxTreeOptions::without_include_expansion(),
+            )
         }
         SourceFileKind::LibraryMap => SyntaxTree::from_library_map_text(&text, "", ""),
         SourceFileKind::ProjectManifest => SyntaxTree::from_text("", "", ""),
@@ -148,10 +153,23 @@ fn syntax_tree_options_for_file(
 ) -> syntax::SyntaxTreeOptions {
     let project_config = db.project_config();
     let profile_id = db.file_compilation_profile(file_id);
+    let include_buffers = db.include_buffers_for_profile(profile_id).as_ref().clone();
+    syntax_tree_options_for_profile(&project_config, profile_id, include_buffers)
+}
+
+fn syntax_tree_options_for_profile(
+    project_config: &ProjectConfig,
+    profile_id: Option<CompilationProfileId>,
+    include_buffers: Vec<SyntaxTreeBuffer>,
+) -> syntax::SyntaxTreeOptions {
     let preprocess = project_config.preprocess_for_profile(profile_id);
     let include_paths = preprocess.include_dir_strings();
-    let include_buffers = db.include_buffers_for_profile(profile_id).as_ref().clone();
-    syntax::SyntaxTreeOptions { predefines: preprocess.predefines, include_paths, include_buffers }
+    syntax::SyntaxTreeOptions {
+        predefines: preprocess.predefines,
+        include_paths,
+        include_buffers,
+        ..syntax::SyntaxTreeOptions::default()
+    }
 }
 
 fn parse_src_for_compilation(db: &dyn SourceRootDb, file_id: FileId) -> SyntaxTree {
@@ -320,6 +338,12 @@ fn source_root_semantic_diagnostics(
     }
 
     let plan = db.compilation_plan_for_root(source_root_id);
+    let compilation_include_buffers =
+        compilation_plan::compilation_source_buffers_for_plan(db, &plan);
+    let project_config = db.project_config();
+    let profile_id = project_config.profile_for_root(source_root_id);
+    let compilation_options =
+        syntax_tree_options_for_profile(&project_config, profile_id, compilation_include_buffers);
     let mut compilation = Compilation::new_with_top_modules(&plan.top_modules);
     let mut buffer_file_ids = FxHashMap::default();
     let path_file_ids = path_file_ids(db);
@@ -327,15 +351,12 @@ fn source_root_semantic_diagnostics(
         let text = db.file_text(file_id);
         let identity = source_file_identity(db, file_id);
         let buffer_ids = match db.file_kind(file_id) {
-            SourceFileKind::SystemVerilog => {
-                let options = syntax_tree_options_for_file(db, file_id);
-                compilation.add_syntax_tree_from_text(
-                    &text,
-                    &identity.name,
-                    &identity.path,
-                    &options,
-                )
-            }
+            SourceFileKind::SystemVerilog => compilation.add_syntax_tree_from_text(
+                &text,
+                &identity.name,
+                &identity.path,
+                &compilation_options,
+            ),
             SourceFileKind::LibraryMap => compilation.add_library_map_syntax_tree_from_text(
                 &text,
                 &identity.name,

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -342,4 +342,42 @@ mod tests {
             "transitively included .sv should use VFS text: {diagnostics:?}"
         );
     }
+
+    #[test]
+    fn semantic_compilation_preloads_root_source_buffers() {
+        let dir = TestDir::new("diagnostics-preloaded-roots");
+        let root = dir.path().to_path_buf();
+        let a_path = root.join("a.sv");
+        let b_path = root.join("b.sv");
+        let a_text = "module a; endmodule\n";
+        let b_text = "module b; endmodule\n";
+        std::fs::write(&a_path, a_text).unwrap();
+        std::fs::write(&b_path, b_text).unwrap();
+
+        let mut db = RootDb::new(None);
+        let mut file_set = FileSet::default();
+        file_set.insert(FileId(0), VfsPath::from(a_path.clone()));
+        file_set.insert(FileId(1), VfsPath::from(b_path.clone()));
+
+        let mut change = Change::new();
+        change.add_changed_file(ChangedFile {
+            file_id: FileId(0),
+            change_kind: ChangeKind::Create(Arc::from(a_text), LineEnding::Unix),
+        });
+        change.add_changed_file(ChangedFile {
+            file_id: FileId(1),
+            change_kind: ChangeKind::Create(Arc::from(b_text), LineEnding::Unix),
+        });
+        change.set_roots(vec![SourceRoot::new_local(file_set)]);
+        db.apply_change(change);
+
+        let plan = db.compilation_plan_for_root(SourceRootId(0));
+        assert_eq!(plan.roots, vec![FileId(0), FileId(1)]);
+        let buffers = base_db::compilation_plan::compilation_source_buffers_for_plan(&db, &plan);
+        let buffer_paths = buffers.iter().map(|buffer| buffer.path.as_str()).collect::<Vec<_>>();
+        let a_path = a_path.to_string();
+        let b_path = b_path.to_string();
+        assert!(buffer_paths.contains(&a_path.as_str()));
+        assert!(buffer_paths.contains(&b_path.as_str()));
+    }
 }

--- a/crates/syntax/src/ptr.rs
+++ b/crates/syntax/src/ptr.rs
@@ -114,7 +114,12 @@ mod tests {
         std::fs::write(include_rel, "typedef logic cwd_include_t;\n").expect("include fixture");
 
         let text = format!("`include \"{include_rel}\"\nmodule top;\nendmodule\n");
-        let tree = slang::SyntaxTree::from_text_no_include_expansion(&text, "", "");
+        let tree = slang::SyntaxTree::from_text_with_options(
+            &text,
+            "",
+            "",
+            &slang::SyntaxTreeOptions::without_include_expansion(),
+        );
         let root = tree.root().expect("root syntax node");
         let unit = ast::CompilationUnit::cast(root).expect("compilation unit");
         let mut saw_root_module = false;

--- a/crates/syntax/src/slang_ext.rs
+++ b/crates/syntax/src/slang_ext.rs
@@ -514,8 +514,7 @@ endmodule
 "#;
         let options = SyntaxTreeOptions {
             predefines: vec![String::from("CA_WIDTH=8")],
-            include_paths: Vec::new(),
-            include_buffers: Vec::new(),
+            ..SyntaxTreeOptions::default()
         };
         let tree = SyntaxTree::from_text_with_options(
             text,


### PR DESCRIPTION
Closes https://github.com/pascal-lab/vizsla/issues/34.

I can no longer reproduce the panic locally after #44 and #46. There is still a significant performance concern around diagnostics, so I can't tell that the experience is fully resolved yet. 

If the panic shows up again, we can reopen the issue or track it with a new repro.