### PR TITLE
fix(vscode): highlight Verilog declaration lists

### DIFF
--- a/editors/vscode/syntaxes/verilog.tmLanguage.json
+++ b/editors/vscode/syntaxes/verilog.tmLanguage.json
@@ -13,6 +13,9 @@
       "include": "#module_pattern"
     },
     {
+      "include": "#declarations"
+    },
+    {
       "include": "#keywords"
     },
     {
@@ -96,6 +99,123 @@
         {
           "match": "\\b[01xXzZ]+\\b",
           "name": "constant.numeric.logic.verilog"
+        }
+      ]
+    },
+    "declaration_names": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "variable.other.identifier.verilog"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "include": "#constants"
+                },
+                {
+                  "include": "#operators"
+                }
+              ]
+            }
+          },
+          "match": "\\b([a-zA-Z_][a-zA-Z0-9_$]*)\\b\\s*((?:\\[[^\\]\\r\\n]*\\]\\s*)*)(?=,|;|\\)|$)",
+          "name": "meta.declaration.name.verilog"
+        }
+      ]
+    },
+    "declaration_modifiers": {
+      "patterns": [
+        {
+          "match": "\\b(signed|unsigned|scalared|vectored)\\b",
+          "name": "storage.modifier.verilog"
+        },
+        {
+          "match": "\\b(reg|integer|time|real|realtime|event)\\b",
+          "name": "storage.type.variable.verilog"
+        },
+        {
+          "match": "\\b(supply0|supply1|tri|tri0|tri1|triand|trior|trireg|uwire|wand|wire|wor)\\b",
+          "name": "storage.type.net.verilog"
+        }
+      ]
+    },
+    "declaration_body": {
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#declaration_modifiers"
+        },
+        {
+          "include": "#constants"
+        },
+        {
+          "include": "#declaration_names"
+        },
+        {
+          "include": "#operators"
+        }
+      ]
+    },
+    "declarations": {
+      "patterns": [
+        {
+          "begin": "\\b(input|output|inout)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "support.type.direction.verilog"
+            }
+          },
+          "end": "(?=\\b(?:input|output|inout)\\b|;|\\))",
+          "name": "meta.declaration.port.verilog",
+          "patterns": [
+            {
+              "include": "#declaration_body"
+            }
+          ]
+        },
+        {
+          "begin": "\\b(reg|integer|time|real|realtime|event)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "storage.type.variable.verilog"
+            }
+          },
+          "end": ";",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.terminator.expression.verilog"
+            }
+          },
+          "name": "meta.declaration.variable.verilog",
+          "patterns": [
+            {
+              "include": "#declaration_body"
+            }
+          ]
+        },
+        {
+          "begin": "\\b(supply0|supply1|tri|tri0|tri1|triand|trior|trireg|uwire|wand|wire|wor)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "storage.type.net.verilog"
+            }
+          },
+          "end": ";",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.terminator.expression.verilog"
+            }
+          },
+          "name": "meta.declaration.net.verilog",
+          "patterns": [
+            {
+              "include": "#declaration_body"
+            }
+          ]
         }
       ]
     },
