### PR TITLE
feat(completion): add parameterized module declaration snippet

### DIFF
--- a/crates/ide/src/completion/engine/snippets.toml
+++ b/crates/ide/src/completion/engine/snippets.toml
@@ -1,5 +1,6 @@
 [top_level]
 module = "module ${1:name} (${2:ports});\n\t${0}\nendmodule"
+"module #(...)" = { plain = "module", snippet = "module ${1:name} #(\n\tparameter ${2:PARAM} = ${3:VALUE}\n) (${4:ports});\n\t${0}\nendmodule" }
 primitive = "primitive ${1:name} (${2:ports});\n\t${0}\nendprimitive"
 macromodule = "macromodule ${1:name} (${2:ports});\n\t${0}\nendmodule"
 config = "config ${1:name};\n\tdesign ${2:work.top};\nendconfig"


### PR DESCRIPTION
## Summary

Adds a top-level module declaration completion snippet with a parameter port list.

This covers declaring parameterized modules from completion, for example expanding `module #(...)` into a module skeleton that includes `#(...)` before the port list.

## Changes

- Add a `module #(...)` top-level completion snippet.
- Keep the snippet gated by the existing `module` keyword completion context via `plain = "module"`.

## Tests

- `cargo test -p ide snippets::tests -- --nocapture`

Closes #57