### PR TITLE
ci: avoid duplicate PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: [master]
   pull_request:
     types: [opened, synchronize, reopened]
     branches: ["**"]


### PR DESCRIPTION
## Summary

- Limit the CI workflow push trigger to master.
- Keep pull_request and manual workflow_dispatch triggers unchanged.

## Motivation

Feature branches with an open PR currently run the same CI workflow twice: once for the branch push and once for the PR synchronization event. Restricting push to master leaves PR validation covered by pull_request while avoiding duplicate checks on PR branches.

## Validation

- git diff --check