### PR TITLE
fix(lsp): handle include-expanded source map nodes

### DIFF
--- a/crates/hir/src/hir_def.rs
+++ b/crates/hir/src/hir_def.rs
@@ -39,8 +39,12 @@ pub(crate) fn lower_named_label_opt(label: Option<ast::NamedLabel>) -> Option<Id
 
 macro alloc_idx_and_src($hir:expr => $arena:expr, $ast:expr => $src_map:expr $(,)?) {{
     let idx = $arena.alloc($hir.into());
-    let src = $ast.into();
-    $src_map.insert(src, idx);
+    // HIR lowering can consume include-expanded AST nodes, but source maps only
+    // store locations that can be navigated in the parsed root file.
+    if let Some(ast) = $crate::source_map::SourceAst::new($ast) {
+        let src = $crate::source_map::FromSourceAst::from_source_ast(ast);
+        $src_map.insert(src, idx);
+    }
     idx
 }}
 

--- a/crates/hir/src/hir_def/aggregate.rs
+++ b/crates/hir/src/hir_def/aggregate.rs
@@ -11,7 +11,7 @@ use utils::text_edit::TextRange;
 use super::{Ident, expr::data_ty::DataTy, lower_ident_opt};
 use crate::{
     container::{ContainerId, InContainer},
-    source_map::{IsNamedSrc, IsSrc, ToAstNode},
+    source_map::{FromSourceAst, IsNamedSrc, IsSrc, SourceAst, ToAstNode, root_token_in},
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -105,6 +105,12 @@ impl From<ast::StructUnionType<'_>> for StructSrc {
     }
 }
 
+impl<'a> FromSourceAst<'a, ast::StructUnionType<'a>> for StructSrc {
+    fn from_source_ast(node: SourceAst<ast::StructUnionType<'a>>) -> Self {
+        StructSrc { node: AstNodeExt::to_ptr(&node.into_inner()) }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ClassMemberKind {
     Property,
@@ -173,6 +179,17 @@ impl From<ast::ClassDeclaration<'_>> for ClassSrc {
     fn from(node: ast::ClassDeclaration<'_>) -> Self {
         let syntax = node.syntax();
         let name = node.name().map(|name| SyntaxTokenPtr::from_token_in(syntax, name));
+        ClassSrc { node: AstNodeExt::to_ptr(&node), name }
+    }
+}
+
+impl<'a> FromSourceAst<'a, ast::ClassDeclaration<'a>> for ClassSrc {
+    fn from_source_ast(node: SourceAst<ast::ClassDeclaration<'a>>) -> Self {
+        let node = node.into_inner();
+        let syntax = node.syntax();
+        let name = node
+            .name()
+            .and_then(|name| root_token_in(syntax, name).map(SyntaxTokenPtr::from_token));
         ClassSrc { node: AstNodeExt::to_ptr(&node), name }
     }
 }

--- a/crates/hir/src/hir_def/module/generate.rs
+++ b/crates/hir/src/hir_def/module/generate.rs
@@ -49,7 +49,9 @@ use crate::{
         typedef::{Typedef, TypedefId, TypedefSrc, lower_typedef_data_ty},
     },
     region_tree::{RegionTree, RegionTreeBuilder},
-    source_map::{IsNamedSrc, IsSrc, SourceMap, ToAstNode},
+    source_map::{
+        FromSourceAst, IsNamedSrc, IsSrc, SourceAst, SourceMap, ToAstNode, root_token_in,
+    },
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -66,8 +68,16 @@ pub enum GenerateRegionSrc {
 }
 
 impl GenerateRegionSrc {
-    pub fn from_direct_member(member: &ast::Member<'_>) -> Self {
-        Self::DirectItem(syntax::slang_ext::AstNodeExt::to_ptr(member))
+    /// Source-map key for synthetic generate regions that wrap a direct member.
+    ///
+    /// Direct generate regions do not have their own AST node, so use the
+    /// member as the navigable location when that member belongs to the
+    /// parsed root file. Include-expanded members still lower into HIR, but
+    /// have no source entry here.
+    pub fn from_direct_member(member: &ast::Member<'_>) -> Option<Self> {
+        SourceAst::new(*member).map(|member| {
+            Self::DirectItem(syntax::slang_ext::AstNodeExt::to_ptr(&member.into_inner()))
+        })
     }
 
     fn ptr(&self) -> SyntaxNodePtr {
@@ -115,6 +125,12 @@ impl<'a> ToAstNode<'a, ast::GenerateRegion<'a>> for GenerateRegionSrc {
 impl From<ast::GenerateRegion<'_>> for GenerateRegionSrc {
     fn from(region: ast::GenerateRegion<'_>) -> Self {
         Self::GenerateRegion(syntax::slang_ext::AstNodeExt::to_ptr(&region))
+    }
+}
+
+impl<'a> FromSourceAst<'a, ast::GenerateRegion<'a>> for GenerateRegionSrc {
+    fn from_source_ast(region: SourceAst<ast::GenerateRegion<'a>>) -> Self {
+        Self::GenerateRegion(syntax::slang_ext::AstNodeExt::to_ptr(&region.into_inner()))
     }
 }
 
@@ -228,7 +244,7 @@ impl From<ast::GenerateBlock<'_>> for GenerateBlockSrc {
         GenerateBlockSrc::GenerateBlock {
             node: syntax::slang_ext::AstNodeExt::to_ptr(&block),
             name: generate_block_name(block)
-                .map(|name| SyntaxTokenPtr::from_token_in(syntax, name)),
+                .and_then(|name| root_token_in(syntax, name).map(SyntaxTokenPtr::from_token)),
         }
     }
 }
