### PR TITLE
feat(vscode): add diagnostic rule quick actions

### DIFF
--- a/editors/vscode/l10n/bundle.l10n.zh-cn.json
+++ b/editors/vscode/l10n/bundle.l10n.zh-cn.json
@@ -21,6 +21,8 @@
   "Create Manifest": "创建项目配置文件",
   "Create Manifests": "创建项目配置文件",
   "Creating a manifest will restart the Vizsla language server so the workspace can reload it.": "创建项目配置文件会重启 Vizsla 语言服务器，以便工作区重新加载它。",
+  "Downgrade diagnostic {0} to warning in user settings": "在用户设置中将诊断 {0} 降级为 warning",
+  "Downgrade diagnostic {0} to warning in workspace settings": "在工作区设置中将诊断 {0} 降级为 warning",
   "No Vizsla project manifest was detected in {0}. Project-aware features like semantic diagnostics, navigation, and references may be severely limited. {1}": "未在 {0} 中检测到 Vizsla 项目配置文件。语义诊断、导航和引用等项目感知功能可能严重受限。{1}",
   "No Vizsla project manifest was detected in {0} workspace folders. Project-aware features like semantic diagnostics, navigation, and references may be severely limited. {1}": "未在 {0} 个工作区文件夹中检测到 Vizsla 项目配置文件。语义诊断、导航和引用等项目感知功能可能严重受限。{1}",
   "Failed to create {0} in {1}: {2}": "无法在 {1} 中创建 {0}：{2}",
@@ -34,10 +36,13 @@
   "Vizsla server: {0}": "Vizsla 服务器：{0}",
   "Failed to query Vizsla server version: {0}": "无法查询 Vizsla 服务器版本：{0}",
   "Show Output": "显示输出",
+  "Ignore diagnostic {0} in user settings": "在用户设置中忽略诊断 {0}",
+  "Ignore diagnostic {0} in workspace settings": "在工作区设置中忽略诊断 {0}",
   "Open a Verilog or SystemVerilog file first.": "请先打开 Verilog 或 SystemVerilog 文件。",
   "Qihe analysis is only available for Verilog files.": "Qihe 分析仅适用于 Verilog 文件。",
   "Vizsla language server is not running.": "Vizsla 语言服务器未运行。",
   "Failed to run Qihe analysis: {0}": "无法运行 Qihe 分析：{0}",
+  "Unable to update Vizsla diagnostic rules: {0}": "无法更新 Vizsla 诊断规则：{0}",
   "Restart": "重启",
   "Vizsla server configuration changed. Restart the language server to apply it.": "Vizsla 服务器配置已更改。请重启语言服务器以应用更改。"
 }

