### PR TITLE
fix(inlay): anchor end-structure hints to endmodule ranges

### DIFF
--- a/crates/hir/src/hir_def/module.rs
+++ b/crates/hir/src/hir_def/module.rs
@@ -17,16 +17,13 @@ use specify::{
     SpecifyBlock, SpecifyBlockId, SpecifyBlockSrc, SpecifyItem, SpecifyItemId, SpecifyItemSrc,
 };
 use syntax::{
-    SyntaxKind, TokenKind,
     ast::{self, AstNode, PortList},
-    has_name::HasName,
-    ptr::{SyntaxNodePtr, SyntaxTokenPtr},
+    ptr::SyntaxNodePtr,
 };
 use triomphe::Arc;
 use utils::{
     define_enum_deriving_from,
     get::{Get, GetRef},
-    text_edit::TextRange,
 };
 
 use super::{
@@ -56,9 +53,10 @@ use super::{
 use crate::{
     container::{ContainerId, InFile},
     db::{HirDb, InternDb},
+    define_src_with_name_and_token,
     file::HirFileId,
     region_tree::{RegionTree, RegionTreeBuilder},
-    source_map::{IsNamedSrc, IsSrc, SourceMap, ToAstNode},
+    source_map::{SourceMap, ToAstNode},
 };
 
 pub mod continuous_assgin;
@@ -146,71 +144,7 @@ define_container! {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-pub struct ModuleSrc {
-    pub node: SyntaxNodePtr,
-    pub name: Option<SyntaxTokenPtr>,
-    end: Option<SyntaxTokenPtr>,
-}
-
-impl ModuleSrc {
-    pub fn end_range(&self) -> Option<TextRange> {
-        self.end.map(|end| end.range())
-    }
-}
-
-impl IsSrc for ModuleSrc {
-    fn kind(&self) -> SyntaxKind {
-        self.node.kind()
-    }
-
-    fn range(&self) -> TextRange {
-        self.node.range()
-    }
-}
-
-impl IsNamedSrc for ModuleSrc {
-    fn name_kind(&self) -> Option<TokenKind> {
-        self.name.map(|name| name.kind())
-    }
-
-    fn name_range(&self) -> Option<TextRange> {
-        self.name.map(|name| name.range())
-    }
-}
-
-impl<'a> ToAstNode<'a, ast::ModuleDeclaration<'a>> for ModuleSrc {
-    fn to_node(&self, tree: &'a syntax::SyntaxTree) -> Option<ast::ModuleDeclaration<'a>> {
-        let mut node = self.node.to_node(tree)?;
-        while !<ast::ModuleDeclaration<'a> as AstNode>::can_cast(node.kind()) {
-            node = node.children().find_map(|elem| elem.as_node())?;
-        }
-        <ast::ModuleDeclaration<'a> as AstNode>::cast(node)
-    }
-}
-
-impl From<ast::ModuleDeclaration<'_>> for ModuleSrc {
-    fn from(node: ast::ModuleDeclaration<'_>) -> Self {
-        let syntax = node.syntax();
-        Self {
-            node: SyntaxNodePtr::from_node(syntax),
-            name: node.name().map(|name| SyntaxTokenPtr::from_token_in(syntax, name)),
-            end: node.endmodule().map(|end| SyntaxTokenPtr::from_token_in(syntax, end)),
-        }
-    }
-}
-
-impl From<ModuleSrc> for SyntaxNodePtr {
-    fn from(src: ModuleSrc) -> Self {
-        src.node
-    }
-}
-
-impl From<ModuleSrc> for Option<SyntaxTokenPtr> {
-    fn from(src: ModuleSrc) -> Self {
-        src.name
-    }
-}
+define_src_with_name_and_token!(ModuleSrc(ast::ModuleDeclaration, end: endmodule, end_range));
 
 impl Module {
     pub fn param_port_id_by_idx(&self, idx: usize) -> Option<DeclId> {

--- a/crates/hir/src/hir_def/module.rs
+++ b/crates/hir/src/hir_def/module.rs
@@ -17,13 +17,16 @@ use specify::{
     SpecifyBlock, SpecifyBlockId, SpecifyBlockSrc, SpecifyItem, SpecifyItemId, SpecifyItemSrc,
 };
 use syntax::{
+    SyntaxKind, TokenKind,
     ast::{self, AstNode, PortList},
-    ptr::SyntaxNodePtr,
+    has_name::HasName,
+    ptr::{SyntaxNodePtr, SyntaxTokenPtr},
 };
 use triomphe::Arc;
 use utils::{
     define_enum_deriving_from,
     get::{Get, GetRef},
+    text_edit::TextRange,
 };
 
 use super::{
@@ -53,10 +56,9 @@ use super::{
 use crate::{
     container::{ContainerId, InFile},
     db::{HirDb, InternDb},
-    define_src_with_name,
     file::HirFileId,
     region_tree::{RegionTree, RegionTreeBuilder},
-    source_map::{SourceMap, ToAstNode},
+    source_map::{IsNamedSrc, IsSrc, SourceMap, ToAstNode},
 };
 
 pub mod continuous_assgin;
@@ -144,7 +146,71 @@ define_container! {
     }
 }
 
-define_src_with_name!(ModuleSrc(ast::ModuleDeclaration));
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub struct ModuleSrc {
+    pub node: SyntaxNodePtr,
+    pub name: Option<SyntaxTokenPtr>,
+    end: Option<SyntaxTokenPtr>,
+}
+
+impl ModuleSrc {
+    pub fn end_range(&self) -> Option<TextRange> {
+        self.end.map(|end| end.range())
+    }
+}
+
+impl IsSrc for ModuleSrc {
+    fn kind(&self) -> SyntaxKind {
+        self.node.kind()
+    }
+
+    fn range(&self) -> TextRange {
+        self.node.range()
+    }
+}
+
+impl IsNamedSrc for ModuleSrc {
+    fn name_kind(&self) -> Option<TokenKind> {
+        self.name.map(|name| name.kind())
+    }
+
+    fn name_range(&self) -> Option<TextRange> {
+        self.name.map(|name| name.range())
+    }
+}
+
+impl<'a> ToAstNode<'a, ast::ModuleDeclaration<'a>> for ModuleSrc {
+    fn to_node(&self, tree: &'a syntax::SyntaxTree) -> Option<ast::ModuleDeclaration<'a>> {
+        let mut node = self.node.to_node(tree)?;
+        while !<ast::ModuleDeclaration<'a> as AstNode>::can_cast(node.kind()) {
+            node = node.children().find_map(|elem| elem.as_node())?;
+        }
+        <ast::ModuleDeclaration<'a> as AstNode>::cast(node)
+    }
+}
+
+impl From<ast::ModuleDeclaration<'_>> for ModuleSrc {
+    fn from(node: ast::ModuleDeclaration<'_>) -> Self {
+        let syntax = node.syntax();
+        Self {
+            node: SyntaxNodePtr::from_node(syntax),
+            name: node.name().map(|name| SyntaxTokenPtr::from_token_in(syntax, name)),
+            end: node.endmodule().map(|end| SyntaxTokenPtr::from_token_in(syntax, end)),
+        }
+    }
+}
+
+impl From<ModuleSrc> for SyntaxNodePtr {
+    fn from(src: ModuleSrc) -> Self {
+        src.node
+    }
+}
+
+impl From<ModuleSrc> for Option<SyntaxTokenPtr> {
+    fn from(src: ModuleSrc) -> Self {
+        src.name
+    }
+}
 
 impl Module {
     pub fn param_port_id_by_idx(&self, idx: usize) -> Option<DeclId> {

--- a/crates/hir/src/source_map.rs
+++ b/crates/hir/src/source_map.rs
@@ -347,3 +347,77 @@ macro_rules! define_src_with_name {
         }
     };
 }
+
+#[macro_export]
+macro_rules! define_src_with_name_and_token {
+    ($name:ident(ast:: $ty:ident, $token:ident : $token_getter:ident, $range_getter:ident)) => {
+        #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+        pub struct $name {
+            pub node: syntax::ptr::SyntaxNodePtr,
+            pub name: Option<syntax::ptr::SyntaxTokenPtr>,
+            $token: Option<syntax::ptr::SyntaxTokenPtr>,
+        }
+
+        impl $name {
+            pub fn $range_getter(&self) -> Option<utils::text_edit::TextRange> {
+                self.$token.map(|token| token.range())
+            }
+        }
+
+        impl $crate::source_map::IsSrc for $name {
+            fn kind(&self) -> syntax::SyntaxKind {
+                self.node.kind()
+            }
+
+            fn range(&self) -> utils::text_edit::TextRange {
+                self.node.range()
+            }
+        }
+
+        impl $crate::source_map::IsNamedSrc for $name {
+            fn name_kind(&self) -> Option<syntax::TokenKind> {
+                self.name.map(|name| name.kind())
+            }
+
+            fn name_range(&self) -> Option<utils::text_edit::TextRange> {
+                self.name.map(|name| name.range())
+            }
+        }
+
+        impl<'a> $crate::source_map::ToAstNode<'a, ast::$ty<'a>> for $name {
+            fn to_node(&self, tree: &'a syntax::SyntaxTree) -> Option<ast::$ty<'a>> {
+                let mut node = self.node.to_node(tree)?;
+                while !<ast::$ty<'a> as syntax::ast::AstNode>::can_cast(node.kind()) {
+                    node = node.children().find_map(|elem| elem.as_node())?;
+                }
+                <ast::$ty<'a> as syntax::ast::AstNode>::cast(node)
+            }
+        }
+
+        impl From<ast::$ty<'_>> for $name {
+            fn from(node: ast::$ty<'_>) -> Self {
+                let syntax = syntax::ast::AstNode::syntax(&node);
+                Self {
+                    node: syntax::slang_ext::AstNodeExt::to_ptr(&node),
+                    name: <ast::$ty<'_> as syntax::has_name::HasName<'_>>::name(&node)
+                        .map(|name| syntax::ptr::SyntaxTokenPtr::from_token_in(syntax, name)),
+                    $token: node
+                        .$token_getter()
+                        .map(|token| syntax::ptr::SyntaxTokenPtr::from_token_in(syntax, token)),
+                }
+            }
+        }
+
+        impl From<$name> for syntax::ptr::SyntaxNodePtr {
+            fn from(src: $name) -> Self {
+                src.node
+            }
+        }
+
+        impl From<$name> for Option<syntax::ptr::SyntaxTokenPtr> {
+            fn from(src: $name) -> Self {
+                src.name
+            }
+        }
+    };
+}