@@ -239,8 +255,9 @@ impl From<ast::LoopGenerate<'_>> for GenerateBlockSrc {
         GenerateBlockSrc::LoopGenerate {
             node: syntax::slang_ext::AstNodeExt::to_ptr(&loop_generate),
             name: block.and_then(|block| {
-                generate_block_name(block)
-                    .map(|name| SyntaxTokenPtr::from_token_in(block.syntax(), name))
+                generate_block_name(block).and_then(|name| {
+                    root_token_in(block.syntax(), name).map(SyntaxTokenPtr::from_token)
+                })
             }),
         }
     }
@@ -849,10 +866,11 @@ impl LowerModuleCtx<'_> {
         let mut items = SmallVec::new();
         self.lower_generate_region_member(item, &mut items);
 
-        alloc_idx_and_src! {
-            GenerateRegion { items } => self.module.generate_regions,
-            src => self.module_source_map.generate_region_srcs,
+        let idx = self.module.generate_regions.alloc(GenerateRegion { items });
+        if let Some(src) = src {
+            self.module_source_map.generate_region_srcs.insert(src, idx);
         }
+        idx
     }
 }
 

--- a/crates/hir/src/hir_def/typedef.rs
+++ b/crates/hir/src/hir_def/typedef.rs
@@ -10,7 +10,7 @@ use utils::text_edit::TextRange;
 use super::{Ident, aggregate::StructId, expr::data_ty::DataTy};
 use crate::{
     container::{ContainerId, InContainer},
-    source_map::{IsNamedSrc, IsSrc, ToAstNode},
+    source_map::{FromSourceAst, IsNamedSrc, IsSrc, SourceAst, ToAstNode, root_token_in},
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -69,6 +69,17 @@ impl From<ast::TypedefDeclaration<'_>> for TypedefSrc {
             node: AstNodeExt::to_ptr(&node),
             name: name_token.map(|name| SyntaxTokenPtr::from_token_in(syntax, name)),
         }
+    }
+}
+
+impl<'a> FromSourceAst<'a, ast::TypedefDeclaration<'a>> for TypedefSrc {
+    fn from_source_ast(node: SourceAst<ast::TypedefDeclaration<'a>>) -> Self {
+        let node = node.into_inner();
+        let syntax = node.syntax();
+        let name = node
+            .name()
+            .and_then(|name| root_token_in(syntax, name).map(SyntaxTokenPtr::from_token));
+        TypedefSrc { node: AstNodeExt::to_ptr(&node), name }
     }
 }
 

--- a/crates/hir/src/source_map.rs
+++ b/crates/hir/src/source_map.rs
@@ -2,7 +2,10 @@ use std::{fmt::Debug, hash::Hash};
 
 pub(crate) use la_arena::{ArenaMap, Idx};
 use rustc_hash::FxHashMap;
-use syntax::{SyntaxKind, TokenKind, ast::AstNode};
+use syntax::{
+    SyntaxKind, SyntaxNode, SyntaxToken, SyntaxTokenWithParent, TokenKind, ast::AstNode,
+    has_text_range::HasTextRange,
+};
 pub(crate) use utils::get::Get;
 use utils::{get::GetRef, text_edit::TextRange};
 
