### PR TITLE
fix(lsp): avoid duplicate slang diagnostics work

### DIFF
--- a/crates/base-db/src/source_db.rs
+++ b/crates/base-db/src/source_db.rs
@@ -117,6 +117,15 @@ struct SourceFileIdentity {
     path: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompilationDiagnostic {
+    /// File attribution after mapping slang source buffers back to VFS files.
+    pub file_id: FileId,
+    /// The compilation phase that produced the diagnostic.
+    pub source: DiagnosticSource,
+    pub diagnostic: SyntaxDiagnostic,
+}
+
 fn source_file_identity(db: &dyn SourceDb, file_id: FileId) -> SourceFileIdentity {
     let path = db.file_path(file_id).map(|path| path.to_string()).unwrap_or_default();
     let name = if path.is_empty() { "source".to_owned() } else { path.clone() };
@@ -258,6 +267,14 @@ pub trait SourceRootDb: SourceDb {
         &self,
         profile_id: Option<CompilationProfileId>,
     ) -> Arc<CompilationPlan>;
+    /// Diagnostics produced by one slang compilation profile. This is the
+    /// semantic diagnostics path, but it also returns parse diagnostics from
+    /// the same syntax trees so one request does not parse the same roots
+    /// twice.
+    fn compilation_profile_diagnostics(
+        &self,
+        profile_id: CompilationProfileId,
+    ) -> Arc<[CompilationDiagnostic]>;
     fn include_buffers_for_profile(
         &self,
         profile_id: Option<CompilationProfileId>,
@@ -269,6 +286,8 @@ pub trait SourceRootDb: SourceDb {
         offset: TextSize,
     ) -> Arc<[ParserExpectedSyntax]>;
     fn parse_diagnostics(&self, file_id: FileId) -> Arc<[SyntaxDiagnostic]>;
+    /// Diagnostics for the compilation profile that owns `file_id`.
+    fn file_compilation_diagnostics(&self, file_id: FileId) -> Arc<[CompilationDiagnostic]>;
     fn semantic_diagnostics(&self, file_id: FileId) -> Arc<[SyntaxDiagnostic]>;
     fn source_root_semantic_diagnostics(
         &self,
@@ -331,20 +350,33 @@ fn semantic_diagnostics(db: &dyn SourceRootDb, file_id: FileId) -> Arc<[SyntaxDi
     )
 }
 
-fn source_root_semantic_diagnostics(
+fn file_compilation_diagnostics(
     db: &dyn SourceRootDb,
     file_id: FileId,
-) -> Arc<[(FileId, SyntaxDiagnostic)]> {
+) -> Arc<[CompilationDiagnostic]> {
     let source_root_id = db.source_root_id(file_id);
     let config = db.diagnostics_config();
     if !config.enabled || !config.semantic.enabled || db.file_is_project_ignored(file_id) {
-        return Arc::from(Vec::<(FileId, SyntaxDiagnostic)>::new());
+        return Arc::from(Vec::<CompilationDiagnostic>::new());
     }
 
     let project_config = db.project_config();
     let Some(profile_id) = project_config.profile_for_root(source_root_id) else {
-        return Arc::from(Vec::<(FileId, SyntaxDiagnostic)>::new());
+        return Arc::from(Vec::<CompilationDiagnostic>::new());
     };
+    db.compilation_profile_diagnostics(profile_id)
+}
+
+fn compilation_profile_diagnostics(
+    db: &dyn SourceRootDb,
+    profile_id: CompilationProfileId,
+) -> Arc<[CompilationDiagnostic]> {
+    let config = db.diagnostics_config();
+    if !config.enabled || !config.semantic.enabled {
+        return Arc::from(Vec::<CompilationDiagnostic>::new());
+    }
+
+    let project_config = db.project_config();
     let plan = db.compilation_plan_for_profile(Some(profile_id));
     let compilation_include_buffers =
         compilation_plan::compilation_source_buffers_for_plan(db, &plan);
@@ -376,18 +408,59 @@ fn source_root_semantic_diagnostics(
         insert_buffer_file_ids(&mut buffer_file_ids, &path_file_ids, buffer_ids, file_id);
     }
 
-    let diagnostics = compilation
-        .semantic_diagnostics_with_options(&config.slang.warnings)
-        .into_iter()
-        .filter_map(|diag| {
-            let diag_file_id =
-                diag.buffer_id.and_then(|buffer_id| buffer_file_ids.get(&buffer_id).copied())?;
-            let diag = config.apply_rules(DiagnosticSource::Semantic, diag)?;
-            Some((diag_file_id, diag))
-        })
-        .collect::<Vec<_>>();
+    let mut diagnostics = Vec::new();
+    if config.parse.enabled {
+        diagnostics.extend(
+            compilation
+                .parse_diagnostics_with_options(&config.slang.warnings)
+                .into_iter()
+                .filter_map(|diag| {
+                    let diag_file_id = diag
+                        .buffer_id
+                        .and_then(|buffer_id| buffer_file_ids.get(&buffer_id).copied())?;
+                    let diag = config.apply_rules(DiagnosticSource::Parse, diag)?;
+                    Some(CompilationDiagnostic {
+                        file_id: diag_file_id,
+                        source: DiagnosticSource::Parse,
+                        diagnostic: diag,
+                    })
+                }),
+        );
+    }
+
+    diagnostics.extend(
+        compilation
+            .semantic_diagnostics_with_options(&config.slang.warnings)
+            .into_iter()
+            .filter_map(|diag| {
+                let diag_file_id = diag
+                    .buffer_id
+                    .and_then(|buffer_id| buffer_file_ids.get(&buffer_id).copied())?;
+                let diag = config.apply_rules(DiagnosticSource::Semantic, diag)?;
+                Some(CompilationDiagnostic {
+                    file_id: diag_file_id,
+                    source: DiagnosticSource::Semantic,
+                    diagnostic: diag,
+                })
+            }),
+    );
 
     Arc::from(diagnostics)
+}
+
+fn source_root_semantic_diagnostics(
+    db: &dyn SourceRootDb,
+    file_id: FileId,
+) -> Arc<[(FileId, SyntaxDiagnostic)]> {
+    Arc::from(
+        db.file_compilation_diagnostics(file_id)
+            .iter()
+            .filter_map(|diag| {
+                (diag.source == DiagnosticSource::Semantic)
+                    .then_some((diag.file_id, diag.diagnostic.clone()))
+            })
+            .collect::<Vec<_>>(),
+    )
 }
 
 #[cfg(test)]

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -1,4 +1,5 @@
 use base_db::{
+    diagnostics_config::DiagnosticSource as SlangDiagnosticSource,
     source_db::{SourceDb, SourceRootDb},
     source_root::{SourceRootDiagnosticScope, SourceRootRole},
 };
@@ -78,45 +79,52 @@ impl VizslaDiagnosticDescriptor {
 pub(crate) fn parse_diagnostics(db: &RootDb, file_id: FileId) -> Vec<Diagnostic> {
     db.parse_diagnostics(file_id)
         .iter()
-        .map(|diag| Diagnostic {
-            file_id,
-            code: diag.code,
-            subsystem: diag.subsystem,
-            name: diag.name.clone(),
-            option_name: diag.option_name.clone(),
-            groups: diag.groups.clone(),
-            source: DiagnosticSource::SlangParse,
-            range: to_text_range(diag),
-            severity: diag.severity,
-            message: diag.message.clone(),
-            message_key: None,
-            message_args: Vec::new(),
-        })
+        .map(|diag| slang_diagnostic(file_id, SlangDiagnosticSource::Parse, diag))
         .collect()
 }
 
+fn compilation_diagnostics(db: &RootDb, file_id: FileId) -> Vec<Diagnostic> {
+    db.file_compilation_diagnostics(file_id)
+        .iter()
+        .map(|diag| slang_diagnostic(diag.file_id, diag.source, &diag.diagnostic))
+        .collect()
+}
+
+fn slang_diagnostic(
+    file_id: FileId,
+    source: SlangDiagnosticSource,
+    diag: &SyntaxDiagnostic,
+) -> Diagnostic {
+    Diagnostic {
+        file_id,
+        code: diag.code,
+        subsystem: diag.subsystem,
+        name: diag.name.clone(),
+        option_name: diag.option_name.clone(),
+        groups: diag.groups.clone(),
+        source: match source {
+            SlangDiagnosticSource::Parse => DiagnosticSource::SlangParse,
+            SlangDiagnosticSource::Semantic => DiagnosticSource::SlangSemantic,
+        },
+        range: to_text_range(diag),
+        severity: diag.severity,
+        message: diag.message.clone(),
+        message_key: None,
+        message_args: Vec::new(),
+    }
+}
+
 pub(crate) fn diagnostics(db: &RootDb, file_id: FileId) -> Vec<Diagnostic> {
-    let mut diagnostics = parse_diagnostics(db, file_id);
+    let mut diagnostics = if slang_semantic_diagnostics_active(db, file_id) {
+        Vec::new()
+    } else {
+        parse_diagnostics(db, file_id)
+    };
     diagnostics.extend(vizsla_diagnostics(db, file_id));
 
-    diagnostics.extend(db.source_root_semantic_diagnostics(file_id).iter().filter_map(
-        |(diag_file_id, diag)| {
-            (*diag_file_id == file_id).then_some(Diagnostic {
-                file_id: *diag_file_id,
-                code: diag.code,
-                subsystem: diag.subsystem,
-                name: diag.name.clone(),
-                option_name: diag.option_name.clone(),
-                groups: diag.groups.clone(),
-                source: DiagnosticSource::SlangSemantic,
-                range: to_text_range(diag),
-                severity: diag.severity,
-                message: diag.message.clone(),
-                message_key: None,
-                message_args: Vec::new(),
-            })
-        },
-    ));
+    diagnostics.extend(
+        compilation_diagnostics(db, file_id).into_iter().filter(|diag| diag.file_id == file_id),
+    );
 
     diagnostics
 }
@@ -136,27 +144,20 @@ pub(crate) fn source_root_diagnostics(db: &RootDb, file_id: FileId) -> Vec<Diagn
 
     let mut diagnostics = Vec::new();
 
-    for file_id in source_root.iter() {
-        diagnostics.extend(parse_diagnostics(db, file_id));
-        diagnostics.extend(vizsla_diagnostics(db, file_id));
-    }
+    if slang_semantic_diagnostics_active(db, file_id) {
+        diagnostics.extend(compilation_diagnostics(db, file_id));
+    } else {
+        for file_id in source_root.iter() {
+            diagnostics.extend(parse_diagnostics(db, file_id));
+            diagnostics.extend(vizsla_diagnostics(db, file_id));
+        }
 
-    diagnostics.extend(db.source_root_semantic_diagnostics(file_id).iter().map(
-        |(diag_file_id, diag)| Diagnostic {
-            file_id: *diag_file_id,
-            code: diag.code,
-            subsystem: diag.subsystem,
-            name: diag.name.clone(),
-            option_name: diag.option_name.clone(),
-            groups: diag.groups.clone(),
-            source: DiagnosticSource::SlangSemantic,
-            range: to_text_range(diag),
-            severity: diag.severity,
-            message: diag.message.clone(),
-            message_key: None,
-            message_args: Vec::new(),
-        },
-    ));
+        diagnostics.extend(db.source_root_semantic_diagnostics(file_id).iter().map(
+            |(diag_file_id, diag)| {
+                slang_diagnostic(*diag_file_id, SlangDiagnosticSource::Semantic, diag)
+            },
+        ));
+    }
 
     diagnostics
 }

--- a/crates/slang/bindings/rust/ffi.rs
+++ b/crates/slang/bindings/rust/ffi.rs
@@ -473,6 +473,12 @@ mod slang_ffi {
         fn Compilation_semantic_diagnostics(compilation: &Compilation) -> Vec<RawSyntaxDiagnostic>;
 
         #[namespace = "wrapper::ast"]
+        fn Compilation_parse_diagnostics_with_options(
+            compilation: &Compilation,
+            warning_options: Vec<String>,
+        ) -> Vec<RawSyntaxDiagnostic>;
+
+        #[namespace = "wrapper::ast"]
         fn Compilation_semantic_diagnostics_with_options(
             compilation: &Compilation,
             warning_options: Vec<String>,
@@ -652,6 +658,7 @@ impl_functions! {
         fn add_syntax_tree_from_text(self_: Pin<&mut Compilation>, text: CxxSV, name: CxxSV, path: CxxSV, predefines: Vec<String>, include_paths: Vec<String>, include_buffers: Vec<RawSourceBuffer>, expand_includes: bool) -> RawSyntaxTreeBufferIds |> Compilation_add_syntax_tree_from_text;
         fn add_library_map_syntax_tree_from_text(self_: Pin<&mut Compilation>, text: CxxSV, name: CxxSV, path: CxxSV) -> RawSyntaxTreeBufferIds |> Compilation_add_library_map_syntax_tree_from_text;
         fn semantic_diagnostics(&self) -> Vec<RawSyntaxDiagnostic> |> Compilation_semantic_diagnostics;
+        fn parse_diagnostics_with_options(&self, warning_options: Vec<String>) -> Vec<RawSyntaxDiagnostic> |> Compilation_parse_diagnostics_with_options;
         fn semantic_diagnostics_with_options(&self, warning_options: Vec<String>) -> Vec<RawSyntaxDiagnostic> |> Compilation_semantic_diagnostics_with_options;
     }
 }

--- a/crates/slang/bindings/rust/ffi/wrapper.cc
+++ b/crates/slang/bindings/rust/ffi/wrapper.cc
@@ -26,8 +26,7 @@ std::string source_manager_path_key(std::string_view path) {
 
 void apply_warning_options(slang::DiagnosticEngine& engine,
                            const rust::Vec<rust::String>& warning_options) {
-  if (warning_options.empty())
-    return;
+  engine.setDefaultWarnings();
 
   auto options = to_std_strings(warning_options);
   (void)engine.setWarningOptions(options);
@@ -606,6 +605,23 @@ rust::Vec<::RawSyntaxDiagnostic> Compilation_semantic_diagnostics(const Compilat
   if (!source_manager)
     return {};
   slang::DiagnosticEngine engine(*source_manager);
+  rust::Vec<::RawSyntaxDiagnostic> rust_diags;
+  rust_diags.reserve(diags.size());
+  for (const auto& diag : diags)
+    rust_diags.emplace_back(to_rust_syntax_diagnostic(diag, engine, *source_manager));
+  return rust_diags;
+}
+
+rust::Vec<::RawSyntaxDiagnostic> Compilation_parse_diagnostics_with_options(
+    const Compilation& compilation,
+    rust::Vec<rust::String> warning_options) {
+  auto& inner = const_cast<Compilation&>(compilation).inner();
+  auto& diags = inner.getParseDiagnostics();
+  auto source_manager = inner.getSourceManager();
+  if (!source_manager)
+    return {};
+  slang::DiagnosticEngine engine(*source_manager);
+  apply_warning_options(engine, warning_options);
   rust::Vec<::RawSyntaxDiagnostic> rust_diags;
   rust_diags.reserve(diags.size());
   for (const auto& diag : diags)

--- a/crates/slang/bindings/rust/ffi/wrapper.h
+++ b/crates/slang/bindings/rust/ffi/wrapper.h
@@ -610,6 +610,9 @@ namespace wrapper {
         std::string_view path);
 
     rust::Vec<::RawSyntaxDiagnostic> Compilation_semantic_diagnostics(const Compilation& compilation);
+    rust::Vec<::RawSyntaxDiagnostic> Compilation_parse_diagnostics_with_options(
+        const Compilation& compilation,
+        rust::Vec<rust::String> warning_options);
     rust::Vec<::RawSyntaxDiagnostic> Compilation_semantic_diagnostics_with_options(
         const Compilation& compilation,
         rust::Vec<rust::String> warning_options);

--- a/crates/slang/bindings/rust/lib.rs
+++ b/crates/slang/bindings/rust/lib.rs
@@ -1456,6 +1456,17 @@ impl Compilation {
         self._ptr.semantic_diagnostics().into_iter().map(SyntaxDiagnostic::from_raw).collect()
     }
 
+    pub fn parse_diagnostics_with_options(
+        &self,
+        warning_options: &[String],
+    ) -> Vec<SyntaxDiagnostic> {
+        self._ptr
+            .parse_diagnostics_with_options(warning_options.to_vec())
+            .into_iter()
+            .map(SyntaxDiagnostic::from_raw)
+            .collect()
+    }
+
     pub fn semantic_diagnostics_with_options(
         &self,
         warning_options: &[String],


### PR DESCRIPTION
This enable `setDefaultWarnings()` in slang so that there won't be THAT MUCH warnings in diagnostics, which (partially?) fixes https://github.com/pascal-lab/vizsla/issues/35.

After the C++ build optimization, the remaining overhead came from the LSP diagnostics path parsing the same compilation roots more than once and from Rust bindings not initializing slang’s default warning group. 

Before:

```text
textDocument/diagnostic
  |
  +-- parse_diagnostics(file)
  |     |
  |     +-- build include plan / preproc index
  |     +-- parse root for syntax diagnostics
  |
  +-- source_root_semantic_diagnostics(file)
        |
        +-- build same profile compilation
        +-- parse root again into Compilation
        +-- get semantic diagnostics
```

After:

```text
textDocument/diagnostic
  |
  +-- compilation_profile_diagnostics(profile)
        |
        +-- build include plan / preproc index
        +-- parse roots once into Compilation
        |
        +-- Compilation::getParseDiagnostics()
        +-- Compilation::getSemanticDiagnostics()
```

The new path makes profile-level slang compilation the source of truth for both parse and semantic diagnostics, while preserving explicit warning configuration such as `warnings=["everything"]`, and it (partially? again) fixes https://github.com/pascal-lab/vizsla/issues/49.

The performance metric:

| Scenario | Config | Time | Diagnostics | Notes |
|---|---:|---:|---:|---|
| Old release, C++ not optimized | default | ~82.0s | 49,690 | slang C++ Release flags missed `/O2` |
| C++ optimized, after #103 | default | ~16.6s | 49,690 | Still repeated parse/compile and default warning behavior was too broad |
| After this PR | default | ~9.8s | 0 | Uses slang default warning group |
| After this PR | `warnings=["everything"]` | ~10.4s | 49,690 | Explicit all-warnings mode still reports the full set |