--- a/crates/ide/src/inlay_hint.rs
+++ b/crates/ide/src/inlay_hint.rs
@@ -12,10 +12,14 @@ use hir::{
         },
     },
     scope::UnitEntry,
-    source_map::IsSrc,
+    source_map::{IsSrc, ToAstNode},
 };
 use ide_db::root_db::RootDb;
-use syntax::{ast, match_ast_kind};
+use syntax::{
+    ast::{self, AstNode},
+    has_text_range::HasTextRangeIn,
+    match_ast_kind,
+};
 use utils::{
     get::{Get, GetRef},
     text_edit::{TextEdit, TextRange, TextSize},
@@ -128,6 +132,23 @@ impl InlayHintCollector {
         );
     }
 
+    fn collect_end_structure_hint(&mut self, end_range: TextRange, name: &str) {
+        if !self.intersect(end_range) {
+            return;
+        }
+
+        self.hints.push(InlayHint {
+            label: format!(": {name}"),
+            tooltip: None,
+            target_location: None,
+            padding_left: true,
+            padding_right: false,
+            position: end_range.end(),
+            kind: InlayKind::EndStructure,
+            text_edit: None,
+        });
+    }
+
     fn into_hints(self) -> Vec<InlayHint> {
         self.hints
     }
@@ -191,9 +212,16 @@ fn collect_module_items(
 
     if collector.config.end_structure
         && let Some(name) = &module.name
+        && let Some(end_range) = endmodule_range(db, module_id.file_id, module_src)
     {
-        collector.collect_hint(module_src, None::<InFile<ModuleSrc>>, format!(": {name}"), None);
+        collector.collect_end_structure_hint(end_range, name);
     }
+}
+
+fn endmodule_range(db: &RootDb, file_id: HirFileId, module_src: ModuleSrc) -> Option<TextRange> {
+    let tree = db.parse(file_id);
+    let module_decl = module_src.to_node(&tree)?;
+    module_decl.endmodule()?.text_range_in(module_decl.syntax())
 }
 
 fn process_instantiation(
@@ -378,6 +406,10 @@ mod tests {
         InlayHintConfig { port_connection: false, parameter_assignment: true, end_structure: false }
     }
 
+    fn end_structure_config() -> InlayHintConfig {
+        InlayHintConfig { port_connection: false, parameter_assignment: false, end_structure: true }
+    }
+
     fn port_hint_labels(text: &str) -> Vec<String> {
         let (db, file_id) = db_with_file(text);
         let range = TextRange::new(TextSize::from(0), TextSize::of(text));
@@ -396,6 +428,44 @@ mod tests {
             .filter(|hint| matches!(hint.kind, InlayKind::ParamAssign))
             .map(|hint| hint.label)
             .collect()
+    }
+
+    #[test]
+    fn comment_only_range_does_not_return_end_structure_hint() {
+        let text = "\
+module top;
+    // ISSUE_RANGE_START
+    // This comment-only area contains no module ending.
+    // ISSUE_RANGE_END
+
+endmodule
+";
+        let start = text.find("// ISSUE_RANGE_START").unwrap();
+        let end_marker = text.find("// ISSUE_RANGE_END").unwrap();
+        let end = end_marker + text[end_marker..].find('\n').unwrap() + 1;
+        let range = TextRange::new(TextSize::of(&text[..start]), TextSize::of(&text[..end]));
+        let (db, file_id) = db_with_file(text);
+
+        let hints = inlay_hint(&db, file_id, range, end_structure_config());
+
+        assert!(hints.is_empty(), "comment-only range returned hints: {hints:?}");
+    }
+
+    #[test]
+    fn endmodule_range_returns_end_structure_hint() {
+        let text = "module top;\nendmodule\n";
+        let start = text.find("endmodule").unwrap();
+        let end = start + "endmodule".len();
+        let range = TextRange::new(TextSize::of(&text[..start]), TextSize::of(&text[..end]));
+        let (db, file_id) = db_with_file(text);
+
+        let labels = inlay_hint(&db, file_id, range, end_structure_config())
+            .into_iter()
+            .filter(|hint| matches!(hint.kind, InlayKind::EndStructure))
+            .map(|hint| hint.label)
+            .collect::<Vec<_>>();
+
+        assert_eq!(labels, vec![": top"]);
     }
 
     #[test]

--- a/crates/ide/src/inlay_hint.rs
+++ b/crates/ide/src/inlay_hint.rs
@@ -12,14 +12,10 @@ use hir::{
         },
     },
     scope::UnitEntry,
-    source_map::{IsSrc, ToAstNode},
+    source_map::IsSrc,
 };
 use ide_db::root_db::RootDb;
