### PR TITLE
fix(vscode): update qs lockfile

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -3871,9 +3871,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
## Summary

This change updates the VS Code extension lockfile so the transitive `qs` dependency resolves to the patched `6.15.2` release.

Root cause: `@vscode/vsce` depends on `typed-rest-client`, which accepts `qs` through `^6.9.1`; the lockfile had resolved it to `6.15.1`, which is covered by GHSA-q8mj-m7cp-5q26 / CVE-2026-8723.

## Validation

- `npm audit --json` reports 0 vulnerabilities in `editors/vscode`
- `npm test`
- `npm run package:debug`