@@ -228,6 +348,9 @@
           "patterns": [
             {
               "include": "#comments"
+            },
+            {
+              "include": "#declarations"
             },
             {
               "include": "#keywords"

--- a/editors/vscode/test/grammar.test.ts
+++ b/editors/vscode/test/grammar.test.ts
@@ -1,0 +1,114 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+type GrammarRule = {
+  begin?: string;
+  end?: string;
+  include?: string;
+  match?: string;
+  name?: string;
+  patterns?: GrammarRule[];
+};
+
+type Grammar = GrammarRule & {
+  repository: Record<string, GrammarRule>;
+};
+
+function readGrammar(fileName: string): Grammar {
+  return JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'syntaxes', fileName), 'utf8')) as Grammar;
+}
+
+function requireRule(rule: GrammarRule | undefined, message: string): GrammarRule {
+  assert.ok(rule, message);
+  return rule;
+}
+
+function patternIncludes(rule: GrammarRule): string[] {
+  return rule.patterns?.map((pattern) => pattern.include).filter((include) => include !== undefined) ?? [];
+}
+
+function assertIncludesBefore(rule: GrammarRule, before: string, after: string, message: string): void {
+  const includes = patternIncludes(rule);
+  const beforeIndex = includes.indexOf(before);
+  const afterIndex = includes.indexOf(after);
+
+  assert.notEqual(beforeIndex, -1, `${message}: missing ${before}`);
+  assert.notEqual(afterIndex, -1, `${message}: missing ${after}`);
+  assert.ok(beforeIndex < afterIndex, `${message}: expected ${before} before ${after}`);
+}
+
+function collectDeclarationNames(grammar: Grammar, text: string): string[] {
+  const rule = requireRule(grammar.repository.declaration_names.patterns?.[0], 'declaration name rule exists');
+  assert.ok(rule.match, 'declaration name rule has a match pattern');
+
+  return [...text.matchAll(new RegExp(rule.match, 'gm'))].map((match) => match[1]);
+}
+
+test('verilog grammar applies declaration rules before generic keyword rules', () => {
+  const grammar = readGrammar('verilog.tmLanguage.json');
+  assertIncludesBefore(grammar, '#declarations', '#keywords', 'top-level grammar');
+
+  const moduleRule = requireRule(
+    grammar.repository.module_pattern.patterns?.find((rule) => rule.name === 'meta.block.module.verilog'),
+    'module grammar rule exists',
+  );
+  assertIncludesBefore(moduleRule, '#declarations', '#keywords', 'module grammar');
+});
+
+test('verilog declaration rules are not nested into instantiation bodies', () => {
+  const grammar = readGrammar('verilog.tmLanguage.json');
+  const instantiationRule = requireRule(
+    grammar.repository.instantiation_patterns.patterns?.find(
+      (rule) => rule.name === 'meta.block.instantiation.parameterless.verilog',
+    ),
+    'parameterless instantiation grammar rule exists',
+  );
+
+  assert.equal(patternIncludes(instantiationRule).includes('#declarations'), false);
+});
+
+test('verilog declaration names cover comma-separated and split-line declarations', () => {
+  const grammar = readGrammar('verilog.tmLanguage.json');
+
+  assert.deepEqual(
+    collectDeclarationNames(
+      grammar,
+      `
+        [15:0] x,
+        y,
+        zx, nx,
+        [15:0] y1,
+        y2,
+        noty1;
+      `,
+    ),
+    ['x', 'y', 'zx', 'nx', 'y1', 'y2', 'noty1'],
+  );
+  assert.deepEqual(collectDeclarationNames(grammar, '[WIDTH-1:0] data, other;'), ['data', 'other']);
+});
+
+test('verilog declaration blocks cover standard port, net, and reg declaration starts', () => {
+  const grammar = readGrammar('verilog.tmLanguage.json');
+  const declarations = grammar.repository.declarations.patterns ?? [];
+  const portRule = requireRule(
+    declarations.find((rule) => rule.name === 'meta.declaration.port.verilog'),
+    'port declaration rule exists',
+  );
+  const variableRule = requireRule(
+    declarations.find((rule) => rule.name === 'meta.declaration.variable.verilog'),
+    'variable declaration rule exists',
+  );
+  const netRule = requireRule(
+    declarations.find((rule) => rule.name === 'meta.declaration.net.verilog'),
+    'net declaration rule exists',
+  );
+
+  assert.match('input [15:0] x,', new RegExp(portRule.begin ?? ''));
+  assert.match('output zr, ng', new RegExp(portRule.begin ?? ''));
+  assert.match('reg [15:0] r1, r2;', new RegExp(variableRule.begin ?? ''));
+  assert.match('wire [15:0] x1, x2, notx1;', new RegExp(netRule.begin ?? ''));
+  assert.match(' output next_port', new RegExp(portRule.end ?? ''));
+  assert.match(');', new RegExp(portRule.end ?? ''));
+});


### PR DESCRIPTION
Adds Verilog TextMate grammar coverage for comma-separated and split-line declaration lists, including port, net, and variable declarations.

Related: https://github.com/textmate/verilog.tmbundle/issues/2