### PR TITLE
fix(vfs): ignore stale loaded file batches

### DIFF
--- a/crates/vfs-notify/src/lib.rs
+++ b/crates/vfs-notify/src/lib.rs
@@ -64,6 +64,7 @@ type NotifyEvent = notify::Result<notify::Event>;
 
 struct NotifyActor {
     sender: loader::Sender,
+    config_version: u32,
     watched_files: FxHashSet<AbsPathBuf>,
     watched_dirs: Vec<loader::Directories>,
     // Drop order is significant.
@@ -80,6 +81,7 @@ impl NotifyActor {
     fn new(sender: loader::Sender) -> NotifyActor {
         NotifyActor {
             sender,
+            config_version: 0,
             watched_files: FxHashSet::default(),
             watched_dirs: Vec::new(),
             watcher: None,
@@ -120,6 +122,7 @@ impl NotifyActor {
                         }
 
                         let config_version = config.version;
+                        self.config_version = config_version;
                         let n_total = config.to_load.len();
                         if n_total > 0 {
                             self.send(loader::Message::Progress {
@@ -142,7 +145,7 @@ impl NotifyActor {
                                 tracing::debug!("watched entry dropped because receiver is closed");
                             }
                             let files = Self::load_entry(&watch_tx, entry, do_watch);
-                            self.send(loader::Message::Loaded { files });
+                            self.send(loader::Message::Loaded { files, config_version });
                             self.send(loader::Message::Progress {
                                 n_total,
                                 n_done: 1 + processed
@@ -167,7 +170,10 @@ impl NotifyActor {
                     ServerMsg::Invalidate(path) => {
                         let contents = read(path.as_path());
                         let files = vec![(path, contents)];
-                        self.send(loader::Message::Loaded { files });
+                        self.send(loader::Message::Loaded {
+                            files,
+                            config_version: self.config_version,
+                        });
                     }
                 },
                 Event::NotifyEvent(event) => {
@@ -212,7 +218,10 @@ impl NotifyActor {
                         })
                         .collect();
 
-                    self.send(loader::Message::Loaded { files });
+                    self.send(loader::Message::Loaded {
+                        files,
+                        config_version: self.config_version,
+                    });
                 }
             }
         }

--- a/crates/vfs/src/loader.rs
+++ b/crates/vfs/src/loader.rs
@@ -31,7 +31,7 @@ pub struct Config {
 
 pub enum Message {
     Progress { n_total: usize, n_done: usize, config_version: u32 },
-    Loaded { files: Vec<(AbsPathBuf, LoadResult)> },
+    Loaded { files: Vec<(AbsPathBuf, LoadResult)>, config_version: u32 },
 }
 
 pub type Sender = crossbeam_channel::Sender<Message>;
@@ -112,9 +112,11 @@ impl Directories {
 impl fmt::Debug for Message {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Message::Loaded { files } => {
-                f.debug_struct("Loaded").field("n_files", &files.len()).finish()
-            }
+            Message::Loaded { files, config_version } => f
+                .debug_struct("Loaded")
+                .field("n_files", &files.len())
+                .field("config_version", config_version)
+                .finish(),
             Message::Progress { n_total, n_done, config_version } => f
                 .debug_struct("Progress")
                 .field("n_total", n_total)

--- a/src/global_state/main_loop.rs
+++ b/src/global_state/main_loop.rs
@@ -53,10 +53,62 @@ impl Event {
             Event::Vfs(vfs_loader::Message::Progress { n_done, n_total, .. }) => {
                 format!("vfs progress {n_done}/{n_total}")
             }
-            Event::Vfs(vfs_loader::Message::Loaded { files }) => {
+            Event::Vfs(vfs_loader::Message::Loaded { files, .. }) => {
                 format!("vfs loaded files={}", files.len())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lsp_server::Connection;
+    use utils::{lines::LineEnding, paths::AbsPathBuf, test_support::TestDir};
+    use vfs::loader::LoadResult;
+
+    use super::*;
+    use crate::{Opt, config::user_config::UserConfig, i18n::I18n};
+
+    fn test_state(root_path: AbsPathBuf) -> GlobalState {
+        let config = Config::new(
+            Opt {
+                process_name: "vizsla-test".to_string(),
+                log: "error".to_string(),
+                log_filename: None,
+                profile_trace: None,
+            },
+            root_path.clone(),
+            lsp_types::ClientCapabilities::default(),
+            vec![root_path],
+            I18n::default(),
+            UserConfig::default(),
+            Vec::new(),
+        );
+
+        let (server, _client) = Connection::memory();
+        GlobalState::new(server.sender, config, lsp_types::TraceValue::Off)
+    }
+
+    #[test]
+    fn stale_loaded_batches_do_not_update_vfs() {
+        let root = TestDir::new("stale-loaded-batches");
+        let root_path = root.path().to_path_buf();
+        let file_path = root_path.join("stale.sv");
+        let mut state = test_state(root_path);
+        state.vfs_config_version = 2;
+
+        state.process_vfs_msg(vfs_loader::Message::Loaded {
+            files: vec![(
+                file_path.clone(),
+                LoadResult::Loaded("module stale; endmodule\n".to_string(), LineEnding::Unix),
+            )],
+            config_version: 1,
+        });
+
+        let vfs_path = VfsPath::from(file_path);
+        let mut vfs = state.vfs.write();
+        assert!(vfs.0.file_id(&vfs_path).is_none());
+        assert!(vfs.0.take_changes().is_empty());
     }
 }
 
@@ -511,7 +563,18 @@ impl GlobalState {
                     None,
                 );
             }
-            vfs_loader::Message::Loaded { files } => {
+            vfs_loader::Message::Loaded { files, config_version } => {
+                always!(config_version <= self.vfs_config_version);
+                if config_version < self.vfs_config_version {
+                    tracing::debug!(
+                        config_version,
+                        current_config_version = self.vfs_config_version,
+                        files = files.len(),
+                        "stale VFS loaded batch ignored"
+                    );
+                    return;
+                }
+
                 let vfs = &mut self.vfs.write().0;
 
                 for (path, content) in files {


### PR DESCRIPTION
`Loaded` messages from the VFS loader now carry the same configuration version as progress messages. The server discards loaded file batches from older VFS configurations before they can update the current VFS state.