--- a/editors/vscode/src/diagnosticActions.ts
+++ b/editors/vscode/src/diagnosticActions.ts
@@ -1,0 +1,145 @@
+import * as vscode from 'vscode';
+
+import {
+  diagnosticCodeSelector,
+  diagnosticSelectorLabel,
+  type DiagnosticRule,
+  type DiagnosticRuleSeverity,
+  type DiagnosticRuleTarget,
+  upsertDiagnosticRule,
+} from './diagnosticRules';
+
+export const configureDiagnosticRuleCommand = 'vizsla.configureDiagnosticRule';
+
+interface ConfigureDiagnosticRuleArgs {
+  selector: string;
+  severity: DiagnosticRuleSeverity;
+  target: DiagnosticRuleTarget;
+}
+
+const diagnosticRulesSetting = 'diagnostics.slang.rules';
+const documentSelector: vscode.DocumentSelector = [
+  { scheme: 'file', language: 'verilog' },
+  { scheme: 'file', language: 'systemverilog' },
+];
+
+export function registerDiagnosticActions(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(configureDiagnosticRuleCommand, configureDiagnosticRule),
+  );
+
+  context.subscriptions.push(
+    vscode.languages.registerCodeActionsProvider(
+      documentSelector,
+      new DiagnosticRuleCodeActionProvider(),
+      { providedCodeActionKinds: [vscode.CodeActionKind.QuickFix] },
+    ),
+  );
+}
+
+class DiagnosticRuleCodeActionProvider implements vscode.CodeActionProvider {
+  provideCodeActions(
+    document: vscode.TextDocument,
+    _range: vscode.Range | vscode.Selection,
+    context: vscode.CodeActionContext,
+  ): vscode.CodeAction[] {
+    const workspaceActionsEnabled = vscode.workspace.workspaceFolders !== undefined;
+    const actions: vscode.CodeAction[] = [];
+    const diagnosticsBySelector = new Map<string, vscode.Diagnostic>();
+
+    for (const diagnostic of context.diagnostics) {
+      const selector = diagnosticCodeSelector(diagnostic);
+      if (!selector) {
+        continue;
+      }
+
+      const existing = diagnosticsBySelector.get(selector);
+      if (!existing || diagnostic.severity === vscode.DiagnosticSeverity.Error) {
+        diagnosticsBySelector.set(selector, diagnostic);
+      }
+    }
+
+    for (const [selector, diagnostic] of diagnosticsBySelector) {
+      const canDowngrade = diagnostic.severity === vscode.DiagnosticSeverity.Error;
+
+      if (workspaceActionsEnabled && vscode.workspace.getWorkspaceFolder(document.uri)) {
+        actions.push(createDiagnosticRuleAction(selector, diagnostic, 'ignore', 'workspace'));
+        if (canDowngrade) {
+          actions.push(createDiagnosticRuleAction(selector, diagnostic, 'warning', 'workspace'));
+        }
+      }
+
+      actions.push(createDiagnosticRuleAction(selector, diagnostic, 'ignore', 'user'));
+      if (canDowngrade) {
+        actions.push(createDiagnosticRuleAction(selector, diagnostic, 'warning', 'user'));
+      }
+    }
+
+    return actions;
+  }
+}
+
+function createDiagnosticRuleAction(
+  selector: string,
+  diagnostic: vscode.Diagnostic,
+  severity: DiagnosticRuleSeverity,
+  target: DiagnosticRuleTarget,
+): vscode.CodeAction {
+  const label = diagnosticSelectorLabel(selector);
+  const title = diagnosticRuleActionTitle(label, severity, target);
+  const action = new vscode.CodeAction(title, vscode.CodeActionKind.QuickFix);
+  action.diagnostics = [diagnostic];
+  action.command = {
+    command: configureDiagnosticRuleCommand,
+    title,
+    arguments: [{ selector, severity, target } satisfies ConfigureDiagnosticRuleArgs],
+  };
+  return action;
+}
+
+function diagnosticRuleActionTitle(
+  label: string,
+  severity: DiagnosticRuleSeverity,
+  target: DiagnosticRuleTarget,
+): string {
+  if (target === 'workspace') {
+    return severity === 'ignore'
+      ? vscode.l10n.t('Ignore diagnostic {0} in workspace settings', label)
+      : vscode.l10n.t('Downgrade diagnostic {0} to warning in workspace settings', label);
+  }
+
+  return severity === 'ignore'
+    ? vscode.l10n.t('Ignore diagnostic {0} in user settings', label)
+    : vscode.l10n.t('Downgrade diagnostic {0} to warning in user settings', label);
+}
+
+async function configureDiagnosticRule(args: ConfigureDiagnosticRuleArgs): Promise<void> {
+  try {
+    const config = vscode.workspace.getConfiguration('vizsla');
+    const target =
+      args.target === 'workspace'
+        ? vscode.ConfigurationTarget.Workspace
+        : vscode.ConfigurationTarget.Global;
+    const rules = diagnosticRulesForTarget(config, args.target);
+    const nextRules = upsertDiagnosticRule(rules, args.selector, args.severity);
+
+    await config.update(diagnosticRulesSetting, nextRules, target);
+  } catch (error) {
+    vscode.window.showErrorMessage(
+      vscode.l10n.t(
+        'Unable to update Vizsla diagnostic rules: {0}',
+        (error as Error).message,
+      ),
+    );
+  }
+}
+
+function diagnosticRulesForTarget(
+  config: vscode.WorkspaceConfiguration,
+  target: DiagnosticRuleTarget,
+): DiagnosticRule[] {
+  const inspected = config.inspect<DiagnosticRule[]>(diagnosticRulesSetting);
+  const value = target === 'workspace' ? inspected?.workspaceValue : inspected?.globalValue;
+
+  return Array.isArray(value) ? value : [];
+}

--- a/editors/vscode/src/diagnosticRules.ts
+++ b/editors/vscode/src/diagnosticRules.ts
@@ -1,0 +1,90 @@
+export type DiagnosticRuleSeverity = 'ignore' | 'info' | 'warning' | 'error' | 'fatal';
+
+export interface DiagnosticRule {
+  selector: string;
+  severity: DiagnosticRuleSeverity;
+  force?: boolean;
+}
+
+export type DiagnosticRuleTarget = 'user' | 'workspace';
+
+export interface DiagnosticLike {
+  source?: string;
+  code?: unknown;
+}
+
+const slangDiagnosticSource = 'slang';
+
+export function diagnosticCodeSelector(diagnostic: DiagnosticLike): string | undefined {
+  if (diagnostic.source !== slangDiagnosticSource) {
+    return undefined;
+  }
+
+  const code = diagnosticCode(diagnostic.code);
+  return code ? `code:${code.subsystem}:${code.code}` : undefined;
+}
+
+export function diagnosticSelectorLabel(selector: string): string {
+  return selector.startsWith('code:') ? selector.slice('code:'.length) : selector;
+}
+
+export function upsertDiagnosticRule(
+  rules: readonly DiagnosticRule[],
+  selector: string,
+  severity: DiagnosticRuleSeverity,
+): DiagnosticRule[] {
+  let replaced = false;
+  const next = rules.map((rule) => {
+    if (rule.selector !== selector) {
+      return rule;
+    }
+
+    replaced = true;
+    return { ...rule, severity };
+  });
+
+  if (!replaced) {
+    next.push({ selector, severity });
+  }
+
+  return next;
+}
+
+function diagnosticCode(code: unknown): { subsystem: number; code: number } | undefined {
+  if (typeof code === 'string') {
+    return parseDiagnosticCode(code);
+  }
+
+  if (isDiagnosticCodeObject(code)) {
+    const value = code.value;
+    if (typeof value === 'string') {
+      return parseDiagnosticCode(value);
+    }
+  }
+
+  return undefined;
+}
+
+function parseDiagnosticCode(value: string): { subsystem: number; code: number } | undefined {
+  const [subsystem, code, ...rest] = value.split(':');
+  if (rest.length > 0 || !subsystem || !code) {
+    return undefined;
+  }
+
+  const parsedSubsystem = Number(subsystem);
+  const parsedCode = Number(code);
+  if (
+    !Number.isInteger(parsedSubsystem)
+    || !Number.isInteger(parsedCode)
+    || parsedSubsystem < 0
+    || parsedCode < 0
+  ) {
+    return undefined;
+  }
+
+  return { subsystem: parsedSubsystem, code: parsedCode };
+}
+
+function isDiagnosticCodeObject(value: unknown): value is { value: unknown } {
+  return typeof value === 'object' && value !== null && 'value' in value;
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -11,6 +11,7 @@ import {
 } from 'vscode-languageclient/node';
 
 import { getBundledServerPath, getPlatformFolder } from './platform';
+import { registerDiagnosticActions } from './diagnosticActions';
 import {
   DEFAULT_PROJECT_CONFIG_TEXT,
   PROJECT_CONFIG_FILE_NAMES,
@@ -722,6 +723,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     },
   );
   context.subscriptions.push(runQiheRegistration);