@@ -94,6 +97,65 @@ pub trait ToAstNode<'a, Output: AstNode<'a>> {
     fn to_node(&self, tree: &'a syntax::SyntaxTree) -> Option<Output>;
 }
 
+/// AST node that is valid as an IDE source-map location in the parsed root
+/// file.
+///
+/// Slang can expose semantic AST nodes that originate from include or macro
+/// expansion. Those nodes are still valid input for HIR lowering, but they do
+/// not have a stable text range in the root buffer, so they must not become
+/// source-map keys. Use `SourceAst::new` at the HIR allocation/source-map
+/// boundary when HIR should still be allocated but the source-map entry may be
+/// absent.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SourceAst<Ast> {
+    ast: Ast,
+}
+
+impl<'a, Ast> SourceAst<Ast>
+where
+    Ast: AstNode<'a>,
+{
+    /// Returns `None` when the AST node has no root-buffer text range.
+    ///
+    /// Callers should treat that as "no navigable source location", not as a
+    /// lowering failure.
+    pub(crate) fn new(ast: Ast) -> Option<Self> {
+        ast.syntax().text_range()?;
+        Some(Self { ast })
+    }
+
+    pub(crate) fn into_inner(self) -> Ast {
+        self.ast
+    }
+}
+
+/// Conversion from a root-buffer AST node into a source-map key.
+///
+/// `alloc_idx_and_src!` depends on this trait instead of plain `From<ast::...>`
+/// so adding a new source-map entry point requires an explicit implementation
+/// that is checked by `cargo check`. Keep ordinary `From<ast::...>` impls for
+/// lookup paths that already operate on AST nodes under the cursor in the root
+/// file.
+pub(crate) trait FromSourceAst<'a, Ast: AstNode<'a>> {
+    fn from_source_ast(ast: SourceAst<Ast>) -> Self;
+}
+
+/// Attach a bare token returned by generated AST accessors to a root-buffer
+/// context.
+///
+/// Use this inside `FromSourceAst` implementations for optional focus tokens
+/// such as names or keywords. A token from macro/include expansion is not a
+/// valid root-buffer focus range, so callers should leave that field as `None`
+/// while still keeping the enclosing source-map node.
+pub(crate) fn root_token_in<'a>(
+    context: SyntaxNode<'a>,
+    token: SyntaxToken<'a>,
+) -> Option<SyntaxTokenWithParent<'a>> {
+    let token = SyntaxTokenWithParent { parent: context, tok: token };
+    token.text_range()?;
+    Some(token)
+}
+
 #[macro_export]
 macro_rules! define_src {
     ($name:ident(ast::$ty:ident)) => {
@@ -126,6 +188,12 @@ macro_rules! define_src {
         impl From<ast::$ty<'_>> for $name {
             fn from(node: ast::$ty<'_>) -> Self {
                 Self(syntax::slang_ext::AstNodeExt::to_ptr(&node))
+            }
+        }
+
+        impl<'a> $crate::source_map::FromSourceAst<'a, ast::$ty<'a>> for $name {
+            fn from_source_ast(node: $crate::source_map::SourceAst<ast::$ty<'a>>) -> Self {
+                Self(syntax::slang_ext::AstNodeExt::to_ptr(&node.into_inner()))
             }
         }
 
@@ -182,6 +250,12 @@ macro_rules! define_src {
                     Self::$ty(syntax::slang_ext::AstNodeExt::to_ptr(&node))
                 }
             }
+
+            impl<'a> $crate::source_map::FromSourceAst<'a, ast::$ty<'a>> for $name {
+                fn from_source_ast(node: $crate::source_map::SourceAst<ast::$ty<'a>>) -> Self {
+                    Self::$ty(syntax::slang_ext::AstNodeExt::to_ptr(&node.into_inner()))
+                }
+            }
         )*
     };
 }
@@ -231,7 +305,22 @@ macro_rules! define_src_with_name {
                 Self {
                     node: syntax::slang_ext::AstNodeExt::to_ptr(&node),
                     name: <ast::$ty<'_> as syntax::has_name::HasName<'_>>::name(&node)
-                    .map(|name| syntax::ptr::SyntaxTokenPtr::from_token_in(syntax, name)),
+                        .map(|name| syntax::ptr::SyntaxTokenPtr::from_token_in(syntax, name)),
+                }
+            }
+        }
+
+        impl<'a> $crate::source_map::FromSourceAst<'a, ast::$ty<'a>> for $name {
+            fn from_source_ast(node: $crate::source_map::SourceAst<ast::$ty<'a>>) -> Self {
+                let node = node.into_inner();
+                let syntax = syntax::ast::AstNode::syntax(&node);
+                Self {
+                    node: syntax::slang_ext::AstNodeExt::to_ptr(&node),
+                    name: <ast::$ty<'a> as syntax::has_name::HasName<'a>>::name(&node)
+                        .and_then(|name| {
+                            $crate::source_map::root_token_in(syntax, name)
+                                .map(syntax::ptr::SyntaxTokenPtr::from_token)
+                        }),
                 }
             }
         }
