### PR TITLE
fix(lsp): escape system task completion snippets

### DIFF
--- a/crates/ide/src/completion/engine/system.rs
+++ b/crates/ide/src/completion/engine/system.rs
@@ -32,11 +32,12 @@ fn collect_system_subroutines(
         .iter()
         .filter(|name| name.starts_with(prefix))
         .map(|name| {
+            let snippet_name = name.replacen('$', r"\$", 1);
             CompletionCandidate::semantic_snippet(
                 name.clone(),
                 ctx.replacement,
                 format!("{name}()"),
-                format!("{name}(${{1:args}})"),
+                format!("{snippet_name}(${{1:args}})"),
             )
         })
         .collect()

--- a/crates/ide/src/completion/engine/tests.rs
+++ b/crates/ide/src/completion/engine/tests.rs
@@ -389,6 +389,18 @@ fn statement_completion_uses_slang_system_task_facts() {
 }
 
 #[test]
+fn system_task_snippet_preserves_dollar_prefixed_name() {
+    let items =
+        completions_in_text("module m; initial begin\n  $di/*caret*/\nend endmodule\n", None);
+    let display = items.iter().find(|item| item.label == "$display").unwrap();
+    let mut text = "module m; initial begin\n  $di\nend endmodule\n".to_string();
+
+    display.snippet_edit.as_ref().unwrap().apply_on(&mut text);
+
+    assert_eq!(text, "module m; initial begin\n  \\$display(${1:args})\nend endmodule\n");
+}
+
+#[test]
 fn standalone_dollar_completion_suggests_system_tasks_and_functions() {
     let items = completions_in_text("module m; initial begin\n  $/*caret*/\nend endmodule\n", None);
     let item_labels = labels(&items);


### PR DESCRIPTION
﻿Closes #100 by escaping the leading `$` in system task completion snippets so VS Code does not treat the task name as a snippet variable.
Without the escape, accepting `$display` expands the snippet variable to empty text and leaves only the argument placeholder.
