### PR TITLE
fix(diagnostics): refresh workspace diagnostics after manifest reload

### DIFF
--- a/src/global_state/process_changes.rs
+++ b/src/global_state/process_changes.rs
@@ -79,6 +79,14 @@ impl GlobalState {
     }
 
     pub(crate) fn invalidate_diagnostics(&mut self, invalidation: DiagnosticInvalidation) {
+        if matches!(invalidation, DiagnosticInvalidation::WorkspaceChanged)
+            && self.config.cli_pull_diagnostics_support()
+            && self.config.cli_workspace_diagnostic_refresh_support()
+        {
+            self.send_request::<WorkspaceDiagnosticRefresh>((), DEFAULT_REQ_HANDLER);
+            return;
+        }
+
         let file_ids = match invalidation {
             DiagnosticInvalidation::FileChanges(file_ids) => {
                 if self.config.diagnostics_config().semantic.enabled {


### PR DESCRIPTION
## Summary

Refreshes pull diagnostics after project manifest reloads.

Changing `vizsla_config.toml` already triggers workspace reload, but pull-diagnostics clients may keep showing stale workspace diagnostics until another source file changes. This sends `workspace/diagnostic/refresh` for workspace-level diagnostic invalidation when the client supports it.

## Changes

- Send `workspace/diagnostic/refresh` on `WorkspaceChanged` diagnostic invalidation for pull-diagnostics clients.
- Keep existing push diagnostics behavior unchanged for clients that do not use pull diagnostics.

## Tests

- `cargo test -p vizsla`

Closes #38
