### PR TITLE
chore(release): align server version with extension

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vizsla"
-version = "0.1.0"
+version = "0.1.4"
 edition = "2024"
 authors = ["roifewu <roifewu@gmail.com>"]
 repository = "https://github.com/pascal-lab/vizsla"


### PR DESCRIPTION
The server version reported by `vizsla --version` and LSP server metadata now uses package version `0.1.4`, matching the extension and changelog release.
