### PR TITLE
feat(docs): support Cloudflare Pages previews

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,9 +1,13 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 
+const isCloudflarePages = process.env.CF_PAGES === '1';
+const site = process.env.ASTRO_SITE ?? process.env.CF_PAGES_URL ?? 'https://pascal-lab.github.io';
+const base = process.env.ASTRO_BASE ?? (isCloudflarePages ? '/' : '/vizsla');
+
 export default defineConfig({
-  site: 'https://pascal-lab.github.io',
-  base: '/vizsla',
+  site,
+  base,
   integrations: [
     starlight({
       title: 'Vizsla 用户手册',


### PR DESCRIPTION
## Summary

- Make the Astro docs config adapt to Cloudflare Pages preview deployments.
- Keep the existing GitHub Pages default base path at `/vizsla`.
- Allow `ASTRO_SITE` and `ASTRO_BASE` to override generated site/base values when needed.

## Validation

- `npm run build` in `docs`
- `git diff --check`