### PR TITLE
fix(lsp): resolve named instance connections

### DIFF
--- a/crates/hir/src/semantics/pathres.rs
+++ b/crates/hir/src/semantics/pathres.rs
@@ -1,8 +1,4 @@
-use syntax::{
-    SyntaxNode, SyntaxToken, SyntaxTokenWithParent,
-    ast::{self, AstNode},
-};
-use utils::get::GetRef;
+use syntax::{SyntaxNode, SyntaxTokenWithParent};
 
 use super::SemanticsImpl;
 use crate::{
@@ -12,8 +8,7 @@ use crate::{
     file::HirFileId,
     hir_def::{
         block::BlockId,
-        declaration::Declaration,
-        expr::declarator::{DeclId, DeclaratorParent},
+        expr::declarator::DeclId,
         file::{config::ConfigDeclId, library::LibraryDeclId, udp::UdpDeclId},
         lower_ident_opt,
         module::{
@@ -37,60 +32,6 @@ impl SemanticsImpl<'_> {
             let container = ctx.find_container(InFile::new(file_id, parent));
             ctx.name_to_def(InContainer::new(container, ident))
         })
-    }
-
-    pub fn nameres_named_port_conn(
-        &self,
-        conn: ast::NamedPortConnection,
-    ) -> Option<PathResolution> {
-        let entry = self.nameres_instance_conn(conn.name(), conn.syntax())?;
-
-        if matches!(entry.value, ModuleEntry::AnsiPortEntry(_) | ModuleEntry::NonAnsiPortEntry(_)) {
-            Some(entry.into())
-        } else {
-            None
-        }
-    }
-
-    pub fn nameres_named_param_assign(
-        &self,
-        conn: ast::NamedParamAssignment,
-    ) -> Option<PathResolution> {
-        let entry = self.nameres_instance_conn(conn.name(), conn.syntax())?;
-        let module = self.db.module(entry.module_id);
-        if let ModuleEntry::DeclId(decl_id) = entry.value
-            && let DeclaratorParent::DeclarationId(declaration_id) = module.get(decl_id).parent
-            && let Declaration::ParamDecl(_) = module.get(declaration_id)
-        {
-            Some(entry.into())
-        } else {
-            None
-        }
-    }
-
-    fn nameres_instance_conn(
-        &self,
-        name: Option<SyntaxToken>,
-        node: SyntaxNode,
-    ) -> Option<InModule<ModuleEntry>> {
-        let db = self.db;
-        let conn_name = lower_ident_opt(name)?;
-
-        let instantiation = ast::HierarchyInstantiation::cast(node.parent()?.parent()?)?;
-        let module_id = self.nameres_instantiation(instantiation)?;
-
-        let module_scope = db.module_scope(module_id);
-        let entry = module_scope.get(&conn_name)?;
-
-        Some(InModule::new(module_id, entry))
-    }
-
-    pub fn nameres_instantiation(
-        &self,
-        instantiation: ast::HierarchyInstantiation,
-    ) -> Option<ModuleId> {
-        let module_name = lower_ident_opt(instantiation.type_())?;
-        self.db.unit_scope().resolve_module(&module_name).unique()
     }
 
     pub(in crate::semantics) fn find_container(&self, node: InFile<SyntaxNode>) -> ContainerId {

--- a/crates/hir/src/semantics/resolver.rs
+++ b/crates/hir/src/semantics/resolver.rs
@@ -50,7 +50,7 @@ impl SemanticsImpl<'_> {
         Some(InModule::new(module_id, instantiation_id))
     }
 
-    pub fn resolve_named_port_conn(
+    pub fn resolve_port_connection(
         &self,
         file_id: HirFileId,
         conn: ast::PortConnection,

--- a/crates/ide/src/definitions.rs
+++ b/crates/ide/src/definitions.rs
@@ -37,7 +37,10 @@ use utils::{
     line_index::TextRange,
 };
 
-use crate::module_resolution::{ModuleResolution, resolve_instantiation_target};
+use crate::module_resolution::{
+    ModuleResolution, resolve_instantiation_target, resolve_named_param_assignment,
+    resolve_named_port_connection,
+};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum DefinitionOrigin {
@@ -447,10 +450,12 @@ impl DefinitionClass {
 
         let res = match_ast! { parent,
             ast::NamedParamAssignment[it] if it.name() == Some(tok) => {
-                sema.nameres_named_param_assign(it).map(Definition::from)?.into()
+                resolve_named_param_assignment(sema.db, file_id.file_id(), it)
+                    .map(Definition::from)?.into()
             },
             ast::NamedPortConnection[it] if it.name() == Some(tok) => {
-                let port = sema.nameres_named_port_conn(it).map(Definition::from);
+                let port = resolve_named_port_connection(sema.db, file_id.file_id(), it)
+                    .map(Definition::from);
 
                 if it.open_paren().is_none() && it.close_paren().is_none() {
                     let local = sema.nameres_ident(file_id, tp).map(Definition::from);

--- a/crates/ide/src/module_resolution.rs
+++ b/crates/ide/src/module_resolution.rs
@@ -2,12 +2,20 @@ use std::cmp::Ordering;
 
 use base_db::{source_db::SourceRootDb, source_root::SourceRootRole};
 use hir::{
+    container::InModule,
     db::HirDb,
-    hir_def::{Ident, module::ModuleId},
-    scope::ScopeResolution,
+    hir_def::{
+        Ident, declaration::Declaration, expr::declarator::DeclaratorParent, module::ModuleId,
+    },
+    scope::{ModuleEntry, ScopeResolution},
+    semantics::pathres::PathResolution,
 };
 use ide_db::root_db::RootDb;
-use syntax::ast;
+use syntax::{
+    SyntaxAncestors,
+    ast::{self, AstNode},
+};
+use utils::get::GetRef;
 use vfs::{FileId, VfsPath};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -52,6 +60,79 @@ pub(crate) fn resolve_module_name(
 ) -> ModuleResolution {
     let policy = ModuleResolutionPolicy::for_file(db, from_file);
     resolve_module_name_with_policy(db, name, policy)
+}
+
+pub(crate) fn resolve_named_port_connection(
+    db: &RootDb,
+    from_file: FileId,
+    conn: ast::NamedPortConnection,
+) -> Option<PathResolution> {
+    let name = hir::hir_def::lower_ident_opt(conn.name())?;
+    let instantiation =
+        SyntaxAncestors::start_from(conn.syntax()).find_map(ast::HierarchyInstantiation::cast)?;
+    resolve_named_port_in_instantiation(db, from_file, instantiation, &name)
+}
+
+pub(crate) fn resolve_named_param_assignment(
+    db: &RootDb,
+    from_file: FileId,
+    assign: ast::NamedParamAssignment,
+) -> Option<PathResolution> {
+    let name = hir::hir_def::lower_ident_opt(assign.name())?;
+    let instantiation =
+        SyntaxAncestors::start_from(assign.syntax()).find_map(ast::HierarchyInstantiation::cast)?;
+    resolve_named_param_in_instantiation(db, from_file, instantiation, &name)
+}
+
+fn resolve_named_port_in_instantiation(
+    db: &RootDb,
+    from_file: FileId,
+    instantiation: ast::HierarchyInstantiation,
+    port_name: &Ident,
+) -> Option<PathResolution> {
+    let target_module_id = resolve_instantiation_target(db, from_file, instantiation).unique()?;
+    resolve_named_port_in_module(db, target_module_id, port_name)
+}
+
+fn resolve_named_param_in_instantiation(
+    db: &RootDb,
+    from_file: FileId,
+    instantiation: ast::HierarchyInstantiation,
+    param_name: &Ident,
+) -> Option<PathResolution> {
+    let target_module_id = resolve_instantiation_target(db, from_file, instantiation).unique()?;
+    resolve_named_param_in_module(db, target_module_id, param_name)
+}
+
+fn resolve_named_port_in_module(
+    db: &RootDb,
+    module_id: ModuleId,
+    port_name: &Ident,
+) -> Option<PathResolution> {
+    let entry = db.module_scope(module_id).get(port_name)?;
+    if matches!(entry, ModuleEntry::AnsiPortEntry(_) | ModuleEntry::NonAnsiPortEntry(_)) {
+        Some(PathResolution::from(InModule::new(module_id, entry)))
+    } else {
+        None
+    }
+}
+
+fn resolve_named_param_in_module(
+    db: &RootDb,
+    module_id: ModuleId,
+    param_name: &Ident,
+) -> Option<PathResolution> {
+    let ModuleEntry::DeclId(decl_id) = db.module_scope(module_id).get(param_name)? else {
+        return None;
+    };
+    let module = db.module(module_id);
+    if let DeclaratorParent::DeclarationId(declaration_id) = module.get(decl_id).parent
+        && let Declaration::ParamDecl(_) = module.get(declaration_id)
+    {
+        Some(PathResolution::ParamDecl(InModule::new(module_id, decl_id)))
+    } else {
+        None
+    }
 }
 
 fn resolve_module_name_with_policy(
@@ -198,10 +279,12 @@ fn dir_ancestors(path: VfsPath) -> Vec<VfsPath> {
 
 #[cfg(test)]
 mod tests {
-    use base_db::{change::Change, source_root::SourceRoot};
+    use base_db::{change::Change, source_db::SourceDb, source_root::SourceRoot};
+    use hir::{container::InModule, semantics::pathres::PathResolution};
     use smol_str::SmolStr;
+    use syntax::{SyntaxNodeExt, ast};
     use triomphe::Arc;
-    use utils::lines::LineEnding;
+    use utils::{lines::LineEnding, text_edit::TextSize};
     use vfs::{ChangeKind, ChangedFile, FileId, FileSet};
 
     use super::*;
@@ -248,6 +331,76 @@ mod tests {
 
         assert_eq!(module_id.file_id.file_id(), FileId(0));
         assert_eq!(candidates.len(), 2);
+    }
+
+    #[test]
+    fn named_port_resolution_uses_same_proximity_policy_as_module_resolution() {
+        let top = "module top; child #(.WIDTH(1)) u(.a(sig)); endmodule\n";
+        let db = db_with_root(
+            &[
+                (
+                    "/project/a/child.sv",
+                    "module child #(parameter WIDTH = 1) (input wire a); endmodule\n",
+                ),
+                ("/project/a/top.sv", top),
+                (
+                    "/project/b/child.sv",
+                    "module child #(parameter WIDTH = 1) (input wire a); endmodule\n",
+                ),
+            ],
+            SourceRoot::new_best_effort_index,
+        );
+
+        let tree = db.parse_src(FileId(1));
+        let root = tree.root().expect("test source should parse");
+        let port_conn = root
+            .find_node_at_offset::<ast::NamedPortConnection>(TextSize::from(
+                top.find(".a").unwrap() as u32 + 1,
+            ))
+            .expect("named port connection should parse");
+
+        let Some(PathResolution::AnsiPort(InModule { module_id, .. })) =
+            resolve_named_port_connection(&db, FileId(1), port_conn)
+        else {
+            panic!("expected named port connection to resolve to nearest child port");
+        };
+
+        assert_eq!(module_id.file_id.file_id(), FileId(0));
+    }
+
+    #[test]
+    fn named_param_resolution_uses_same_proximity_policy_as_module_resolution() {
+        let top = "module top; child #(.WIDTH(1)) u(.a(sig)); endmodule\n";
+        let db = db_with_root(
+            &[
+                (
+                    "/project/a/child.sv",
+                    "module child #(parameter WIDTH = 1) (input wire a); endmodule\n",
+                ),
+                ("/project/a/top.sv", top),
+                (
+                    "/project/b/child.sv",
+                    "module child #(parameter WIDTH = 1) (input wire a); endmodule\n",
+                ),
+            ],
+            SourceRoot::new_best_effort_index,
+        );
+
+        let tree = db.parse_src(FileId(1));
+        let root = tree.root().expect("test source should parse");
+        let param_assign = root
+            .find_node_at_offset::<ast::NamedParamAssignment>(TextSize::from(
+                top.find(".WIDTH").unwrap() as u32 + 1,
+            ))
+            .expect("named parameter assignment should parse");
+
+        let Some(PathResolution::ParamDecl(InModule { module_id, .. })) =
+            resolve_named_param_assignment(&db, FileId(1), param_assign)
+        else {
+            panic!("expected named parameter assignment to resolve to nearest child parameter");
+        };
+
+        assert_eq!(module_id.file_id.file_id(), FileId(0));
     }
 
     #[test]

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -138,7 +138,7 @@ fn edits_from_refs(
                     }
                     (None, None) => {
                         if let Some(port_conn) = ast::PortConnection::cast(it.syntax()) {
-                            if let Some(ref_container) = sema.resolve_named_port_conn(hir_file_id, port_conn)
+                            if let Some(ref_container) = sema.resolve_port_connection(hir_file_id, port_conn)
                                 && def
                                     .container_id(sema.db)
                                     .is_some_and(|id| id == ref_container.module_id.into())

--- a/crates/ide/src/semantic_tokens.rs
+++ b/crates/ide/src/semantic_tokens.rs
@@ -16,16 +16,18 @@ use hir::{
     },
     scope::NonAnsiPortEntry,
     semantics::{Semantics, pathres::PathResolution},
-    source_map::{IsNamedSrc, IsSrc},
+    source_map::{IsNamedSrc, IsSrc, ToAstNode},
 };
 use ide_db::root_db::RootDb;
 use smol_str::SmolStr;
-use syntax::has_text_range::HasTextRange;
+use syntax::{ast, has_text_range::HasTextRange};
 use utils::{
     get::{Get, GetRef},
     text_edit::TextRange,
 };
 use vfs::FileId;
+
+use crate::module_resolution::{resolve_named_param_assignment, resolve_named_port_connection};
 
 mod collector;
 mod port;
@@ -240,34 +242,8 @@ fn collect_module(
         };
     }
 
-    for (param_assign_id, param_assign) in module.inst_param_assigns.iter() {
-        let Some(range) = module_src_map.get(param_assign_id).and_then(|src| src.name_range())
-        else {
-            continue;
-        };
-        check_range!(collector, range);
-
-        match param_assign {
-            ParamAssign::Named(Some(name), _) => {
-                check_range!(collector, range);
-                collect_ident_like(name, range, collector);
-            }
-            ParamAssign::Named(..) | ParamAssign::Ordered(_) => {}
-        }
-    }
-
-    for (conn_id, conn) in module.inst_port_conns.iter() {
-        match conn {
-            PortConn::Named(Some(name), _) => {
-                let Some(range) = module_src_map.get(conn_id).map(|src| src.range()) else {
-                    continue;
-                };
-                check_range!(collector, range);
-                collect_ident_like(name, range, collector);
-            }
-            PortConn::Named(..) | PortConn::Empty | PortConn::Ordered(_) | PortConn::Wildcard => {}
-        }
-    }
+    collect_named_param_assignments(sema, module_id, collector);
+    collect_named_port_connections(sema, module_id, collector);
 
     for (expr_id, expr) in module.exprs.iter() {
         match expr {
@@ -378,14 +354,89 @@ fn collect_block(
     }
 }
 
+fn collect_named_port_connections(
+    sema: &Semantics<'_, RootDb>,
+    module_id: ModuleId,
+    collector: &mut SemaTokenCollector,
+) {
+    let db = sema.db;
+    let (module, module_src_map) = db.module_with_source_map(module_id);
+    let (module, module_src_map) = (module.as_ref(), module_src_map.as_ref());
+    let tree = db.parse(module_id.file_id);
+
+    for (conn_id, conn) in module.inst_port_conns.iter() {
+        let PortConn::Named(Some(_), _) = conn else {
+            continue;
+        };
+        let Some(src) = module_src_map.get(conn_id) else {
+            continue;
+        };
+        let Some(range) = src.name_range() else {
+            continue;
+        };
+        check_range!(collector, range);
+
+        let Some(named) =
+            src.to_node(&tree).and_then(ast::PortConnection::as_named_port_connection)
+        else {
+            continue;
+        };
+        if let Some(res) = resolve_named_port_connection(db, module_id.file_id.file_id(), named) {
+            collect_resolved_path(sema, res, range, collector);
+        }
+    }
+}
+
+fn collect_named_param_assignments(
+    sema: &Semantics<'_, RootDb>,
+    module_id: ModuleId,
+    collector: &mut SemaTokenCollector,
+) {
+    let db = sema.db;
+    let (module, module_src_map) = db.module_with_source_map(module_id);
+    let (module, module_src_map) = (module.as_ref(), module_src_map.as_ref());
+    let tree = db.parse(module_id.file_id);
+
+    for (assign_id, assign) in module.inst_param_assigns.iter() {
+        let ParamAssign::Named(Some(_), _) = assign else {
+            continue;
+        };
+        let Some(src) = module_src_map.get(assign_id) else {
+            continue;
+        };
+        let Some(range) = src.name_range() else {
+            continue;
+        };
+        check_range!(collector, range);
+
+        let Some(named) =
+            src.to_node(&tree).and_then(ast::ParamAssignment::as_named_param_assignment)
+        else {
+            continue;
+        };
+        if let Some(res) = resolve_named_param_assignment(db, module_id.file_id.file_id(), named) {
+            collect_resolved_path(sema, res, range, collector);
+        }
+    }
+}
+
 fn collect_ident_like(
     sema: &Semantics<'_, RootDb>,
     in_cont: InContainer<Ident>,
     range: TextRange,
     collector: &mut SemaTokenCollector,
 ) -> Option<()> {
-    let db = sema.db;
     let res = sema.name_to_def(in_cont)?;
+    collect_resolved_path(sema, res, range, collector)
+}
+
+fn collect_resolved_path(
+    sema: &Semantics<'_, RootDb>,
+    res: PathResolution,
+    range: TextRange,
+    collector: &mut SemaTokenCollector,
+) -> Option<()> {
+    let db = sema.db;
 
     match res {
         PathResolution::NonAnsiPort { label, port_decl, data_decl, module } => {
@@ -433,7 +484,10 @@ mod tests {
     use base_db::{change::Change, source_root::SourceRoot};
     use insta::assert_debug_snapshot;
     use triomphe::Arc;
-    use utils::{lines::LineEnding, text_edit::TextRange};
+    use utils::{
+        lines::LineEnding,
+        text_edit::{TextRange, TextSize},
+    };
     use vfs::{ChangeKind, ChangedFile, FileId, FileSet, VfsPath};
 
     use super::*;
@@ -498,5 +552,87 @@ mod tests {
                 .unwrap();
             assert_debug_snapshot!(name, tokens);
         }
+    }
+
+    #[test]
+    fn named_port_connection_labels_use_target_module_ports() {
+        let text = r#"
+module darksocv
+(
+    input        UART_RXD,
+    output [31:0] LED,
+    input  [31:0] IPORT,
+    output [31:0] OPORT,
+    output [3:0]  DEBUG
+);
+    wire [31:0] iport;
+    wire [31:0] oport;
+
+    darkio io0 (
+        .RXD    (UART_RXD),
+        .TXD    (UART_TXD),
+        .LED    (LED),
+        .IPORT  (iport),
+        .OPORT  (oport),
+        .DEBUG  (IODEBUG)
+    );
+endmodule
+
+module darkio
+(
+    input         RXD,
+    output        TXD,
+    output [31:0] LED,
+    input  [31:0] IPORT,
+    output [31:0] OPORT,
+    output  [3:0] DEBUG
+);
+endmodule
+"#;
+        let (host, file_id) = setup(text);
+        let tokens = host
+            .make_analysis()
+            .semantic_tokens(
+                file_id,
+                SemaTokenConfig { port: SemaTokenPortConfig { clk_rst: true, io: true } },
+                Some(TextRange::up_to(TextSize::of(text))),
+            )
+            .unwrap();
+
+        let token = |needle: &str| {
+            let start = text.find(needle).expect("connection label should exist") + 1;
+            let end = start + needle.len() - 1;
+            let range = TextRange::new(TextSize::from(start as u32), TextSize::from(end as u32));
+            tokens
+                .iter()
+                .find(|token| !token.is_empty() && token.range == range)
+                .copied()
+                .unwrap_or_else(|| panic!("expected token at {range:?} for {needle}"))
+        };
+
+        assert_eq!(
+            (token(".RXD").tag, token(".RXD").mods),
+            (SemaTokenTag::Port(SemaTokenPort::Others), SemaTokenModifier::READ)
+        );
+        assert_eq!(
+            (token(".TXD").tag, token(".TXD").mods),
+            (SemaTokenTag::Port(SemaTokenPort::Others), SemaTokenModifier::WRITE)
+        );
+        assert_eq!(
+            (token(".LED").tag, token(".LED").mods),
+            (SemaTokenTag::Port(SemaTokenPort::Others), SemaTokenModifier::WRITE)
+        );
+        assert_eq!(
+            (token(".IPORT").tag, token(".IPORT").mods),
+            (SemaTokenTag::Port(SemaTokenPort::Others), SemaTokenModifier::READ)
+        );
+        assert_eq!(
+            (token(".OPORT").tag, token(".OPORT").mods),
+            (SemaTokenTag::Port(SemaTokenPort::Others), SemaTokenModifier::WRITE)
+        );
+        assert_eq!(
+            (token(".DEBUG").tag, token(".DEBUG").mods),
+            (SemaTokenTag::Port(SemaTokenPort::Others), SemaTokenModifier::WRITE)
+        );
     }
 }

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_lsp_snapshots.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_lsp_snapshots.snap
@@ -28,6 +28,8 @@ cfg_top Config container=None
 40..41 Port(Others) SemaTokenModifier(WRITE)
 193..196 Port(Clk) SemaTokenModifier(READ)
 219..226 Instance SemaTokenModifier(0x0)
+228..229 Port(Others) SemaTokenModifier(READ)
+237..238 Port(Others) SemaTokenModifier(WRITE)
 253..258 Instance SemaTokenModifier(0x0)
 264..267 Port(Clk) SemaTokenModifier(READ)
 520..523 Port(Clk) SemaTokenModifier(READ)


### PR DESCRIPTION
Fixes #76. This change resolves named port and parameter connections against the instantiated target module instead of the local module scope, so goto definition and semantic tokens now agree on the same accurate target-module resolution path. It also removes the misleading HIR named-connection resolution helpers and renames the remaining source-map helper to make future misuse less likely. 