### PR TITLE
refactor(config): decouple manifest path selection

### DIFF
--- a/crates/base-db/src/source_root.rs
+++ b/crates/base-db/src/source_root.rs
@@ -1,4 +1,3 @@
-use utils::paths::AbsPathBuf;
 use vfs::{FileId, FileSet, FileSetConfig, Vfs, VfsPath, anchored_path::AnchoredPath};
 
 use crate::source_db::SourceFileKind;
@@ -16,35 +15,32 @@ pub enum SourceRootRole {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SourceRoot {
     role: SourceRootRole,
-    source_paths: Option<Vec<AbsPathBuf>>,
+    source_files: Option<Vec<FileId>>,
     file_set: FileSet,
 }
 
 impl SourceRoot {
     pub fn new_local(file_set: FileSet) -> SourceRoot {
-        SourceRoot { role: SourceRootRole::Local, source_paths: None, file_set }
+        SourceRoot { role: SourceRootRole::Local, source_files: None, file_set }
     }
 
     pub fn new_library(file_set: FileSet) -> SourceRoot {
-        SourceRoot { role: SourceRootRole::Library, source_paths: None, file_set }
+        SourceRoot { role: SourceRootRole::Library, source_files: None, file_set }
     }
 
     pub fn new_ignored(file_set: FileSet) -> SourceRoot {
-        SourceRoot { role: SourceRootRole::Ignored, source_paths: None, file_set }
+        SourceRoot { role: SourceRootRole::Ignored, source_files: None, file_set }
     }
 
-    pub fn new_local_with_source_paths(
-        file_set: FileSet,
-        source_paths: Vec<AbsPathBuf>,
-    ) -> SourceRoot {
-        SourceRoot { role: SourceRootRole::Local, source_paths: Some(source_paths), file_set }
+    pub fn new_local_with_source_files(file_set: FileSet, source_files: Vec<FileId>) -> SourceRoot {
+        SourceRoot { role: SourceRootRole::Local, source_files: Some(source_files), file_set }
     }
 
-    pub fn new_library_with_source_paths(
+    pub fn new_library_with_source_files(
         file_set: FileSet,
-        source_paths: Vec<AbsPathBuf>,
+        source_files: Vec<FileId>,
     ) -> SourceRoot {
-        SourceRoot { role: SourceRootRole::Library, source_paths: Some(source_paths), file_set }
+        SourceRoot { role: SourceRootRole::Library, source_files: Some(source_files), file_set }
     }
 
     pub fn role(&self) -> SourceRootRole {
@@ -79,16 +75,11 @@ impl SourceRoot {
         let Some(path) = self.path_for_file(file) else {
             return SourceFileKind::default();
         };
-        let Some(abs_path) = path.as_abs_path() else {
-            return SourceFileKind::from_path(path);
-        };
         let kind = SourceFileKind::from_path(path);
-        let Some(source_paths) = &self.source_paths else {
+        let Some(source_files) = &self.source_files else {
             return kind;
         };
-        if matches!(kind, SourceFileKind::LibraryMap)
-            || source_paths.iter().any(|source_path| abs_path.starts_with(source_path))
-        {
+        if matches!(kind, SourceFileKind::LibraryMap) || source_files.contains(file) {
             kind
         } else {
             SourceFileKind::IncludeHeader
@@ -101,27 +92,28 @@ pub struct SourceRootConfig {
     pub fileset_config: FileSetConfig,
     pub local_filesets: Vec<usize>,
     pub ignored_filesets: Vec<usize>,
-    pub source_paths_by_fileset: Vec<Vec<AbsPathBuf>>,
 }
 
 impl SourceRootConfig {
     pub fn partition(&self, vfs: &Vfs) -> Vec<SourceRoot> {
         self.fileset_config
-            .partition(vfs)
+            .partition_with_source(vfs)
             .into_iter()
             .enumerate()
-            .map(|(idx, file_set)| {
-                let source_paths = self.source_paths_by_fileset.get(idx).cloned();
+            .map(|(idx, partition)| {
+                let file_set = partition.file_set;
+                let source_files =
+                    partition.source_files.map(|source_files| source_files.into_iter().collect());
                 if self.ignored_filesets.contains(&idx) {
                     return SourceRoot::new_ignored(file_set);
                 }
-                match (self.local_filesets.contains(&idx), source_paths) {
-                    (true, Some(source_paths)) => {
-                        SourceRoot::new_local_with_source_paths(file_set, source_paths)
+                match (self.local_filesets.contains(&idx), source_files) {
+                    (true, Some(source_files)) => {
+                        SourceRoot::new_local_with_source_files(file_set, source_files)
                     }
                     (true, None) => SourceRoot::new_local(file_set),
-                    (false, Some(source_paths)) => {
-                        SourceRoot::new_library_with_source_paths(file_set, source_paths)
+                    (false, Some(source_files)) => {
+                        SourceRoot::new_library_with_source_files(file_set, source_files)
                     }
                     (false, None) => SourceRoot::new_library(file_set),
                 }
@@ -142,7 +134,6 @@ mod tests {
             fileset_config: builder.build(),
             local_filesets: Vec::new(),
             ignored_filesets: vec![1],
-            source_paths_by_fileset: Vec::new(),
         };
         let roots = config.partition(&Vfs::default());
 

--- a/crates/project-model/src/lib.rs
+++ b/crates/project-model/src/lib.rs
@@ -18,12 +18,24 @@ pub use toml_workspace::{
 };
 use triomphe::Arc;
 use utils::paths::{AbsPathBuf, sort_and_remove_subfolders};
-use vfs::{FileSetConfig, VfsPath};
+use vfs::{FileSetConfig, FileSetFilter, PathSelection, VfsPath};
 
-use crate::{project_manifest::ProjectManifest, toml_workspace::TomlWorkspace};
+use crate::{
+    macro_def::MacroDef, project_manifest::ProjectManifest, toml_workspace::TomlWorkspace,
+};
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct Workspace(pub TomlWorkspace);
+pub struct Workspace {
+    top_modules: Vec<String>,
+    workspace_root: AbsPathBuf,
+    macro_defs: MacroDef,
+    source: PathSelection,
+    include_dirs: Vec<AbsPathBuf>,
+    exclude: Vec<AbsPathBuf>,
+    library_paths: Vec<AbsPathBuf>,
+    is_lib: bool,
+    configures_semantic_diagnostics: bool,
+}
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ProjectModel {
@@ -33,15 +45,15 @@ pub struct ProjectModel {
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct WorkspaceRoot {
     pub is_lib: bool,
-    pub sources: Vec<AbsPathBuf>,
+    pub source: PathSelection,
     pub include_dirs: Vec<AbsPathBuf>,
     pub exclude: Vec<AbsPathBuf>,
 }
 
 impl WorkspaceRoot {
     pub fn load_paths(&self) -> Vec<AbsPathBuf> {
-        let mut paths = self.sources.clone();
-        paths.extend(self.include_dirs.iter().cloned());
+        let mut paths = self.include_dirs.clone();
+        paths.extend(self.source.roots.iter().cloned());
         sort_and_remove_subfolders(&mut paths);
         paths
     }
@@ -56,49 +68,133 @@ impl Workspace {
     fn load_helper(manifest: &ProjectManifest, is_lib: bool) -> anyhow::Result<Workspace> {
         match manifest {
             ProjectManifest::Toml(toml) => {
-                let toml_workspaces = TomlWorkspace::load_from_file(toml, is_lib)
+                let toml_workspace = TomlWorkspace::load_from_file(toml)
                     .with_context(|| "failed to load workspace in {manifest:?}")?;
 
-                Ok(Self(toml_workspaces))
+                Self::from_toml(toml_workspace, is_lib)
             }
             ProjectManifest::UnconfiguredRoot(path) => {
-                Ok(Self(TomlWorkspace::from_unconfigured_root(path, is_lib)))
+                Ok(Self::from_unconfigured_root(path, is_lib))
             }
+        }
+    }
+
+    fn from_toml(toml: TomlWorkspace, is_lib: bool) -> anyhow::Result<Self> {
+        let TomlWorkspace {
+            top_modules,
+            workspace_root,
+            macro_defs,
+            sources,
+            include_dirs,
+            libraries,
+            mut exclude,
+        } = toml;
+
+        sort_and_remove_subfolders(&mut exclude);
+        let mut source_paths = Vec::new();
+        let mut library_paths = libraries;
+        for path in sources {
+            if is_excluded(&path, &exclude) {
+                continue;
+            }
+            if path.starts_with(&workspace_root) {
+                source_paths.push(path);
+            } else {
+                library_paths.push(path);
+            }
+        }
+        sort_and_remove_subfolders(&mut source_paths);
+
+        let include_dirs = resolve_include_dirs(include_dirs, &source_paths, &exclude);
+        let library_paths = resolve_library_paths(library_paths, &exclude);
+        let configures_semantic_diagnostics = !source_paths.is_empty() || !include_dirs.is_empty();
+        let source = PathSelection::all(source_paths);
+
+        Ok(Self {
+            top_modules,
+            workspace_root,
+            macro_defs,
+            source,
+            include_dirs,
+            exclude,
+            library_paths,
+            is_lib,
+            configures_semantic_diagnostics,
+        })
+    }
+
+    fn from_unconfigured_root(path: &AbsPathBuf, is_lib: bool) -> Self {
+        let source_roots = if is_lib { vec![path.clone()] } else { Vec::new() };
+        let include_dirs = source_roots.clone();
+        Self {
+            top_modules: Vec::new(),
+            workspace_root: path.clone(),
+            macro_defs: MacroDef::default(),
+            source: PathSelection::all(source_roots),
+            include_dirs,
+            exclude: Vec::new(),
+            library_paths: Vec::new(),
+            is_lib,
+            configures_semantic_diagnostics: false,
         }
     }
 
     pub fn to_roots(&self) -> Vec<WorkspaceRoot> {
-        let Workspace(TomlWorkspace { sources, include_dirs, exclude, is_lib, .. }) = self;
         vec![WorkspaceRoot {
-            is_lib: *is_lib,
-            sources: sources.to_vec(),
-            include_dirs: include_dirs.to_vec(),
-            exclude: exclude.to_vec(),
+            is_lib: self.is_lib,
+            source: self.source.clone(),
+            include_dirs: self.include_dirs.clone(),
+            exclude: self.exclude.clone(),
         }]
     }
 
     fn top_modules(&self) -> Vec<String> {
-        self.0.top_modules.clone()
+        self.top_modules.clone()
     }
 
     fn root(&self) -> &AbsPathBuf {
-        &self.0.workspace_root
+        &self.workspace_root
     }
 
     fn library_paths(&self) -> &[AbsPathBuf] {
-        &self.0.package
+        &self.library_paths
     }
 
     fn enables_semantic_diagnostics(&self) -> bool {
-        self.0.configures_semantic_diagnostics || self.0.is_lib
+        self.configures_semantic_diagnostics || self.is_lib
+    }
+
+    pub fn is_lib(&self) -> bool {
+        self.is_lib
     }
 
     fn preprocess_config(&self) -> PreprocessConfig {
         PreprocessConfig {
-            predefines: self.0.macro_defs.to_predefine_strings(),
-            include_dirs: self.0.include_dirs.clone(),
+            predefines: self.macro_defs.to_predefine_strings(),
+            include_dirs: self.include_dirs.clone(),
         }
     }
+}
+
+fn resolve_include_dirs(
+    configured: Option<Vec<AbsPathBuf>>,
+    source_paths: &[AbsPathBuf],
+    exclude: &[AbsPathBuf],
+) -> Vec<AbsPathBuf> {
+    let mut include_dirs = configured.unwrap_or_else(|| source_paths.to_vec());
+    include_dirs.retain(|path| !is_excluded(path, exclude));
+    sort_and_remove_subfolders(&mut include_dirs);
+    include_dirs
+}
+
+fn resolve_library_paths(mut paths: Vec<AbsPathBuf>, exclude: &[AbsPathBuf]) -> Vec<AbsPathBuf> {
+    paths.retain(|path| !is_excluded(path, exclude));
+    sort_and_remove_subfolders(&mut paths);
+    paths
+}
+
+fn is_excluded(path: &AbsPathBuf, exclude: &[AbsPathBuf]) -> bool {
+    exclude.iter().any(|excluded| path.starts_with(excluded))
 }
 
 impl ProjectModel {
@@ -122,7 +218,7 @@ impl ProjectModel {
                 }
             };
 
-            for package in &workspace.0.package {
+            for package in workspace.library_paths() {
                 match ProjectManifest::from_path(package) {
                     Ok(manifest) => {
                         if !loaded_manifests.contains(&manifest) {
@@ -149,7 +245,6 @@ pub fn get_workspace_folder(
     let mut fsc = FileSetConfig::builder();
     let mut local_filesets = Vec::new();
     let mut root_workspaces = Vec::new();
-    let mut source_paths_by_fileset = Vec::new();
 
     for (workspace_idx, workspace) in workspaces.iter().enumerate() {
         for root in workspace.to_roots() {
@@ -158,23 +253,28 @@ pub fn get_workspace_folder(
                 continue;
             }
             let root_file_set = load_paths.iter().cloned().map(VfsPath::from).collect_vec();
+            let mut exclude_paths = root.exclude.clone();
+            for excl in global_excludes {
+                if load_paths.iter().any(|incl| incl.starts_with(excl) || excl.starts_with(incl)) {
+                    exclude_paths.push(excl.clone());
+                }
+            }
+            let mut include = Vec::new();
+            if !root.include_dirs.is_empty() {
+                include.push(PathSelection::all(root.include_dirs.clone()));
+            }
+            if !root.source.is_empty() {
+                include.push(root.source.clone());
+            }
+            let source =
+                if root.source.is_empty() { Vec::new() } else { vec![root.source.clone()] };
 
             let entry = {
-                let mut dirs = vfs::loader::Directories {
+                let dirs = vfs::loader::Directories {
                     extensions: ["v", "sv", "vh", "svh", "svi", "map"].map(String::from).into(),
-                    include: load_paths,
-                    exclude: root.exclude,
+                    include: include.clone(),
+                    exclude: exclude_paths.clone(),
                 };
-                for excl in global_excludes {
-                    if dirs
-                        .include
-                        .iter()
-                        .any(|incl| incl.starts_with(excl) || excl.starts_with(incl))
-                    {
-                        dirs.exclude.push(excl.clone());
-                    }
-                }
-
                 vfs::loader::Entry::Directories(dirs)
             };
 
@@ -182,8 +282,10 @@ pub fn get_workspace_folder(
                 local_filesets.push(fsc.len());
             }
 
-            fsc.add_file_set(root_file_set);
-            source_paths_by_fileset.push(root.sources);
+            fsc.add_filtered_file_set(
+                root_file_set,
+                FileSetFilter { include, source: Some(source), exclude_paths },
+            );
 
             if !root.is_lib {
                 watch.push(load.len());
@@ -237,12 +339,7 @@ pub fn get_workspace_folder(
     (
         load,
         watch,
-        SourceRootConfig {
-            fileset_config,
-            local_filesets,
-            ignored_filesets,
-            source_paths_by_fileset,
-        },
+        SourceRootConfig { fileset_config, local_filesets, ignored_filesets },
         project_config,
     )
 }
@@ -295,7 +392,9 @@ fn collect_dependency_roots(
 mod tests {
     use std::fs;
 
-    use utils::test_support::TestDir;
+    use base_db::source_root::SourceRootRole;
+    use utils::{lines::LineEnding, test_support::TestDir};
+    use vfs::{Vfs, loader::LoadResult};
 
     use super::*;
 
@@ -325,8 +424,8 @@ libraries = ["../pkg"]
 
         assert!(errors.is_empty(), "{errors:#?}");
         assert_eq!(model.workspaces.len(), 2);
-        assert!(!model.workspaces[0].0.is_lib);
-        assert!(model.workspaces[1].0.is_lib);
+        assert!(!model.workspaces[0].is_lib());
+        assert!(model.workspaces[1].is_lib());
     }
 
     #[test]
@@ -354,8 +453,8 @@ libraries = ["../pkg/rtl"]
 
         assert!(errors.is_empty(), "{errors:#?}");
         assert_eq!(model.workspaces.len(), 2);
-        assert!(!model.workspaces[0].0.is_lib);
-        assert!(model.workspaces[1].0.is_lib);
+        assert!(!model.workspaces[0].is_lib());
+        assert!(model.workspaces[1].is_lib());
 
         let root_profile_id = project_config.profile_for_root(SourceRootId(0)).unwrap();
         let root_profile = project_config.profile(root_profile_id).unwrap();
@@ -429,6 +528,104 @@ include_dirs = ["include"]
         assert!(errors.is_empty(), "{errors:#?}");
         assert_eq!(load.len(), 1);
         assert_eq!(source_root_config.ignored_filesets, vec![1]);
+    }
+
+    #[test]
+    fn source_paths_default_include_dirs_to_sources() {
+        let base = TestDir::new("project-model-source-path-default-includes");
+        let root = base.join("root");
+        let rtl = root.join("rtl");
+        fs::create_dir_all(rtl.join("nested")).unwrap();
+        fs::write(
+            root.join(project_manifest::MANIFEST_FILE_NAME),
+            r#"sources = ["rtl"]
+"#,
+        )
+        .unwrap();
+
+        let top = rtl.join("nested/top.sv");
+        let manifest = ProjectManifest::from_path(&root).unwrap();
+        let (model, errors) = ProjectModel::load(vec![manifest]);
+        let (load, _, _, project_config) = get_workspace_folder(&model.workspaces, &[]);
+
+        assert!(errors.is_empty(), "{errors:#?}");
+        let dirs = match &load[0] {
+            vfs::loader::Entry::Directories(dirs) => dirs,
+            other => panic!("expected directory loader entry, got {other:?}"),
+        };
+        assert!(dirs.contains_file(top.as_path()));
+
+        let profile_id = project_config.profile_for_root(SourceRootId(0)).unwrap();
+        let profile = project_config.profile(profile_id).unwrap();
+        assert_eq!(profile.preprocess.include_dirs, [rtl]);
+    }
+
+    #[test]
+    fn excluded_source_roots_are_not_loaded() {
+        let base = TestDir::new("project-model-excluded-source-root");
+        let root = base.join("root");
+        fs::create_dir_all(root.join("rtl")).unwrap();
+        fs::write(
+            root.join(project_manifest::MANIFEST_FILE_NAME),
+            r#"sources = ["rtl"]
+exclude = ["rtl"]
+"#,
+        )
+        .unwrap();
+
+        let manifest = ProjectManifest::from_path(&root).unwrap();
+        let (model, errors) = ProjectModel::load(vec![manifest]);
+        let (load, _, _, project_config) = get_workspace_folder(&model.workspaces, &[]);
+
+        assert!(errors.is_empty(), "{errors:#?}");
+        assert!(load.is_empty());
+        assert_eq!(project_config.profile_for_root(SourceRootId(0)), None);
+    }
+
+    #[test]
+    fn source_and_exclude_paths_filter_loaded_and_open_files() {
+        let base = TestDir::new("project-model-source-paths");
+        let root = base.join("root");
+        let rtl = root.join("rtl");
+        let excluded = rtl.join("excluded");
+        fs::create_dir_all(rtl.join("nested")).unwrap();
+        fs::create_dir_all(&excluded).unwrap();
+        fs::write(
+            root.join(project_manifest::MANIFEST_FILE_NAME),
+            r#"sources = ["rtl"]
+include_dirs = []
+exclude = ["rtl/excluded"]
+"#,
+        )
+        .unwrap();
+
+        let top = rtl.join("nested/top.sv");
+        let excluded_top = excluded.join("top.sv");
+        let manifest = ProjectManifest::from_path(&root).unwrap();
+        let (model, errors) = ProjectModel::load(vec![manifest]);
+        let (load, _, source_root_config, _) = get_workspace_folder(&model.workspaces, &[]);
+
+        assert!(errors.is_empty(), "{errors:#?}");
+        assert_eq!(load.len(), 1);
+        let dirs = match &load[0] {
+            vfs::loader::Entry::Directories(dirs) => dirs,
+            other => panic!("expected directory loader entry, got {other:?}"),
+        };
+        assert!(dirs.contains_file(top.as_path()));
+        assert!(!dirs.contains_file(excluded_top.as_path()));
+
+        let mut vfs = Vfs::default();
+        for file in [&top, &excluded_top] {
+            vfs.set_file_contents(
+                &VfsPath::from(file.clone()),
+                LoadResult::Loaded(String::new(), LineEnding::Unix),
+            );
+        }
+
+        let roots = source_root_config.partition(&vfs);
+        assert!(roots[0].file_for_path(&VfsPath::from(top)).is_some());
+        assert_eq!(roots[1].role(), SourceRootRole::Ignored);
+        assert!(roots[1].file_for_path(&VfsPath::from(excluded_top)).is_some());
     }
 
     #[test]
@@ -565,8 +762,8 @@ libraries = ["../pkg"]
 
         assert!(errors.is_empty(), "{errors:#?}");
         assert_eq!(model.workspaces.len(), 2);
-        assert!(!model.workspaces[0].0.is_lib);
-        assert!(!model.workspaces[1].0.is_lib);
+        assert!(!model.workspaces[0].is_lib());
+        assert!(!model.workspaces[1].is_lib());
 
         let app_profile_id = project_config.profile_for_root(SourceRootId(0)).unwrap();
         let app_profile = project_config.profile(app_profile_id).unwrap();

--- a/crates/project-model/src/toml_workspace.rs
+++ b/crates/project-model/src/toml_workspace.rs
@@ -2,12 +2,11 @@ use std::sync::LazyLock;
 
 use anyhow::Context;
 use const_format::formatcp;
-use itertools::Itertools;
 use regex::Regex;
 use rustc_hash::FxHashSet;
 use serde::Deserialize;
 use smol_str::SmolStr;
-use utils::paths::{AbsPathBuf, Utf8PathBuf, sort_and_remove_subfolders};
+use utils::paths::{AbsPathBuf, Utf8PathBuf};
 
 use crate::macro_def::{MacroAtom, MacroDef};
 
@@ -181,15 +180,13 @@ pub struct TomlWorkspace {
     pub workspace_root: AbsPathBuf,
     pub macro_defs: MacroDef,
     pub sources: Vec<AbsPathBuf>,
-    pub include_dirs: Vec<AbsPathBuf>,
+    pub include_dirs: Option<Vec<AbsPathBuf>>,
+    pub libraries: Vec<AbsPathBuf>,
     pub exclude: Vec<AbsPathBuf>,
-    pub package: Vec<AbsPathBuf>,
-    pub is_lib: bool,
-    pub configures_semantic_diagnostics: bool,
 }
 
 impl TomlWorkspace {
-    pub fn load_from_file(toml: &AbsPathBuf, is_lib: bool) -> anyhow::Result<Self> {
+    pub fn load_from_file(toml: &AbsPathBuf) -> anyhow::Result<Self> {
         let toml_file =
             std::fs::read_to_string(toml).with_context(|| format!("failed to read {:?}", toml))?;
 
@@ -203,51 +200,22 @@ impl TomlWorkspace {
             .to_path_buf();
         let macro_defs = toml_schema.defines;
 
-        let mut exclude = toml_schema
-            .exclude
+        let include_dirs = toml_schema.include_dirs.map(|paths| {
+            paths.into_iter().map(|path| workspace_root.absolutize(path)).collect::<Vec<_>>()
+        });
+        let sources = toml_schema
+            .sources
+            .unwrap_or_default()
             .into_iter()
             .map(|path| workspace_root.absolutize(path))
-            .collect_vec();
-        sort_and_remove_subfolders(&mut exclude);
-
-        let include_dirs_was_configured = toml_schema.include_dirs.is_some();
-        let mut sources = Vec::new();
-        let mut include_dirs = Vec::new();
-        let mut package = Vec::new();
-
-        for path in toml_schema.sources.unwrap_or_default() {
-            let path = workspace_root.absolutize(path);
-            if exclude.iter().all(|excluded| !path.starts_with(excluded)) {
-                if path.starts_with(&workspace_root) {
-                    sources.push(path);
-                } else {
-                    package.push(path);
-                }
-            }
-        }
-
-        for path in toml_schema.include_dirs.unwrap_or_default() {
-            let path = workspace_root.absolutize(path);
-            if exclude.iter().all(|excluded| !path.starts_with(excluded)) {
-                include_dirs.push(path);
-            }
-        }
-
-        for path in toml_schema.libraries {
-            let path = workspace_root.absolutize(path);
-            if exclude.iter().all(|excluded| !path.starts_with(excluded)) {
-                package.push(path);
-            }
-        }
-
-        sort_and_remove_subfolders(&mut sources);
-        sort_and_remove_subfolders(&mut include_dirs);
-        sort_and_remove_subfolders(&mut package);
-
-        if include_dirs.is_empty() && !include_dirs_was_configured {
-            include_dirs = sources.clone();
-        }
-        let configures_semantic_diagnostics = !sources.is_empty() || !include_dirs.is_empty();
+            .collect::<Vec<_>>();
+        let libraries = toml_schema
+            .libraries
+            .into_iter()
+            .map(|path| workspace_root.absolutize(path))
+            .collect::<Vec<_>>();
+        let exclude =
+            toml_schema.exclude.into_iter().map(|path| workspace_root.absolutize(path)).collect();
 
         Ok(TomlWorkspace {
             top_modules,
@@ -255,27 +223,9 @@ impl TomlWorkspace {
             macro_defs,
             sources,
             include_dirs,
+            libraries,
             exclude,
-            package,
-            is_lib,
-            configures_semantic_diagnostics,
         })
-    }
-
-    pub fn from_unconfigured_root(path: &AbsPathBuf, is_lib: bool) -> Self {
-        let sources = if is_lib { vec![path.clone()] } else { Vec::new() };
-        let include_dirs = sources.clone();
-        Self {
-            top_modules: Vec::new(),
-            workspace_root: path.clone(),
-            macro_defs: MacroDef::default(),
-            sources,
-            include_dirs,
-            exclude: vec![],
-            package: vec![],
-            is_lib,
-            configures_semantic_diagnostics: false,
-        }
     }
 }
 
@@ -327,22 +277,12 @@ defines = [
         let root = TestDir::new("empty-manifest");
         let manifest = root.write("vizsla_config.toml", "");
 
-        let workspace = TomlWorkspace::load_from_file(&manifest, false).unwrap();
+        let workspace = TomlWorkspace::load_from_file(&manifest).unwrap();
 
         assert!(workspace.sources.is_empty());
-        assert!(workspace.include_dirs.is_empty());
-        assert!(!workspace.configures_semantic_diagnostics);
-    }
-
-    #[test]
-    fn unconfigured_root_uses_syntax_only_default() {
-        let root = TestDir::new("unconfigured-root");
-
-        let workspace = TomlWorkspace::from_unconfigured_root(&root.path().to_path_buf(), false);
-
-        assert!(workspace.sources.is_empty());
-        assert!(workspace.include_dirs.is_empty());
-        assert!(!workspace.configures_semantic_diagnostics);
+        assert_eq!(workspace.include_dirs, None);
+        assert!(workspace.libraries.is_empty());
+        assert!(workspace.exclude.is_empty());
     }
 
     #[test]
@@ -350,21 +290,22 @@ defines = [
         let root = TestDir::new("empty-sources");
         let manifest = root.write("vizsla_config.toml", "sources = []\n");
 
-        let workspace = TomlWorkspace::load_from_file(&manifest, false).unwrap();
+        let workspace = TomlWorkspace::load_from_file(&manifest).unwrap();
 
         assert!(workspace.sources.is_empty());
     }
 
     #[test]
-    fn excluded_configured_sources_do_not_default_to_workspace_root() {
-        let root = TestDir::new("excluded-sources");
+    fn parses_source_and_exclude_paths_as_absolute_paths() {
+        let root = TestDir::new("manifest-source-exclude-paths");
         root.create_dir_all("rtl");
         let manifest =
-            root.write("vizsla_config.toml", "sources = [\"rtl\"]\nexclude = [\"rtl\"]\n");
+            root.write("vizsla_config.toml", "sources = [\"rtl\"]\nexclude = [\"build\"]\n");
 
-        let workspace = TomlWorkspace::load_from_file(&manifest, false).unwrap();
+        let workspace = TomlWorkspace::load_from_file(&manifest).unwrap();
 
-        assert!(workspace.sources.is_empty());
+        assert_eq!(workspace.sources, [root.join("rtl")]);
+        assert_eq!(workspace.exclude, [root.join("build")]);
     }
 
     #[test]
@@ -373,8 +314,24 @@ defines = [
         root.create_dir_all("rtl");
         let manifest = root.write("vizsla_config.toml", "sources = [\"rtl\"]\ninclude_dirs = []\n");
 
-        let workspace = TomlWorkspace::load_from_file(&manifest, false).unwrap();
+        let workspace = TomlWorkspace::load_from_file(&manifest).unwrap();
 
-        assert!(workspace.include_dirs.is_empty());
+        assert_eq!(workspace.include_dirs, Some(Vec::new()));
+    }
+
+    #[test]
+    fn parses_paths_as_absolute_paths() {
+        let root = TestDir::new("manifest-paths");
+        let manifest = root.write(
+            "vizsla_config.toml",
+            r#"include_dirs = ["include"]
+libraries = ["../pkg"]
+"#,
+        );
+
+        let workspace = TomlWorkspace::load_from_file(&manifest).unwrap();
+
+        assert_eq!(workspace.include_dirs, Some(vec![root.join("include")]));
+        assert_eq!(workspace.libraries, [root.join("../pkg")]);
     }
 }

--- a/crates/vfs-notify/src/lib.rs
+++ b/crates/vfs-notify/src/lib.rs
@@ -230,10 +230,8 @@ impl NotifyActor {
                 .collect_vec(),
             loader::Entry::Directories(dirs) => {
                 let mut res = Vec::new();
-                let dir_set =
-                    dirs.include.iter().chain(dirs.exclude.iter()).collect::<FxHashSet<_>>();
 
-                for root in &dirs.include {
+                for root in dirs.include_roots() {
                     let walkdir =
                         WalkDir::new(root).follow_links(true).into_iter().filter_entry(|entry| {
                             if !entry.file_type().is_dir() {
@@ -242,7 +240,7 @@ impl NotifyActor {
                             let Ok(path) = AbsPathBuf::try_from(entry.path().to_path_buf()) else {
                                 return false;
                             };
-                            root == &path || !dir_set.contains(&path)
+                            root == &path || dirs.contains_dir(&path)
                         });
 
                     let files = walkdir.filter_map(|it| it.ok()).filter_map(|entry| {
@@ -260,8 +258,7 @@ impl NotifyActor {
                             return None;
                         }
 
-                        let ext = abs_path.extension().unwrap_or_default();
-                        if dirs.extensions.iter().all(|it| it.as_str() != ext) {
+                        if !dirs.contains_file(&abs_path) {
                             return None;
                         }
 

--- a/crates/vfs/src/file_set.rs
+++ b/crates/vfs/src/file_set.rs
@@ -1,6 +1,7 @@
 use fst::{IntoStreamer, Streamer};
 use nohash_hasher::IntMap;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
+use utils::paths::{AbsPath, AbsPathBuf};
 
 use crate::{
     anchored_path::AnchoredPath,
@@ -55,6 +56,68 @@ pub struct FileSetConfig {
     len: usize,
     // Encoded paths -> sets they belong to.
     map: fst::Map<Vec<u8>>,
+    filters: Vec<FileSetFilter>,
+}
+
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub struct PartitionedFileSet {
+    pub file_set: FileSet,
+    pub source_files: Option<FxHashSet<FileId>>,
+}
+
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+pub struct PathSelection {
+    pub roots: Vec<AbsPathBuf>,
+}
+
+impl PathSelection {
+    pub fn all(roots: Vec<AbsPathBuf>) -> Self {
+        Self { roots }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.roots.is_empty()
+    }
+
+    pub fn contains_file(&self, path: &AbsPath) -> bool {
+        self.roots.iter().any(|root| path.starts_with(root))
+    }
+
+    pub fn contains_dir(&self, path: &AbsPath) -> bool {
+        self.roots.iter().any(|root| path.starts_with(root))
+    }
+
+    pub fn roots(&self) -> impl Iterator<Item = &AbsPathBuf> {
+        self.roots.iter()
+    }
+}
+
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub struct FileSetFilter {
+    pub include: Vec<PathSelection>,
+    pub source: Option<Vec<PathSelection>>,
+    pub exclude_paths: Vec<AbsPathBuf>,
+}
+
+impl FileSetFilter {
+    fn matches(&self, path: &VfsPath) -> bool {
+        let Some(path) = path.as_abs_path() else {
+            return self.include.is_empty() && self.exclude_paths.is_empty();
+        };
+        self.include.iter().any(|include| include.contains_file(path))
+            && !self.exclude_paths.iter().any(|exclude| path.starts_with(exclude))
+    }
+
+    fn is_source(&self, path: &VfsPath) -> bool {
+        let Some(source) = &self.source else {
+            return false;
+        };
+        let Some(path) = path.as_abs_path() else {
+            return false;
+        };
+        source.iter().any(|source| source.contains_file(path))
+            && !self.exclude_paths.iter().any(|exclude| path.starts_with(exclude))
+    }
 }
 
 impl Default for FileSetConfig {
@@ -69,12 +132,29 @@ impl FileSetConfig {
     }
 
     pub fn partition(&self, vfs: &Vfs) -> Vec<FileSet> {
+        self.partition_with_source(vfs).into_iter().map(|partition| partition.file_set).collect()
+    }
+
+    pub fn partition_with_source(&self, vfs: &Vfs) -> Vec<PartitionedFileSet> {
         let mut scratch_space = Vec::new();
-        let mut set = vec![FileSet::default(); self.len];
+        let mut set = (0..self.len)
+            .map(|idx| PartitionedFileSet {
+                file_set: FileSet::default(),
+                source_files: self
+                    .filters
+                    .get(idx)
+                    .and_then(|filter| filter.source.as_ref().map(|_| FxHashSet::default())),
+            })
+            .collect::<Vec<_>>();
         for (file_id, path) in vfs.iter() {
             let root = self.classify(path, &mut scratch_space);
-            if let Some(file_set) = set.get_mut(root) {
-                file_set.insert(file_id, path.clone());
+            if let Some(partition) = set.get_mut(root) {
+                partition.file_set.insert(file_id, path.clone());
+                if self.filters.get(root).is_some_and(|filter| filter.is_source(path))
+                    && let Some(source_files) = &mut partition.source_files
+                {
+                    source_files.insert(file_id);
+                }
             }
         }
         set
@@ -87,7 +167,10 @@ impl FileSetConfig {
         let mut longest_prefix = self.len - 1;
         let mut stream = self.map.search(automaton).into_stream();
         while let Some((_, v)) = stream.next() {
-            longest_prefix = v as usize;
+            let idx = v as usize;
+            if self.filters.get(idx).is_some_and(|filter| filter.matches(path)) {
+                longest_prefix = idx;
+            }
         }
         longest_prefix
     }
@@ -96,7 +179,12 @@ impl FileSetConfig {
 /// Builder for [`FileSetConfig`].
 #[derive(Default)]
 pub struct FileSetConfigBuilder {
-    roots: Vec<Vec<VfsPath>>,
+    roots: Vec<FileSetSpec>,
+}
+
+struct FileSetSpec {
+    roots: Vec<VfsPath>,
+    filter: FileSetFilter,
 }
 
 impl FileSetConfigBuilder {
@@ -105,17 +193,31 @@ impl FileSetConfigBuilder {
     }
 
     pub fn add_file_set(&mut self, roots: Vec<VfsPath>) {
-        self.roots.push(roots);
+        let include_paths: Vec<AbsPathBuf> = roots
+            .iter()
+            .filter_map(|root| root.as_abs_path().map(|path| path.to_path_buf()))
+            .collect();
+        let include = if include_paths.is_empty() {
+            Vec::new()
+        } else {
+            vec![PathSelection::all(include_paths)]
+        };
+        self.add_filtered_file_set(roots, FileSetFilter { include, ..FileSetFilter::default() });
+    }
+
+    pub fn add_filtered_file_set(&mut self, roots: Vec<VfsPath>, filter: FileSetFilter) {
+        self.roots.push(FileSetSpec { roots, filter });
     }
 
     pub fn build(self) -> FileSetConfig {
         let len = self.roots.len() + 1;
+        let filters = self.roots.iter().map(|spec| spec.filter.clone()).collect();
         let mut entries = self
             .roots
             .into_iter()
             .enumerate()
-            .flat_map(|(i, paths)| {
-                paths.into_iter().map(move |p| {
+            .flat_map(|(i, spec)| {
+                spec.roots.into_iter().map(move |p| {
                     let mut buf = Vec::new();
                     p.encode(&mut buf);
                     (buf, i as u64)
@@ -127,7 +229,7 @@ impl FileSetConfigBuilder {
         entries.sort();
         entries.dedup_by(|(a, _), (b, _)| a == b);
 
-        FileSetConfig { len, map: fst::Map::from_iter(entries).unwrap_or_default() }
+        FileSetConfig { len, map: fst::Map::from_iter(entries).unwrap_or_default(), filters }
     }
 }
 

--- a/crates/vfs/src/lib.rs
+++ b/crates/vfs/src/lib.rs
@@ -4,6 +4,6 @@ pub mod loader;
 mod vfs;
 mod vfs_path;
 
-pub use file_set::{FileSet, FileSetConfig};
+pub use file_set::{FileSet, FileSetConfig, FileSetFilter, PartitionedFileSet, PathSelection};
 pub use vfs::{ChangeKind, ChangedFile, FileId, FileState, Vfs};
 pub use vfs_path::VfsPath;

--- a/crates/vfs/src/loader.rs
+++ b/crates/vfs/src/loader.rs
@@ -6,6 +6,8 @@ use utils::{
     paths::{AbsPath, AbsPathBuf},
 };
 
+use crate::PathSelection;
+
 #[derive(Debug, Clone)]
 pub enum Entry {
     Files(Vec<AbsPathBuf>),
@@ -15,7 +17,7 @@ pub enum Entry {
 #[derive(Debug, Clone, Default)]
 pub struct Directories {
     pub extensions: Vec<String>,
-    pub include: Vec<AbsPathBuf>,
+    pub include: Vec<PathSelection>,
     pub exclude: Vec<AbsPathBuf>,
 }
 
@@ -75,32 +77,33 @@ impl Directories {
             return false;
         }
 
-        self.includes_path(path)
+        self.includes_file(path)
     }
 
     pub fn contains_dir(&self, path: &AbsPath) -> bool {
-        self.includes_path(path)
+        self.includes_dir(path)
+    }
+
+    pub fn include_roots(&self) -> impl Iterator<Item = &AbsPathBuf> {
+        self.include.iter().flat_map(PathSelection::roots)
     }
 
     /// Returns `true` if `path` is included in `self`.
     ///
     /// It is included if
-    ///   - An element in `self.include` is a prefix of `path`.
-    ///   - This path is longer than any element in `self.exclude` that is a
-    ///     prefix of `path`. In case of equality, exclusion wins.
-    fn includes_path(&self, path: &AbsPath) -> bool {
-        let mut longest_incl: Option<&AbsPathBuf> = None;
-        for incl in &self.include {
-            if path.starts_with(incl) && longest_incl.is_none_or(|path| incl.starts_with(path)) {
-                longest_incl = Some(incl);
-            }
-        }
+    ///   - An include root is a prefix of `path`.
+    ///   - No literal exclude prefix matches `path`.
+    fn includes_file(&self, path: &AbsPath) -> bool {
+        self.include.iter().any(|include| include.contains_file(path)) && !self.is_excluded(path)
+    }
 
-        let Some(longest_incl) = longest_incl else {
-            return false;
-        };
+    fn includes_dir(&self, path: &AbsPath) -> bool {
+        self.include.iter().any(|include| include.contains_dir(path))
+            && !self.exclude.iter().any(|excl| path.starts_with(excl))
+    }
 
-        !self.exclude.iter().any(|excl| path.starts_with(excl) && excl.starts_with(longest_incl))
+    fn is_excluded(&self, path: &AbsPath) -> bool {
+        self.exclude.iter().any(|excl| path.starts_with(excl))
     }
 }
 


### PR DESCRIPTION
## Summary

- Split TOML manifest parsing from resolved workspace path selection.
- Move source/include/exclude path selection into `project-model`.
- Let `vfs` track included files and source files through a generic `PathSelection` / `FileSetFilter`.
- Let `base-db` classify source files from final `FileId`s instead of manifest path rules.

## Notes

This keeps the existing manifest path semantics. Glob/gitignore behavior is intentionally not included in this PR.

## Validation

- `cargo check -p project-model -p vfs -p base-db -p vfs-notify`
- `cargo test -p project-model -p vfs -p base-db`
- `cargo test -p vizsla manifest`
- `cargo xtask check-manifest-schema`
- `npm test` in `editors/vscode`

Prepare for https://github.com/pascal-lab/vizsla/issues/58.