+  registerDiagnosticActions(context);
 
   const configurationRegistration = vscode.workspace.onDidChangeConfiguration(
     async (event) => {

--- a/editors/vscode/test/configuration.test.ts
+++ b/editors/vscode/test/configuration.test.ts
@@ -52,12 +52,25 @@ function collectNlsPlaceholders(value: unknown, keys = new Set<string>()): Set<s
 }
 
 function collectRuntimeL10nMessages(): string[] {
-  const extensionSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'extension.ts'), 'utf8');
-  const matches = extensionSource.matchAll(/vscode\.l10n\.t\(\s*'((?:\\'|[^'])*)'/g);
-  const messages = [...matches].map((match) =>
-    match[1].replace(/\\n/g, '\n').replace(/\\'/g, "'"),
-  );
+  const messages: string[] = [];
+  for (const sourceFile of readSourceFiles(path.join(__dirname, '..', 'src'))) {
+    const source = fs.readFileSync(sourceFile, 'utf8');
+    const matches = source.matchAll(/vscode\.l10n\.t\(\s*'((?:\\'|[^'])*)'/g);
+    messages.push(
+      ...[...matches].map((match) => match[1].replace(/\\n/g, '\n').replace(/\\'/g, "'")),
+    );
+  }
   return [...new Set(messages)].sort();
+}
+
+function readSourceFiles(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return readSourceFiles(entryPath);
+    }
+    return entry.isFile() && entry.name.endsWith('.ts') ? [entryPath] : [];
+  });
 }
 
 test('contributes settings for the complete Vizsla user configuration surface', () => {

--- a/editors/vscode/test/diagnosticRules.test.ts
+++ b/editors/vscode/test/diagnosticRules.test.ts
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  diagnosticCodeSelector,
+  diagnosticSelectorLabel,
+  upsertDiagnosticRule,
+} from '../src/diagnosticRules';
+
+test('builds code selectors from slang diagnostic codes', () => {
+  assert.equal(diagnosticCodeSelector({ source: 'slang', code: '6:129' }), 'code:6:129');
+});
+
+test('builds code selectors from VS Code diagnostic code objects', () => {
+  assert.equal(
+    diagnosticCodeSelector({ source: 'slang', code: { value: '2:260' } }),
+    'code:2:260',
+  );
+});
+
+test('ignores diagnostics that cannot be configured by slang code', () => {
+  assert.equal(diagnosticCodeSelector({ source: 'vizsla', code: '2:260' }), undefined);
+  assert.equal(diagnosticCodeSelector({ source: 'slang', code: 260 }), undefined);
+  assert.equal(diagnosticCodeSelector({ source: 'slang', code: 'bad' }), undefined);
+});
+
+test('renders concise diagnostic selector labels', () => {
+  assert.equal(diagnosticSelectorLabel('code:6:129'), '6:129');
+});
+
+test('upserts diagnostic severity rules by selector', () => {
+  assert.deepEqual(
+    upsertDiagnosticRule(
+      [{ selector: 'code:6:129', severity: 'error', force: true }],
+      'code:6:129',
+      'warning',
+    ),
+    [{ selector: 'code:6:129', severity: 'warning', force: true }],
+  );
+
+  assert.deepEqual(upsertDiagnosticRule([], 'code:2:260', 'ignore'), [
+    { selector: 'code:2:260', severity: 'ignore' },
+  ]);
+});


### PR DESCRIPTION
This PR adds quick actions to downgrade diagnostic rules, so that users don't have to manually recognize code to ignore them in settings themselves.

Related: https://github.com/pascal-lab/vizsla/issues/35#issuecomment-4487254607