### PR TITLE
fix(completion): suggest system tasks and functions after $

### DIFF
--- a/crates/ide/src/completion/context.rs
+++ b/crates/ide/src/completion/context.rs
@@ -37,6 +37,7 @@ pub enum TriggerChar {
     Comma,
     At,
     Hash,
+    Dollar,
     Backtick,
     Apostrophe,
     Newline,
@@ -118,12 +119,14 @@ pub(crate) fn completion_context(
     let parser_expected_syntax = db.parser_expected_syntax(file_id, offset);
     let directive_word = directive_word_at_offset(&text, offset);
     let token_word = library_map_word_at_offset(root, &text, offset);
+    let system_word = standalone_system_identifier_word_at_offset(&text, offset);
     detect_completion_context_impl(
         root,
         offset,
         trigger,
         directive_word,
         token_word,
+        system_word,
         Some(&parser_expected_syntax),
     )
 }
@@ -133,7 +136,7 @@ pub fn detect_completion_context(
     offset: TextSize,
     trigger: Option<TriggerChar>,
 ) -> CompletionContext {
-    detect_completion_context_impl(root, offset, trigger, None, None, None)
+    detect_completion_context_impl(root, offset, trigger, None, None, None, None)
 }
 
 pub fn detect_completion_context_with_source_text(
@@ -145,12 +148,14 @@ pub fn detect_completion_context_with_source_text(
     let parser_expected_syntax = parser_expected_syntax_for_text(root, source_text, offset);
     let directive_word = directive_word_at_offset(source_text, offset);
     let token_word = library_map_word_at_offset(root, source_text, offset);
+    let system_word = standalone_system_identifier_word_at_offset(source_text, offset);
     detect_completion_context_impl(
         root,
         offset,
         trigger,
         directive_word,
         token_word,
+        system_word,
         Some(&parser_expected_syntax),
     )
 }
@@ -161,6 +166,7 @@ fn detect_completion_context_impl(
     trigger: Option<TriggerChar>,
     directive_word: Option<CompletionWord>,
     token_word: Option<CompletionWord>,
+    system_word: Option<CompletionWord>,
     parser_expected_syntax: Option<&[ParserExpectedSyntax]>,
 ) -> CompletionContext {
     let caret = CaretSnapshot::new(root, offset);
@@ -214,6 +220,13 @@ fn detect_completion_context_impl(
 
     if prefix.is_empty()
         && let Some(word) = token_word.filter(|word| !word.prefix.is_empty())
+    {
+        replacement = word.replacement;
+        prefix = word.prefix;
+    }
+
+    if prefix.is_empty()
+        && let Some(word) = system_word
     {
         replacement = word.replacement;
         prefix = word.prefix;
@@ -277,6 +290,26 @@ fn library_map_word_at_offset(
             TextSize::from(word.replacement.end as u32),
         ),
         prefix: word.prefix,
+    })
+}
+
+fn standalone_system_identifier_word_at_offset(
+    source_text: &str,
+    offset: TextSize,
+) -> Option<CompletionWord> {
+    let offset = usize::from(offset);
+    if offset == 0 || offset > source_text.len() || !source_text.is_char_boundary(offset) {
+        return None;
+    }
+
+    let start = offset - 1;
+    if source_text.as_bytes().get(start) != Some(&b'$') {
+        return None;
+    }
+
+    Some(CompletionWord {
+        replacement: TextRange::new(TextSize::from(start as u32), TextSize::from(offset as u32)),
+        prefix: "$".to_owned(),
     })
 }
 
@@ -422,6 +455,17 @@ mod tests {
     fn detects_string_literal() {
         let c = ctx("module m; initial $display(\"he/*caret*/llo\"); endmodule\n");
         assert_eq!(c.lex, LexContext::Literal);
+    }
+
+    #[test]
+    fn detects_standalone_dollar_as_system_identifier_prefix() {
+        let text = "module m; initial begin $/*caret*/ end endmodule\n";
+        let dollar = TextSize::from(text.find('$').unwrap() as u32);
+        let c = ctx(text);
+
+        assert_eq!(c.lex, LexContext::Code);
+        assert_eq!(c.prefix, "$");
+        assert_eq!(c.replacement, TextRange::new(dollar, dollar + TextSize::from(1)));
     }
 
     #[test]

--- a/crates/ide/src/completion/engine/tests.rs
+++ b/crates/ide/src/completion/engine/tests.rs
@@ -74,6 +74,7 @@ fn parse_trigger(line: &str) -> Option<TriggerChar> {
         "," => Some(TriggerChar::Comma),
         "@" => Some(TriggerChar::At),
         "#" => Some(TriggerChar::Hash),
+        "$" => Some(TriggerChar::Dollar),
         "`" => Some(TriggerChar::Backtick),
         "'" => Some(TriggerChar::Apostrophe),
         "\\n" => Some(TriggerChar::Newline),
@@ -115,6 +116,13 @@ fn no_completion_in_line_comment_with_comma_trigger() {
     // regression: comma trigger in line comment should not trigger completion
     let items =
         completions_in_text("// ,,/*caret*/\nmodule m; endmodule\n", Some(TriggerChar::Comma));
+    assert!(items.is_empty());
+}
+
+#[test]
+fn no_completion_in_line_comment_with_dollar_trigger() {
+    let items =
+        completions_in_text("// $/*caret*/\nmodule m; endmodule\n", Some(TriggerChar::Dollar));
     assert!(items.is_empty());
 }
 
@@ -378,6 +386,28 @@ fn statement_completion_uses_slang_system_task_facts() {
         !item_labels.contains(&"$clog2"),
         "system function leaked into statement task completion: {items:?}"
     );
+}
+
+#[test]
+fn standalone_dollar_completion_suggests_system_tasks_and_functions() {
+    let items = completions_in_text("module m; initial begin\n  $/*caret*/\nend endmodule\n", None);
+    let item_labels = labels(&items);
+
+    assert!(item_labels.contains(&"$display"), "system task expected: {items:?}");
+    assert!(item_labels.contains(&"$finish"), "system task expected: {items:?}");
+    assert!(item_labels.contains(&"$time"), "system function expected: {items:?}");
+}
+
+#[test]
+fn dollar_trigger_suggests_system_tasks_and_functions() {
+    let items = completions_in_text(
+        "module m; initial begin\n  $/*caret*/\nend endmodule\n",
+        Some(TriggerChar::Dollar),
+    );
+    let item_labels = labels(&items);
+
+    assert!(item_labels.contains(&"$display"), "system task expected: {items:?}");
+    assert!(item_labels.contains(&"$time"), "system function expected: {items:?}");
 }
 
 #[test]

--- a/src/config/caps.rs
+++ b/src/config/caps.rs
@@ -247,6 +247,7 @@ impl Config {
                     ",".into(),
                     "@".into(),
                     "#".into(),
+                    "$".into(),
                     "`".into(),
                     "'".into(),
                     "\n".into(),

--- a/src/global_state/handlers/request.rs
+++ b/src/global_state/handlers/request.rs
@@ -52,6 +52,7 @@ pub(crate) fn handle_completion(
             ',' => Some(TriggerChar::Comma),
             '@' => Some(TriggerChar::At),
             '#' => Some(TriggerChar::Hash),
+            '$' => Some(TriggerChar::Dollar),
             '`' => Some(TriggerChar::Backtick),
             '\'' => Some(TriggerChar::Apostrophe),
             '\n' | '\r' => Some(TriggerChar::Newline),


### PR DESCRIPTION
## Summary

Fixes system task/function completion after a standalone `$`.

Previously, system completions worked for typed prefixes like `$di`, but a bare `$` produced an empty completion prefix, so `$display`, `$finish`, `$time`, etc. were filtered out.

## Changes

- Treat a standalone `$` before the cursor as completion prefix `$`.
- Register `$` as an LSP completion trigger character.
- Map `$` trigger characters to `TriggerChar::Dollar`.
- Add regression tests for manual completion, `$` trigger completion, and no completion inside line comments.

## Tests

- `cargo test -p ide completion:: -- --nocapture`
- `cargo test -p vizsla`

Closes #56