### PR TITLE
fix(build): provide local release metadata defaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,3 +125,6 @@ winapi = { version = "0.3.9" }
 
 [dev-dependencies]
 utils = { workspace = true, features = ["test-support"] }
+
+[build-dependencies]
+time = { version = "0.3.47", features = ["formatting", "macros"] }

--- a/build.rs
+++ b/build.rs
@@ -1,21 +1,63 @@
-use std::env;
+use std::{env, process::Command};
+
+use time::{OffsetDateTime, macros::format_description};
 
 fn main() {
     println!("cargo:rerun-if-env-changed=VIZSLA_COMMIT_HASH");
     println!("cargo:rerun-if-env-changed=VIZSLA_BUILD_DATE");
+    watch_git_metadata();
 
     let release = env::var("PROFILE").as_deref() == Ok("release");
-    let commit_hash = require_build_env("VIZSLA_COMMIT_HASH", release);
-    let build_date = require_build_env("VIZSLA_BUILD_DATE", release);
+    let commit_hash = build_env("VIZSLA_COMMIT_HASH", release, git_commit_hash);
+    let build_date = build_env("VIZSLA_BUILD_DATE", release, utc_build_date);
 
     println!("cargo:rustc-env=VIZSLA_COMMIT_HASH={commit_hash}");
     println!("cargo:rustc-env=VIZSLA_BUILD_DATE={build_date}");
 }
 
-fn require_build_env(name: &str, release: bool) -> String {
+fn build_env(name: &str, release: bool, fallback: impl FnOnce() -> String) -> String {
     match env::var(name) {
         Ok(value) if !value.trim().is_empty() => value,
-        _ if release => panic!("{name} must be set for release builds"),
+        _ if release => fallback(),
         _ => "dev".to_string(),
     }
+}
+
+fn git_commit_hash() -> String {
+    git_output(["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "unknown".to_string())
+}
+
+fn watch_git_metadata() {
+    for path in [git_path("HEAD"), git_current_branch_path()].into_iter().flatten() {
+        println!("cargo:rerun-if-changed={path}");
+    }
+}
+
+fn git_current_branch_path() -> Option<String> {
+    let branch = git_output(["symbolic-ref", "--quiet", "HEAD"])?;
+    git_path(&branch)
+}
+
+fn git_path(path: impl AsRef<str>) -> Option<String> {
+    git_output(["rev-parse", "--git-path", path.as_ref()])
+}
+
+fn git_output<const N: usize>(args: [&str; N]) -> Option<String> {
+    Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|output| output.trim().to_string())
+        .filter(|output| !output.is_empty())
+}
+
+fn utc_build_date() -> String {
+    format_build_date(OffsetDateTime::now_utc())
+}
+
+fn format_build_date(date: OffsetDateTime) -> String {
+    let format = format_description!("[year][month][day]T[hour][minute][second]Z");
+    date.format(format).expect("UTC build date format should be valid")
 }

--- a/docs/src/content/docs/build-from-source.md
+++ b/docs/src/content/docs/build-from-source.md
@@ -19,6 +19,10 @@ cargo build
 cargo build --release
 ```
 
+发布构建会把构建元数据写入 `vizsla --version` 输出。本地构建如果没有设置
+`VIZSLA_COMMIT_HASH` 和 `VIZSLA_BUILD_DATE`, 会自动使用当前 Git 短提交和 UTC
+构建时间; CI 或发布脚本仍然可以通过这两个环境变量覆盖默认值。
+
 验证版本:
 
 ```powershell
@@ -62,7 +66,7 @@ npm run package
 这个命令会:
 
 1. 编译扩展。
-2. 针对当前宿主平台执行 `cargo build --release`。
+2. 针对当前宿主平台执行 `cargo build --release`, 并使用同样的本地构建元数据默认值。
 3. 把 `target/release/vizsla` 或 `vizsla.exe` 复制到扩展的 `server/<target>` 目录。
 4. 临时把服务器二进制放到运行时 `server` 目录。
 5. 调用 `vsce package --target <target>` 生成 `vizsla-vscode-<target>.vsix`。

--- a/docs/src/content/docs/en/build-from-source.md
+++ b/docs/src/content/docs/en/build-from-source.md
@@ -19,6 +19,11 @@ Release build:
 cargo build --release
 ```
 
+Release builds embed build metadata in the `vizsla --version` output. Local
+builds automatically use the current short Git commit and UTC build time when
+`VIZSLA_COMMIT_HASH` and `VIZSLA_BUILD_DATE` are not set; CI or release scripts
+can still override the defaults with those environment variables.
+
 Verify the version:
 
 ```powershell
@@ -62,7 +67,7 @@ npm run package
 This command:
 
 1. Compiles the extension.
-2. Runs `cargo build --release` for the current host platform.
+2. Runs `cargo build --release` for the current host platform, using the same local build metadata defaults.
 3. Copies `target/release/vizsla` or `vizsla.exe` into the extension's `server/<target>` directory.
 4. Temporarily places the server binary in the runtime `server` directory.
 5. Calls `vsce package --target <target>` to generate `vizsla-vscode-<target>.vsix`.


### PR DESCRIPTION
Release builds now derive the Git commit and UTC build time locally when `VIZSLA_COMMIT_HASH` and `VIZSLA_BUILD_DATE` are not provided. CI and release workflows can still override both values through the existing environment variables.
