### PR TITLE
fix(build): enable optimized slang release builds

### DIFF
--- a/crates/slang/bindings/rust/build.rs
+++ b/crates/slang/bindings/rust/build.rs
@@ -42,6 +42,18 @@ fn build_cpp_lib(cxxbridge_dir: &Path, debug: bool) -> PathBuf {
         .profile(cmake_profile)
         .define("CMAKE_VERBOSE_MAKEFILE", "ON");
 
+    if !debug && cfg!(target_env = "msvc") {
+        // cmake-rs still sets config-specific MSVC flags for Visual Studio
+        // generators to preserve /MD or /MT. That replaces CMake's built-in
+        // Release defaults, while cmake-rs has already filtered optimization
+        // args out of Cargo's compiler flags. Restore the optimized Release
+        // settings explicitly until cmake-rs can rely on
+        // CMAKE_MSVC_RUNTIME_LIBRARY for this path.
+        config
+            .define("CMAKE_C_FLAGS_RELEASE", "/O2 /Ob2 /DNDEBUG")
+            .define("CMAKE_CXX_FLAGS_RELEASE", "/O2 /Ob2 /DNDEBUG");
+    }
+
     config.build()
 }
 


### PR DESCRIPTION
It seems like a bug coming from upstream. See: https://github.com/rust-lang/cmake-rs/issues/277

Though we can avoid it manually, the best fix may be create a pr in cmake-rs. However the cmake-rs crate seems to be lack of maintainance for long time. 😢

Partially fix https://github.com/pascal-lab/vizsla/issues/49. 

The metric comparison with release build in MSVC:

| Scenario | Config | Time | Diagnostics | Notes |
|---|---:|---:|---:|---|
| Old release, C++ not optimized | default | ~82.0s | 49,690 | slang C++ Release flags missed `/O2` |
| C++ optimized, after this PR | default | ~16.6s | 49,690 | Still repeated parse/compile and default warning behavior was too broad |