@@ -324,6 +413,21 @@ macro_rules! define_src_with_name {
                     }
                 }
             }
+
+            impl<'a> $crate::source_map::FromSourceAst<'a, ast::$ty<'a>> for $name {
+                fn from_source_ast(node: $crate::source_map::SourceAst<ast::$ty<'a>>) -> Self {
+                    let node = node.into_inner();
+                    let syntax = syntax::ast::AstNode::syntax(&node);
+                    Self::$ty {
+                        node: syntax::slang_ext::AstNodeExt::to_ptr(&node),
+                        name: <ast::$ty<'a> as syntax::has_name::HasName<'a>>::name(&node)
+                            .and_then(|name| {
+                                $crate::source_map::root_token_in(syntax, name)
+                                    .map(syntax::ptr::SyntaxTokenPtr::from_token)
+                            }),
+                    }
+                }
+            }
         )*
 
         impl From<$name> for syntax::ptr::SyntaxNodePtr {
@@ -404,6 +508,26 @@ macro_rules! define_src_with_name_and_token {
                     $token: node
                         .$token_getter()
                         .map(|token| syntax::ptr::SyntaxTokenPtr::from_token_in(syntax, token)),
+                }
+            }
+        }
+
+        impl<'a> $crate::source_map::FromSourceAst<'a, ast::$ty<'a>> for $name {
+            fn from_source_ast(node: $crate::source_map::SourceAst<ast::$ty<'a>>) -> Self {
+                let node = node.into_inner();
+                let syntax = syntax::ast::AstNode::syntax(&node);
+                Self {
+                    node: syntax::slang_ext::AstNodeExt::to_ptr(&node),
+                    name: <ast::$ty<'a> as syntax::has_name::HasName<'a>>::name(&node).and_then(
+                        |name| {
+                            $crate::source_map::root_token_in(syntax, name)
+                                .map(syntax::ptr::SyntaxTokenPtr::from_token)
+                        },
+                    ),
+                    $token: node.$token_getter().and_then(|token| {
+                        $crate::source_map::root_token_in(syntax, token)
+                            .map(syntax::ptr::SyntaxTokenPtr::from_token)
+                    }),
                 }
             }
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -22,9 +22,9 @@ use lsp_types::{
         Exit, Notification as _,
     },
     request::{
-        CodeActionRequest, DocumentDiagnosticRequest, DocumentSymbolRequest, FoldingRangeRequest,
-        GotoDefinition, HoverRequest, Request as _, SemanticTokensFullRequest, Shutdown,
-        WorkspaceDiagnosticRequest,
+        CodeActionRequest, CodeLensRequest, CodeLensResolve, DocumentDiagnosticRequest,
+        DocumentSymbolRequest, FoldingRangeRequest, GotoDefinition, HoverRequest, References,
+        Request as _, SemanticTokensFullRequest, Shutdown, WorkspaceDiagnosticRequest,
     },
 };
 use serde::de::DeserializeOwned;
@@ -362,6 +362,36 @@ fn request_goto_definition_uris(
     definition.map(goto_definition_response_uris).unwrap_or_default()
 }
 
