### PR TITLE
fix(config): classify vizsla.toml as manifest

### DIFF
--- a/crates/base-db/src/source_db.rs
+++ b/crates/base-db/src/source_db.rs
@@ -57,7 +57,10 @@ pub enum SourceFileKind {
 impl SourceFileKind {
     pub fn from_path(path: &VfsPath) -> Self {
         match path.name_and_extension() {
-            Some(("vizsla_config", Some(ext))) if ext.eq_ignore_ascii_case("toml") => {
+            Some((name, Some(ext)))
+                if (name == "vizsla" || name == "vizsla_config")
+                    && ext.eq_ignore_ascii_case("toml") =>
+            {
                 Self::ProjectManifest
             }
             Some((_, Some(ext))) if ext.eq_ignore_ascii_case("map") => Self::LibraryMap,
@@ -407,5 +410,16 @@ mod tests {
 
         assert_eq!(kind, SourceFileKind::SystemVerilog);
         assert!(kind.is_slang_parse_unit());
+    }
+
+    #[test]
+    fn project_manifests_are_not_slang_parse_diagnostic_units() {
+        for file_name in ["vizsla.toml", "vizsla_config.toml"] {
+            let kind =
+                SourceFileKind::from_path(&VfsPath::new_virtual_path(format!("/root/{file_name}")));
+
+            assert_eq!(kind, SourceFileKind::ProjectManifest);
+            assert!(!kind.is_slang_parse_unit());
+        }
     }
 }

--- a/crates/base-db/src/source_root.rs
+++ b/crates/base-db/src/source_root.rs
@@ -79,7 +79,9 @@ impl SourceRoot {
         let Some(source_files) = &self.source_files else {
             return kind;
         };
-        if matches!(kind, SourceFileKind::LibraryMap) || source_files.contains(file) {
+        if matches!(kind, SourceFileKind::LibraryMap | SourceFileKind::ProjectManifest)
+            || source_files.contains(file)
+        {
             kind
         } else {
             SourceFileKind::IncludeHeader
@@ -150,5 +152,15 @@ mod tests {
 
         assert_eq!(root.role(), SourceRootRole::Ignored);
         assert_eq!(root.file_kind(&file_id), SourceFileKind::SystemVerilog);
+    }
+
+    #[test]
+    fn source_filtered_root_preserves_project_manifest_kind() {
+        let mut file_set = FileSet::default();
+        let file_id = FileId(0);
+        file_set.insert(file_id, VfsPath::new_virtual_path("/root/vizsla.toml".into()));
+        let root = SourceRoot::new_local_with_source_files(file_set, Vec::new());
+
+        assert_eq!(root.file_kind(&file_id), SourceFileKind::ProjectManifest);
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1593,7 +1593,7 @@ fn project_manifest_is_not_diagnosed_as_systemverilog() {
     };
     let temp_dir = TempDir::new("manifest-diagnostics");
     let manifest_text = "top_modules = [\"top\"]\nsources = [\"rtl/**\"]\n";
-    let manifest_path = temp_dir.path().join("vizsla_config.toml");
+    let manifest_path = temp_dir.path().join("vizsla.toml");
     fs::write(&manifest_path, manifest_text).unwrap();
     fs::create_dir_all(temp_dir.path().join("rtl")).unwrap();
 


### PR DESCRIPTION
## Summary

- Classify both `vizsla.toml` and `vizsla_config.toml` as project manifests.
- Preserve project manifest file kind when source roots use explicit source-file filtering.
- Update the manifest diagnostics integration test to cover the preferred `vizsla.toml` filename.

## Root Cause

`SourceFileKind::from_path` only recognized the legacy `vizsla_config.toml` name, so the preferred `vizsla.toml` fell through to the default SystemVerilog kind and received slang diagnostics.

## Validation

- `cargo test -p base-db project_manifest -- --nocapture`
- `cargo test project_manifest_is_not_diagnosed_as_systemverilog -- --nocapture`