### PR TITLE
fix(config): reload workspace on structural setting changes

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -17,13 +17,13 @@ use crate::{
     i18n::{I18n, keys},
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FilesConfig {
     pub watcher: FilesWatcher,
     pub exclude: Vec<AbsPathBuf>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FilesWatcher {
     Client,
     Server,
@@ -169,6 +169,10 @@ impl Config {
                 .map(|it| self.root_path.join(it))
                 .collect(),
         }
+    }
+
+    pub(crate) fn workspace_affecting_settings_changed(&self, other: &Config) -> bool {
+        self.files() != other.files()
     }
 
     pub fn position_encoding(&self) -> PositionEncoding {

--- a/src/global_state/handlers/notification.rs
+++ b/src/global_state/handlers/notification.rs
@@ -104,7 +104,7 @@ pub(crate) fn handle_did_save_text_document(
         // Re-fetch workspaces if a workspace related file has changed
         let config = Arc::make_mut(&mut state.config);
         config.refresh_project_manifests();
-        state.fetch_workspaces_task.request(format!("DidSaveTextDocument {abs_path}"));
+        state.request_workspace_auto_reload(format!("DidSaveTextDocument {abs_path}"));
     }
 
     if state.config.user_config.diagnostics.update == DiagnosticsUpdateUserConfig::OnSave
@@ -175,7 +175,7 @@ pub(crate) fn handle_did_change_workspace_folders(
 
     // TODO: ??
     config.refresh_project_manifests();
-    state.fetch_workspaces_task.request("client workspaces changed".to_string());
+    state.request_workspace_reload("client workspaces changed");
 
     Ok(())
 }
@@ -204,7 +204,7 @@ pub(crate) fn handle_did_change_watched_files(
     if let Some(path) = workspace_structure_change {
         let config = Arc::make_mut(&mut state.config);
         config.refresh_project_manifests();
-        state.fetch_workspaces_task.request(format!("DidChangeWatchedFiles {path}"));
+        state.request_workspace_auto_reload(format!("DidChangeWatchedFiles {path}"));
     }
 
     Ok(())

--- a/src/global_state/handlers/request.rs
+++ b/src/global_state/handlers/request.rs
@@ -250,7 +250,7 @@ fn handle_reload_workspace_command(
 ) -> anyhow::Result<Option<serde_json::Value>> {
     let config = triomphe::Arc::make_mut(&mut state.config);
     config.refresh_project_manifests();
-    state.fetch_workspaces_task.request("workspace reload command".to_string());
+    state.request_workspace_reload("workspace reload command");
     Ok(None)
 }
 

--- a/src/global_state/main_loop.rs
+++ b/src/global_state/main_loop.rs
@@ -176,10 +176,8 @@ impl GlobalState {
             self.register_did_save_cap();
         }
 
-        self.fetch_workspaces_task.request("Start".into());
-        if let Some(cause) = self.fetch_workspaces_task.should_start() {
-            self.fetch_workspaces(cause);
-        }
+        self.request_workspace_reload("Start");
+        self.start_requested_workspace_fetch();
 
         while let Some(event) = self.next_event(&client_receiver) {
             if let Event::Lsp(Message::Notification(Notification { method, .. })) = &event
@@ -295,11 +293,7 @@ impl GlobalState {
             }
         }
 
-        if self.config.user_config.workspace_auto_reload
-            && let Some(cause) = self.fetch_workspaces_task.should_start()
-        {
-            self.fetch_workspaces(cause);
-        }
+        self.start_requested_workspace_fetch();
 
         let loop_duration = loop_start.elapsed();
         if loop_duration > Duration::from_millis(100) && was_stuck {

--- a/src/global_state/process_changes.rs
+++ b/src/global_state/process_changes.rs
@@ -80,7 +80,7 @@ impl GlobalState {
         if let Some(path) = workspace_structure_change {
             let config = triomphe::Arc::make_mut(&mut self.config);
             config.refresh_project_manifests();
-            self.fetch_workspaces_task.request(format!("workspace vfs change: {:?}", path));
+            self.request_workspace_auto_reload(format!("workspace vfs change: {:?}", path));
         }
 
         true

--- a/src/global_state/reload.rs
+++ b/src/global_state/reload.rs
@@ -64,6 +64,22 @@ impl GlobalState {
         })
     }
 
+    pub(crate) fn request_workspace_reload(&mut self, cause: impl Into<String>) {
+        self.fetch_workspaces_task.request(cause.into());
+    }
+
+    pub(crate) fn request_workspace_auto_reload(&mut self, cause: impl Into<String>) {
+        if self.config.user_config.workspace_auto_reload {
+            self.request_workspace_reload(cause);
+        }
+    }
+
+    pub(crate) fn start_requested_workspace_fetch(&mut self) {
+        if let Some(cause) = self.fetch_workspaces_task.should_start() {
+            self.fetch_workspaces(cause);
+        }
+    }
+
     pub(crate) fn fetch_workspace_error_stringify(&self) -> Result<(), String> {
         match self.fetch_workspaces_task.last_op_result() {
             Some((workspaces, _)) if workspaces.is_empty() => Err("no workspace fetched".into()),
@@ -140,6 +156,8 @@ impl GlobalState {
 
     pub(crate) fn update_configuration(&mut self, config: Config) {
         let diagnostics_config = Arc::new(config.diagnostics_config());
+        let workspace_affecting_change =
+            config.workspace_affecting_settings_changed(self.config.as_ref());
         let _old_config = std::mem::replace(&mut self.config, Arc::new(config));
         self.analysis_host.raw_db_mut().set_diagnostics_config_with_durability(
             diagnostics_config,
@@ -147,6 +165,11 @@ impl GlobalState {
         );
         self.diagnostics_revision += 1;
         self.invalidate_diagnostics(DiagnosticInvalidation::WorkspaceChanged);
+        if workspace_affecting_change {
+            let config = Arc::make_mut(&mut self.config);
+            config.refresh_project_manifests();
+            self.request_workspace_reload("configuration changed");
+        }
         // TODO: update LRU capacity
     }
 
@@ -360,5 +383,40 @@ mod tests {
         assert!(
             globs.contains(&format!("{root_path}/{}", project_manifest::LEGACY_MANIFEST_FILE_NAME))
         );
+    }
+
+    #[test]
+    fn diagnostics_config_update_does_not_request_workspace_reload() {
+        let (mut state, _client) = test_state();
+        let mut config = (*state.config).clone();
+        config
+            .update(serde_json::json!({
+                "diagnostics": {
+                    "semantic": { "enable": false }
+                }
+            }))
+            .unwrap();
+
+        state.update_configuration(config);
+
+        assert!(!state.fetch_workspaces_task.has_op_requested());
+    }
+
+    #[test]
+    fn structural_config_update_requests_workspace_reload() {
+        let root = TestDir::new("structural-config-reload");
+        let root_path = root.path().to_path_buf();
+        let (mut state, _client) = test_state_with_root(root_path);
+        let mut config = (*state.config).clone();
+        config
+            .update(serde_json::json!({
+                "files": { "excludeDirs": ["build"] },
+                "workspace": { "auto": { "reload": false } }
+            }))
+            .unwrap();
+
+        state.update_configuration(config);
+
+        assert!(state.fetch_workspaces_task.has_op_requested());
     }
 }


### PR DESCRIPTION
Reload workspace state when structural configuration changes.

Configuration updates that affect file discovery or watching now re-enter the existing workspace reload flow instead of only refreshing diagnostics state. Manual reloads and configuration-driven reloads are separated from auto reloads caused by workspace file changes.