+fn request_reference_uris(
+    client: &Connection,
+    uri: Url,
+    text: &str,
+    needle: &str,
+    request_id: i32,
+) -> Vec<Url> {
+    let request_id = lsp_server::RequestId::from(request_id);
+    client
+        .sender
+        .send(Message::Request(Request::new(
+            request_id.clone(),
+            References::METHOD.to_string(),
+            lsp_types::ReferenceParams {
+                text_document_position: TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier { uri },
+                    position: position_of(text, needle),
+                },
+                context: lsp_types::ReferenceContext { include_declaration: true },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: Default::default(),
+            },
+        )))
+        .unwrap();
+
+    let references: Option<Vec<lsp_types::Location>> =
+        recv_response(client, request_id, "references");
+    references.unwrap_or_default().into_iter().map(|location| location.uri).collect()
+}
+
 fn request_workspace_diagnostic_report(
     client: &Connection,
     request_id: i32,
@@ -526,6 +556,42 @@ fn request_code_actions(
         .unwrap();
 
     recv_response(client, request_id, "codeAction")
+}
+
+fn request_code_lenses(client: &Connection, uri: Url, request_id: i32) -> Vec<lsp_types::CodeLens> {
+    let request_id = lsp_server::RequestId::from(request_id);
+    client
+        .sender
+        .send(Message::Request(Request::new(
+            request_id.clone(),
+            CodeLensRequest::METHOD.to_string(),
+            lsp_types::CodeLensParams {
+                text_document: TextDocumentIdentifier { uri },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: Default::default(),
+            },
+        )))
+        .unwrap();
+
+    recv_response(client, request_id, "codeLens")
+}
+
+fn resolve_code_lens(
+    client: &Connection,
+    lens: lsp_types::CodeLens,
+    request_id: i32,
+) -> lsp_types::CodeLens {
+    let request_id = lsp_server::RequestId::from(request_id);
+    client
+        .sender
+        .send(Message::Request(Request::new(
+            request_id.clone(),
+            CodeLensResolve::METHOD.to_string(),
+            lens,
+        )))
+        .unwrap();
+
+    recv_response(client, request_id, "codeLens/resolve")
 }
 
 fn code_action_titles(actions: &[CodeActionOrCommand]) -> Vec<String> {
@@ -2434,6 +2500,59 @@ fn legacy_publish_diagnostics_refreshes_dependent_open_files() {
         second_top_diags.is_empty(),
         "top.sv diagnostics should refresh when child.sv changes: {second_top_diags:?}"
     );
+
+    shutdown_test_server(&client, server_thread);
+}
+
+#[test]
+fn include_expanded_parameter_decls_keep_module_navigation_available() {
+    let temp_dir = TempDir::new("include-param-module-nav");
+    let rtl_dir = temp_dir.path().join("rtl");
+    fs::create_dir_all(&rtl_dir).unwrap();
+
+    let top_text = "module top;\n  child #(.WIDTH(64)) u_child();\nendmodule\n";
+    let child_text = "module child #(\n`include \"params.vh\"\n) ();\nendmodule\n";
+
+    fs::write(
+        temp_dir.path().join("vizsla.toml"),
+        "top_modules = [\"top\"]\nsources = [\"rtl/*.v\"]\ninclude_dirs = [\"rtl\"]\n",
+    )
+    .unwrap();
+    fs::write(rtl_dir.join("params.vh"), "parameter WIDTH = 32\n").unwrap();
+    let top_path = rtl_dir.join("top.v");
+    let child_path = rtl_dir.join("child.v");
+    fs::write(&top_path, top_text).unwrap();
+    fs::write(&child_path, child_text).unwrap();
+
+    let root_path = temp_dir.path().to_path_buf();
+    let (client, server_thread) =
+        spawn_test_workspace(root_path, ClientCapabilities::default(), UserConfig::default());
+    let top_uri = to_proto::url_from_abs_path(top_path.as_path()).unwrap();
+    let child_uri = to_proto::url_from_abs_path(child_path.as_path()).unwrap();
+
+    open_test_document(&client, top_uri.clone(), top_text);
+    open_test_document(&client, child_uri.clone(), child_text);
+    let _ = request_document_diagnostics(&client, top_uri.clone(), 1);
+
+    let definition_uris =
+        request_goto_definition_uris(&client, top_uri.clone(), top_text, "child #", 2);
+    assert!(
+        definition_uris.contains(&child_uri),
+        "go to definition should reach child.v despite include-expanded parameters: {definition_uris:?}"
+    );
+
+    let reference_uris =
+        request_reference_uris(&client, child_uri.clone(), child_text, "child #", 3);
+    assert!(
+        reference_uris.contains(&child_uri) && reference_uris.contains(&top_uri),
+        "references should include the module declaration and instantiation: {reference_uris:?}"
+    );
+
+    let lenses = request_code_lenses(&client, child_uri, 4);
+    let lens = lenses.into_iter().next().expect("child module should have an instance code lens");
+    let resolved = resolve_code_lens(&client, lens, 5);
+    let title = resolved.command.expect("resolved code lens should have a command").title;
+    assert_eq!(title, "1 instance");
 
     shutdown_test_server(&client, server_thread);
 }


### PR DESCRIPTION
Closes https://github.com/pascal-lab/vizsla/issues/39.

Fixes source-map handling for AST nodes that come from include or macro expansion.

HIR lowering can still consume those nodes semantically, but they do not always have a stable text range in the parsed root file. This previously allowed lowering to panic while building source-map entries, which broke go-to-definition, references, and instance code lens.

The fix adds an explicit `SourceAst` / `FromSourceAst` boundary so source maps only store root-buffer locations, while HIR allocation continues normally.