-use syntax::{
-    ast::{self, AstNode},
-    has_text_range::HasTextRangeIn,
-    match_ast_kind,
-};
+use syntax::{ast, match_ast_kind};
 use utils::{
     get::{Get, GetRef},
     text_edit::{TextEdit, TextRange, TextSize},
@@ -61,6 +57,44 @@ pub struct InlayHint {
     pub text_edit: Option<TextEdit>,
 }
 
+#[derive(Debug, Copy, Clone)]
+struct HintAnchor {
+    range: TextRange,
+    position: TextSize,
+    kind: InlayKind,
+    padding_left: bool,
+    padding_right: bool,
+}
+
+impl HintAnchor {
+    fn from_src(src: impl IsSrc) -> Option<Self> {
+        let range = src.range();
+        let kind = match_ast_kind! { src.kind(),
+            ast::ParamAssignment => InlayKind::ParamAssign,
+            ast::OrderedPortConnection | ast::EmptyPortConnection => InlayKind::Port,
+            _ => return None,
+        };
+
+        Some(Self {
+            range,
+            position: range.start(),
+            kind,
+            padding_left: false,
+            padding_right: false,
+        })
+    }
+
+    fn module_end(range: TextRange) -> Self {
+        Self {
+            range,
+            position: range.end(),
+            kind: InlayKind::EndStructure,
+            padding_left: true,
+            padding_right: false,
+        }
+    }
+}
+
 struct InlayHintCollector {
     hints: Vec<InlayHint>,
     range: TextRange,
@@ -74,30 +108,14 @@ impl InlayHintCollector {
 
     fn collect_hint(
         &mut self,
-        src: impl IsSrc,
+        anchor: HintAnchor,
         target_src: Option<InFile<impl IsSrc>>,
         label: String,
         text_edit: Option<TextEdit>,
     ) {
-        let range = src.range();
-        assert!(range.intersect(self.range).is_some());
-
-        let kind = match_ast_kind! { src.kind(),
-            ast::ParamAssignment => InlayKind::ParamAssign,
-            ast::OrderedPortConnection | ast::EmptyPortConnection => InlayKind::Port,
-            ast::ModuleDeclaration => InlayKind::EndStructure,
-            _ => return,
-        };
-
-        let position = match_ast_kind! { src.kind(),
-            ast::ModuleDeclaration => range.end(),
-            _ => range.start(),
-        };
-
-        let (padding_left, padding_right) = match_ast_kind! { src.kind(),
-            ast::ModuleDeclaration => (true, false),
-            _ => (false, false),
-        };
+        if !self.intersect(anchor.range) {
+            return;
+        }
 
         let (tooltip, target_location) = if let Some(InFile { value: src, file_id }) = target_src {
             let location = InFile::new(file_id, src.range());
@@ -110,12 +128,24 @@ impl InlayHintCollector {
             label,
             tooltip,
             target_location,
-            padding_left,
-            padding_right,
-            position,
-            kind,
+            padding_left: anchor.padding_left,
+            padding_right: anchor.padding_right,
+            position: anchor.position,
+            kind: anchor.kind,
             text_edit,
         });
+    }
+
+    fn collect_src_hint(
+        &mut self,
+        src: impl IsSrc,
+        target_src: Option<InFile<impl IsSrc>>,
+        label: String,
+        text_edit: Option<TextEdit>,
+    ) {
+        if let Some(anchor) = HintAnchor::from_src(src) {
+            self.collect_hint(anchor, target_src, label, text_edit);
+        }
     }
 
     fn collect_port_hint(
@@ -124,7 +154,7 @@ impl InlayHintCollector {
         conn_src: impl IsSrc,
         target_src: InFile<impl IsSrc>,
     ) {
-        self.collect_hint(
+        self.collect_src_hint(
             conn_src,
             Some(target_src),
             format!("{name}: "),
@@ -132,21 +162,15 @@ impl InlayHintCollector {
         );
     }
 
-    fn collect_end_structure_hint(&mut self, end_range: TextRange, name: &str) {
-        if !self.intersect(end_range) {
-            return;
+    fn collect_module_end_hint(&mut self, module_src: ModuleSrc, name: &str) {
+        if let Some(end_range) = module_src.end_range() {
+            self.collect_hint(
+                HintAnchor::module_end(end_range),
+                None::<InFile<ModuleSrc>>,
+                format!(": {name}"),
+                None,
+            );
         }
-
-        self.hints.push(InlayHint {
-            label: format!(": {name}"),
-            tooltip: None,
-            target_location: None,
-            padding_left: true,
-            padding_right: false,
-            position: end_range.end(),
-            kind: InlayKind::EndStructure,
-            text_edit: None,
-        });
     }
 
     fn into_hints(self) -> Vec<InlayHint> {
@@ -212,16 +236,9 @@ fn collect_module_items(
 
     if collector.config.end_structure
         && let Some(name) = &module.name
-        && let Some(end_range) = endmodule_range(db, module_id.file_id, module_src)
     {
-        collector.collect_end_structure_hint(end_range, name);
+        collector.collect_module_end_hint(module_src, name);
     }
-}
-
-fn endmodule_range(db: &RootDb, file_id: HirFileId, module_src: ModuleSrc) -> Option<TextRange> {
-    let tree = db.parse(file_id);
-    let module_decl = module_src.to_node(&tree)?;
-    module_decl.endmodule()?.text_range_in(module_decl.syntax())
 }
 
 fn process_instantiation(
@@ -431,7 +448,7 @@ mod tests {
     }
 
     #[test]
-    fn comment_only_range_does_not_return_end_structure_hint() {
+    fn comment_only_range_skips_module_end_hint() {
         let text = "\
 module top;
     // ISSUE_RANGE_START
@@ -452,7 +469,7 @@ endmodule
     }
 
     #[test]
-    fn endmodule_range_returns_end_structure_hint() {
+    fn module_end_range_returns_end_structure_hint() {
         let text = "module top;\nendmodule\n";
         let start = text.find("endmodule").unwrap();
         let end = start + "endmodule".len();


### PR DESCRIPTION
Closes https://github.com/pascal-lab/vizsla/issues/81.

This PR fixes an inlay hint range-filtering issue, where end-structure hints could be returned for a requested range that only overlapped the module body. The cause was that end-structure hints were collected from the whole `ModuleDeclaration` range, even though the hint is rendered at the module ending.

The fix anchors the hint to the actual `endmodule` token range, so comment-only or otherwise unrelated ranges inside a module no longer return `: module_name` outside the requested range.