### PR TITLE
fix(docs): restore missing 404 entry

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -34,6 +34,7 @@ export default defineConfig({
         },
       ],
       customCss: ['./src/assets/landing.css'],
+      disable404Route: true,
       sidebar: [
         'quick-start',
         'installation',

--- a/docs/src/pages/404.astro
+++ b/docs/src/pages/404.astro
@@ -1,0 +1,74 @@
+---
+const base = import.meta.env.BASE_URL;
+---
+
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>404 | Vizsla 用户手册</title>
+    <meta name="robots" content="noindex" />
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #f8fafc;
+        color: #182230;
+      }
+
+      body {
+        min-height: 100vh;
+        margin: 0;
+        display: grid;
+        place-items: center;
+      }
+
+      main {
+        width: min(34rem, calc(100vw - 2rem));
+      }
+
+      p {
+        margin: 0 0 1.25rem;
+        color: #475467;
+        line-height: 1.7;
+      }
+
+      h1 {
+        margin: 0 0 0.75rem;
+        font-size: clamp(2.5rem, 9vw, 5rem);
+        line-height: 1;
+      }
+
+      a {
+        color: #155eef;
+        font-weight: 650;
+        text-decoration-thickness: 0.08em;
+        text-underline-offset: 0.2em;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          background: #101828;
+          color: #f9fafb;
+        }
+
+        p {
+          color: #d0d5dd;
+        }
+
+        a {
+          color: #84adff;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>404</h1>
+      <p>页面不存在，或者链接已经移动。</p>
+      <a href={base}>返回 Vizsla 用户手册首页</a>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
The docs build no longer relies on Starlight's default 404 route lookup for a missing docs entry. The site disables the injected 404 route and owns a direct Astro `404.astro` page, removing the build-time missing entry warning while preserving `/404.html`.
