### PR TITLE
fix(vfs): stabilize file identity ingress

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,6 @@ nohash-hasher = "0.2.0"
 regex = "1.10.2"
 rustc-hash = "2.1.1"
 salsa = "0.17.0-pre.2"
-same-file = "1.0.6"
 serde = { version = "1.0.189", features = ["derive"] }
 serde_json = "1.0.107"
 smallvec = { version = "1.10.0", features = [

--- a/crates/project-model/src/lib.rs
+++ b/crates/project-model/src/lib.rs
@@ -17,7 +17,10 @@ pub use toml_workspace::{
     generated_toml_manifest_schema,
 };
 use triomphe::Arc;
-use utils::paths::{AbsPathBuf, Utf8Component, Utf8Path, sort_and_remove_subfolders};
+use utils::{
+    path_identity::PathIdentitySet,
+    paths::{AbsPathBuf, Utf8Component, Utf8Path, sort_and_remove_subfolders},
+};
 use vfs::{FileSetConfig, FileSetFilter, PathGlobMatcher, PathMatcher, VfsPath};
 
 use crate::{
@@ -40,20 +43,54 @@ pub struct ProjectModel {
     pub workspaces: Vec<Workspace>,
 }
 
+/// A project-model root after manifest policy has been applied.
+///
+/// The fields are split by consumer. `source` classifies VFS files into source
+/// roots, `source_directories` drives recursive loader/watch scans, and
+/// `source_files` carries exact manifest files through
+/// [`vfs::loader::Entry::Files`].
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct WorkspaceRoot {
     pub role: SourceRootRole,
+    /// Files matching this are semantic source files for this root.
     pub source: PathMatcher,
+    /// Source globs that are safe to expand as directories.
+    pub source_directories: PathMatcher,
+    /// Literal source files from the manifest.
+    pub source_files: Vec<AbsPathBuf>,
+    /// Include/search roots loaded as headers and passed to preprocessing.
     pub include_dirs: Vec<AbsPathBuf>,
     pub exclude_globs: Option<PathGlobMatcher>,
 }
 
 impl WorkspaceRoot {
-    pub fn load_paths(&self) -> Vec<AbsPathBuf> {
+    /// Paths used to build the file-set prefix map.
+    ///
+    /// This includes exact source-file paths so a manually opened file can be
+    /// classified without requiring its parent directory to be a load root.
+    pub fn file_set_paths(&self) -> Vec<AbsPathBuf> {
         let mut paths = self.include_dirs.clone();
         paths.extend(self.source.scan_roots().cloned());
         sort_and_remove_subfolders(&mut paths);
         paths
+    }
+
+    /// Roots that should be recursively expanded by the loader or client
+    /// watcher.
+    ///
+    /// Exact source files are intentionally excluded and are handled through
+    /// `source_files`.
+    pub fn directory_load_paths(&self) -> Vec<AbsPathBuf> {
+        let mut paths = self.include_dirs.clone();
+        paths.extend(self.source_directories.scan_roots().cloned());
+        sort_and_remove_subfolders(&mut paths);
+        paths
+    }
+
+    fn has_load_paths(&self) -> bool {
+        !self.source_files.is_empty()
+            || !self.include_dirs.is_empty()
+            || !self.source_directories.is_empty()
     }
 }
 
@@ -144,29 +181,38 @@ impl Workspace {
         let exclude_patterns = validate_manifest_patterns(exclude_patterns, "exclude")?;
         let exclude_globs = compile_manifest_globs(&workspace_root, exclude_patterns, "exclude")?;
 
-        let mut source_paths = source_roots_for_patterns(&workspace_root, &source_patterns);
-        sort_and_remove_subfolders(&mut source_paths);
-        let source = compile_manifest_globs(&workspace_root, source_patterns, "sources")?
+        let source_locations = source_locations_for_patterns(&workspace_root, &source_patterns);
+        let source = compile_manifest_globs(&workspace_root, source_patterns.clone(), "sources")?
             .map_or_else(
                 || PathMatcher::all_under_roots(Vec::new()),
-                |matcher| PathMatcher::glob(source_paths.clone(), matcher),
+                |matcher| PathMatcher::glob(source_locations.matcher_roots.clone(), matcher),
             );
+        let has_source_paths = source_locations.has_load_paths();
+        let source_directories = compile_manifest_globs(
+            &workspace_root,
+            source_locations.directory_patterns,
+            "sources",
+        )?
+        .map_or_else(
+            || PathMatcher::all_under_roots(Vec::new()),
+            |matcher| PathMatcher::glob(source_locations.directory_roots.clone(), matcher),
+        );
 
         let default_include_paths = if source_policy.defaults_include_dirs_to_sources() {
-            source_paths.as_slice()
+            source_locations.default_include_dirs.as_slice()
         } else {
             &[]
         };
         let include_dirs = resolve_include_dirs(include_dirs, default_include_paths);
         let library_paths = resolve_library_paths(libraries);
-        let roots = workspace_roots(
-            kind,
-            &source_policy,
-            !source_paths.is_empty(),
+        let root_parts = WorkspaceRootParts {
             source,
-            include_dirs.clone(),
+            source_directories,
+            source_files: source_locations.source_files,
+            include_dirs: include_dirs.clone(),
             exclude_globs,
-        );
+        };
+        let roots = workspace_roots(kind, &source_policy, has_source_paths, root_parts);
         let semantic_profile = roots
             .iter()
             .any(|root| root.role.participates_in_semantic_profile())
@@ -179,14 +225,15 @@ impl Workspace {
         let kind = WorkspaceKind::from_is_lib(is_lib);
         let source_roots = vec![path.clone()];
         let include_dirs = if kind.is_library() { source_roots.clone() } else { Vec::new() };
-        let roots = workspace_roots(
-            kind,
-            &ManifestSourcePolicy::DefaultIndex,
-            true,
-            PathMatcher::all_under_roots(source_roots),
-            include_dirs.clone(),
-            None,
-        );
+        let source = PathMatcher::all_under_roots(source_roots.clone());
+        let root_parts = WorkspaceRootParts {
+            source: source.clone(),
+            source_directories: source,
+            source_files: Vec::new(),
+            include_dirs: include_dirs.clone(),
+            exclude_globs: None,
+        };
+        let roots = workspace_roots(kind, &ManifestSourcePolicy::DefaultIndex, true, root_parts);
         let semantic_profile = roots
             .iter()
             .any(|root| root.role.participates_in_semantic_profile())
@@ -236,54 +283,65 @@ fn semantic_profile(
     }
 }
 
+/// Root ingredients before default-source policy splits them into separate
+/// local and best-effort roots.
+#[derive(Clone)]
+struct WorkspaceRootParts {
+    source: PathMatcher,
+    source_directories: PathMatcher,
+    source_files: Vec<AbsPathBuf>,
+    include_dirs: Vec<AbsPathBuf>,
+    exclude_globs: Option<PathGlobMatcher>,
+}
+
+impl WorkspaceRootParts {
+    fn include_only(&self) -> Self {
+        Self {
+            source: PathMatcher::all_under_roots(Vec::new()),
+            source_directories: PathMatcher::all_under_roots(Vec::new()),
+            source_files: Vec::new(),
+            include_dirs: self.include_dirs.clone(),
+            exclude_globs: self.exclude_globs.clone(),
+        }
+    }
+
+    fn source_only(&self) -> Self {
+        Self {
+            source: self.source.clone(),
+            source_directories: self.source_directories.clone(),
+            source_files: self.source_files.clone(),
+            include_dirs: Vec::new(),
+            exclude_globs: self.exclude_globs.clone(),
+        }
+    }
+}
+
 fn workspace_roots(
     kind: WorkspaceKind,
     source_policy: &ManifestSourcePolicy,
     has_source_paths: bool,
-    source: PathMatcher,
-    include_dirs: Vec<AbsPathBuf>,
-    exclude_globs: Option<PathGlobMatcher>,
+    parts: WorkspaceRootParts,
 ) -> Vec<WorkspaceRoot> {
     let mut roots = Vec::new();
 
     if kind.is_library() {
-        push_workspace_root(
-            &mut roots,
-            SourceRootRole::Library,
-            source,
-            include_dirs,
-            exclude_globs,
-        );
+        push_workspace_root(&mut roots, SourceRootRole::Library, parts);
         return roots;
     }
 
     match source_policy {
         ManifestSourcePolicy::DefaultIndex => {
-            push_workspace_root(
-                &mut roots,
-                SourceRootRole::Local,
-                PathMatcher::all_under_roots(Vec::new()),
-                include_dirs,
-                exclude_globs.clone(),
-            );
+            push_workspace_root(&mut roots, SourceRootRole::Local, parts.include_only());
             if has_source_paths {
                 push_workspace_root(
                     &mut roots,
                     SourceRootRole::BestEffortIndex,
-                    source,
-                    Vec::new(),
-                    exclude_globs,
+                    parts.source_only(),
                 );
             }
         }
         ManifestSourcePolicy::Explicit(_) => {
-            push_workspace_root(
-                &mut roots,
-                SourceRootRole::Local,
-                source,
-                include_dirs,
-                exclude_globs,
-            );
+            push_workspace_root(&mut roots, SourceRootRole::Local, parts);
         }
     }
 
@@ -293,12 +351,17 @@ fn workspace_roots(
 fn push_workspace_root(
     roots: &mut Vec<WorkspaceRoot>,
     role: SourceRootRole,
-    source: PathMatcher,
-    include_dirs: Vec<AbsPathBuf>,
-    exclude_globs: Option<PathGlobMatcher>,
+    parts: WorkspaceRootParts,
 ) {
-    let root = WorkspaceRoot { role, source, include_dirs, exclude_globs };
-    if !root.load_paths().is_empty() {
+    let root = WorkspaceRoot {
+        role,
+        source: parts.source,
+        source_directories: parts.source_directories,
+        source_files: parts.source_files,
+        include_dirs: parts.include_dirs,
+        exclude_globs: parts.exclude_globs,
+    };
+    if root.has_load_paths() {
         roots.push(root);
     }
 }
@@ -365,13 +428,60 @@ fn compile_manifest_globs(
         .with_context(|| format!("failed to compile manifest {field} glob patterns"))
 }
 
-fn source_roots_for_patterns(workspace_root: &AbsPathBuf, patterns: &[String]) -> Vec<AbsPathBuf> {
-    patterns.iter().map(|pattern| source_root_for_pattern(workspace_root, pattern)).collect()
+/// Normalized manifest source-pattern facts, separated by how each consumer
+/// uses them.
+#[derive(Debug, Default)]
+struct SourceLocations {
+    matcher_roots: Vec<AbsPathBuf>,
+    directory_roots: Vec<AbsPathBuf>,
+    directory_patterns: Vec<String>,
+    source_files: Vec<AbsPathBuf>,
+    default_include_dirs: Vec<AbsPathBuf>,
 }
 
-fn source_root_for_pattern(workspace_root: &AbsPathBuf, pattern: &str) -> AbsPathBuf {
-    let root = literal_root_prefix(pattern);
-    if root.is_empty() { workspace_root.clone() } else { workspace_root.absolutize(root) }
+impl SourceLocations {
+    fn finish(mut self) -> Self {
+        sort_and_remove_subfolders(&mut self.matcher_roots);
+        sort_and_remove_subfolders(&mut self.directory_roots);
+        sort_and_remove_subfolders(&mut self.default_include_dirs);
+        self.source_files.sort();
+        self.source_files.dedup();
+        self
+    }
+
+    fn has_load_paths(&self) -> bool {
+        !self.directory_roots.is_empty() || !self.source_files.is_empty()
+    }
+}
+
+fn source_locations_for_patterns(
+    workspace_root: &AbsPathBuf,
+    patterns: &[String],
+) -> SourceLocations {
+    let mut locations = SourceLocations::default();
+    for pattern in patterns {
+        if let Some(source_file) = literal_source_file(workspace_root, pattern) {
+            locations.matcher_roots.push(source_file.clone());
+            locations.source_files.push(source_file.clone());
+            locations.default_include_dirs.push(
+                source_file
+                    .parent()
+                    .map(ToOwned::to_owned)
+                    .unwrap_or_else(|| workspace_root.clone()),
+            );
+            continue;
+        }
+
+        let root = literal_root_prefix(pattern);
+        let source_root =
+            if root.is_empty() { workspace_root.clone() } else { workspace_root.absolutize(root) };
+        locations.matcher_roots.push(source_root.clone());
+        locations.directory_roots.push(source_root.clone());
+        locations.default_include_dirs.push(source_root);
+        locations.directory_patterns.push(pattern.clone());
+    }
+
+    locations.finish()
 }
 
 fn literal_root_prefix(pattern: &str) -> &str {
@@ -388,16 +498,38 @@ fn literal_root_prefix(pattern: &str) -> &str {
     trimmed.rsplit_once('/').map_or("", |(parent, _)| parent)
 }
 
+fn literal_source_file(workspace_root: &AbsPathBuf, pattern: &str) -> Option<AbsPathBuf> {
+    if pattern.ends_with('/') || pattern.find(['*', '?', '[', '{']).is_some() {
+        return None;
+    }
+
+    let manifest_path = Utf8Path::new(pattern);
+    let absolute_path = workspace_root.absolutize(manifest_path);
+    if let Ok(metadata) = std::fs::metadata(absolute_path.as_path()) {
+        return metadata.is_file().then_some(absolute_path);
+    }
+
+    if manifest_path.extension().is_some_and(|ext| {
+        vfs::loader::SOURCE_FILE_EXTENSIONS
+            .iter()
+            .any(|candidate| ext.eq_ignore_ascii_case(candidate))
+    }) {
+        return Some(absolute_path);
+    }
+
+    None
+}
+
 impl ProjectModel {
     pub fn load(manifests: Vec<ProjectManifest>) -> (ProjectModel, Vec<anyhow::Error>) {
         let mut pending =
             manifests.into_iter().map(|manifest| (manifest, false)).collect::<VecDeque<_>>();
-        let mut loaded_manifests = FxHashSet::default();
+        let mut loaded_manifests = ProjectManifestIdentitySet::default();
         let mut workspaces = Vec::new();
         let mut errors = Vec::new();
 
         while let Some((manifest, is_lib)) = pending.pop_front() {
-            if !loaded_manifests.insert(manifest.clone()) {
+            if !loaded_manifests.insert(&manifest) {
                 continue;
             }
 
@@ -412,9 +544,7 @@ impl ProjectModel {
             for package in workspace.library_paths() {
                 match ProjectManifest::from_path(package) {
                     Ok(manifest) => {
-                        if !loaded_manifests.contains(&manifest) {
-                            pending.push_back((manifest, true));
-                        }
+                        pending.push_back((manifest, true));
                     }
                     Err(error) => errors.push(error),
                 }
@@ -424,6 +554,20 @@ impl ProjectModel {
         }
 
         (ProjectModel { workspaces }, errors)
+    }
+}
+
+#[derive(Default)]
+struct ProjectManifestIdentitySet {
+    paths: PathIdentitySet,
+}
+
+impl ProjectManifestIdentitySet {
+    fn insert(&mut self, manifest: &ProjectManifest) -> bool {
+        let path = match manifest {
+            ProjectManifest::Toml(path) | ProjectManifest::UnconfiguredRoot(path) => path,
+        };
+        self.paths.insert_path(path.as_path())
     }
 }
 
@@ -445,14 +589,17 @@ pub fn get_workspace_folder(
 
     for (workspace_idx, workspace) in workspaces.iter().enumerate() {
         for root in workspace.roots() {
-            let load_paths = root.load_paths();
-            if load_paths.is_empty() {
+            if !root.has_load_paths() {
                 continue;
             }
-            let root_file_set = load_paths.iter().cloned().map(VfsPath::from).collect_vec();
+            let file_set_paths = root.file_set_paths();
+            let root_file_set = file_set_paths.iter().cloned().map(VfsPath::from).collect_vec();
             let mut exclude_paths = Vec::new();
             for excl in global_excludes {
-                if load_paths.iter().any(|incl| incl.starts_with(excl) || excl.starts_with(incl)) {
+                if file_set_paths
+                    .iter()
+                    .any(|incl| incl.starts_with(excl) || excl.starts_with(incl))
+                {
                     exclude_paths.push(excl.clone());
                 }
             }
@@ -466,15 +613,35 @@ pub fn get_workspace_folder(
             let source =
                 if root.source.is_empty() { Vec::new() } else { vec![root.source.clone()] };
 
-            let entry = {
+            let mut load_entries = Vec::new();
+            let source_files = root
+                .source_files
+                .iter()
+                .filter(|path| {
+                    !is_excluded_load_file(path.as_path(), &exclude_paths, &root.exclude_globs)
+                })
+                .cloned()
+                .collect_vec();
+            if !source_files.is_empty() {
+                load_entries.push(vfs::loader::Entry::Files(source_files));
+            }
+
+            let mut directory_include = Vec::new();
+            if !root.include_dirs.is_empty() {
+                directory_include.push(PathMatcher::all_under_roots(root.include_dirs.clone()));
+            }
+            if !root.source_directories.is_empty() {
+                directory_include.push(root.source_directories.clone());
+            }
+            if !directory_include.is_empty() {
                 let dirs = vfs::loader::Directories {
-                    extensions: ["v", "sv", "vh", "svh", "svi", "map"].map(String::from).into(),
-                    include: include.clone(),
+                    extensions: source_file_extensions(),
+                    include: directory_include,
                     exclude: exclude_paths.clone(),
                     exclude_globs: root.exclude_globs.clone(),
                 };
-                vfs::loader::Entry::Directories(dirs)
-            };
+                load_entries.push(vfs::loader::Entry::Directories(dirs));
+            }
 
             let root_idx = fsc.len();
             fileset_roles.push(root.role);
@@ -489,11 +656,13 @@ pub fn get_workspace_folder(
                 },
             );
 
-            if root.role.is_watched() {
-                watch.push(load.len());
-            }
             loaded_roots.push(LoadedWorkspaceRoot { root_idx, workspace_idx, role: root.role });
-            load.push(entry);
+            for entry in load_entries {
+                if root.role.is_watched() {
+                    watch.push(load.len());
+                }
+                load.push(entry);
+            }
         }
     }
 
@@ -556,6 +725,19 @@ pub fn get_workspace_folder(
     (load, watch, SourceRootConfig { fileset_config, fileset_roles }, project_config)
 }
 
+fn source_file_extensions() -> Vec<String> {
+    vfs::loader::SOURCE_FILE_EXTENSIONS.iter().map(|ext| (*ext).to_owned()).collect()
+}
+
+fn is_excluded_load_file(
+    path: &utils::paths::AbsPath,
+    exclude_paths: &[AbsPathBuf],
+    exclude_globs: &Option<PathGlobMatcher>,
+) -> bool {
+    exclude_paths.iter().any(|exclude| path.starts_with(exclude))
+        || exclude_globs.as_ref().is_some_and(|exclude| exclude.is_match(path))
+}
+
 fn dependency_roots_by_workspace(
     workspaces: &[Workspace],
     root_ids_by_workspace: &FxHashMap<usize, Vec<SourceRootId>>,
@@ -604,7 +786,7 @@ fn collect_dependency_roots(
 mod tests {
     use std::fs;
 
-    use base_db::source_root::SourceRootRole;
+    use base_db::{source_db::SourceFileKind, source_root::SourceRootRole};
     use utils::{lines::LineEnding, test_support::TestDir};
     use vfs::{Vfs, loader::LoadResult};
 
@@ -638,6 +820,25 @@ libraries = ["../pkg"]
         assert_eq!(model.workspaces.len(), 2);
         assert!(!model.workspaces[0].is_lib());
         assert!(model.workspaces[1].is_lib());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn project_model_deduplicates_manifest_path_identities() {
+        let root = TestDir::new("project-model-manifest-identity");
+        fs::create_dir_all(root.join("rtl")).unwrap();
+        let manifest_path = root.join(project_manifest::MANIFEST_FILE_NAME);
+        fs::write(&manifest_path, r#"sources = ["rtl/**"]"#).unwrap();
+        let verbatim_manifest_path =
+            AbsPathBuf::try_from(format!(r"\\?\{manifest_path}").as_str()).unwrap();
+
+        let (model, errors) = ProjectModel::load(vec![
+            ProjectManifest::Toml(manifest_path),
+            ProjectManifest::Toml(verbatim_manifest_path),
+        ]);
+
+        assert!(errors.is_empty(), "{errors:#?}");
+        assert_eq!(model.workspaces.len(), 1);
     }
 
     #[test]
@@ -947,6 +1148,99 @@ include_dirs = []
         };
         assert!(dirs.contains_file(top.as_path()));
         assert!(!dirs.contains_file(nested_top.as_path()));
+    }
+
+    #[test]
+    fn explicit_single_file_source_separates_file_load_from_include_scan_root() {
+        let base = TestDir::new("project-model-single-file-source");
+        let root = base.join("root");
+        let rtl = root.join("rtl");
+        fs::create_dir_all(&rtl).unwrap();
+        fs::write(
+            root.join(project_manifest::MANIFEST_FILE_NAME),
+            r#"sources = ["rtl/top.sv"]
+"#,
+        )
+        .unwrap();
+
+        let top = rtl.join("top.sv");
+        let sibling = rtl.join("sibling.sv");
+        let manifest = ProjectManifest::from_path(&root).unwrap();
+        let (model, errors) = ProjectModel::load(vec![manifest]);
+        let (load, _, source_root_config, project_config) =
+            get_workspace_folder(&model.workspaces, &[]);
+
+        assert!(errors.is_empty(), "{errors:#?}");
+        assert!(load.iter().any(|entry| match entry {
+            vfs::loader::Entry::Files(files) => files == std::slice::from_ref(&top),
+            vfs::loader::Entry::Directories(_) => false,
+        }));
+        let dirs = load
+            .iter()
+            .find_map(|entry| match entry {
+                vfs::loader::Entry::Directories(dirs) => Some(dirs),
+                vfs::loader::Entry::Files(_) => None,
+            })
+            .expect("default include dir should add a directory loader entry");
+        assert!(dirs.contains_file(sibling.as_path()));
+
+        let profile_id = project_config.profile_for_root(SourceRootId(0)).unwrap();
+        let profile = project_config.profile(profile_id).unwrap();
+        assert_eq!(profile.preprocess.include_dirs, [rtl]);
+
+        let mut vfs = Vfs::default();
+        for file in [&top, &sibling] {
+            vfs.set_file_contents(
+                &VfsPath::from(file.clone()),
+                LoadResult::Loaded(String::new(), LineEnding::Unix),
+            );
+        }
+
+        let roots = source_root_config.partition(&vfs);
+        let top_file_id = *roots[0].file_for_path(&VfsPath::from(top)).unwrap();
+        let sibling_file_id = *roots[0].file_for_path(&VfsPath::from(sibling)).unwrap();
+        assert_eq!(roots[0].file_kind(&top_file_id), SourceFileKind::SystemVerilog);
+        assert_eq!(roots[0].file_kind(&sibling_file_id), SourceFileKind::IncludeHeader);
+    }
+
+    #[test]
+    fn explicit_single_file_source_without_include_dirs_loads_only_that_file() {
+        let base = TestDir::new("project-model-single-file-source-no-includes");
+        let root = base.join("root");
+        let rtl = root.join("rtl");
+        fs::create_dir_all(&rtl).unwrap();
+        fs::write(
+            root.join(project_manifest::MANIFEST_FILE_NAME),
+            r#"sources = ["rtl/top.sv"]
+include_dirs = []
+"#,
+        )
+        .unwrap();
+
+        let top = rtl.join("top.sv");
+        let sibling = rtl.join("sibling.sv");
+        let manifest = ProjectManifest::from_path(&root).unwrap();
+        let (model, errors) = ProjectModel::load(vec![manifest]);
+        let (load, _, source_root_config, _) = get_workspace_folder(&model.workspaces, &[]);
+
+        assert!(errors.is_empty(), "{errors:#?}");
+        assert_eq!(load.len(), 1);
+        assert!(
+            matches!(&load[0], vfs::loader::Entry::Files(files) if files == std::slice::from_ref(&top))
+        );
+
+        let mut vfs = Vfs::default();
+        for file in [&top, &sibling] {
+            vfs.set_file_contents(
+                &VfsPath::from(file.clone()),
+                LoadResult::Loaded(String::new(), LineEnding::Unix),
+            );
+        }
+
+        let roots = source_root_config.partition(&vfs);
+        assert!(roots[0].file_for_path(&VfsPath::from(top)).is_some());
+        assert_eq!(roots[1].role(), SourceRootRole::Ignored);
+        assert!(roots[1].file_for_path(&VfsPath::from(sibling)).is_some());
     }
 
     #[test]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -17,13 +17,15 @@ libc = "0.2.150"
 memchr.workspace = true
 nohash-hasher.workspace = true
 rustc-hash.workspace = true
-same-file.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 text-size.workspace = true
 tracing.workspace = true
 triomphe.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+winapi-util = "0.1.11"
 
 [features]
 camino_serde1 = ["camino/serde1"]

--- a/crates/utils/src/path_identity.rs
+++ b/crates/utils/src/path_identity.rs
@@ -1,10 +1,10 @@
 use std::path::Path;
 
 use rustc_hash::{FxHashMap, FxHashSet};
-use same_file::Handle;
 
 use crate::paths::{AbsPath, AbsPathBuf};
 
+/// Normalized path spelling key used before filesystem identity is available.
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct PathKey(String);
 
@@ -35,7 +35,7 @@ impl PathKey {
 /// invent another spelling.
 ///
 /// These strings are safe to hand to external parsers as alternate names for
-/// the same VFS text. File identity comparisons use `same-file` separately.
+/// the same VFS text. File identity comparisons use [`FileIdentityKey`].
 pub fn path_alias_paths(path: &AbsPath) -> Vec<AbsPathBuf> {
     let mut paths = vec![path.to_path_buf()];
 
@@ -52,14 +52,45 @@ pub fn path_alias_keys(path: &AbsPath) -> Vec<PathKey> {
     path_alias_paths(path).iter().map(|path| PathKey::from_abs_path(path)).collect()
 }
 
+/// Value identity for an existing filesystem object.
+///
+/// Unlike `same_file::Handle`, this key does not keep the file open after it is
+/// computed.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct FileIdentityKey(FileIdentityKeyRepr);
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum FileIdentityKeyRepr {
+    #[cfg(unix)]
+    Unix { dev: u64, ino: u64 },
+    #[cfg(windows)]
+    Windows { volume: u64, index: u64 },
+}
+
+impl FileIdentityKey {
+    /// Returns a stable value identity for an existing filesystem path.
+    ///
+    /// The path may be opened or statted while computing the key, but the key
+    /// itself does not retain any OS file handle.
+    pub fn from_path(path: &AbsPath) -> Option<Self> {
+        platform_file_identity_key(path.as_ref())
+    }
+}
+
+/// Maps filesystem identity evidence to a caller-owned value.
+///
+/// Raw and canonical path aliases cover stable path spellings. OS identity keys
+/// cover aliases that only the filesystem can prove, such as links. Callers
+/// should insert a path again when a formerly missing file is created, because
+/// identity evidence may become available later.
 pub struct PathIdentityIndex<T> {
     aliases: FxHashMap<PathKey, T>,
-    handles: Vec<(Handle, T)>,
+    identities: FxHashMap<FileIdentityKey, T>,
 }
 
 impl<T> Default for PathIdentityIndex<T> {
     fn default() -> Self {
-        Self { aliases: FxHashMap::default(), handles: Vec::new() }
+        Self { aliases: FxHashMap::default(), identities: FxHashMap::default() }
     }
 }
 
@@ -74,7 +105,7 @@ impl<T: Copy> PathIdentityIndex<T> {
         for key in path_alias_keys(path) {
             self.aliases.insert(key, value);
         }
-        self.insert_handle(path, value);
+        self.insert_identity(path, value);
     }
 
     pub fn get(&self, path: impl AsRef<str>) -> Option<T> {
@@ -97,27 +128,22 @@ impl<T: Copy> PathIdentityIndex<T> {
             return Some(value);
         }
 
-        let handle = Handle::from_path(path).ok()?;
-        self.handles.iter().find_map(|(known, value)| (known == &handle).then_some(*value))
+        let identity = platform_file_identity_key(path)?;
+        self.identities.get(&identity).copied()
     }
 
-    fn insert_handle(&mut self, path: &AbsPath, value: T) {
-        let Ok(handle) = Handle::from_path(path) else {
-            return;
-        };
-
-        if let Some((_, existing)) = self.handles.iter_mut().find(|(known, _)| known == &handle) {
-            *existing = value;
-        } else {
-            self.handles.push((handle, value));
+    fn insert_identity(&mut self, path: &AbsPath, value: T) {
+        if let Some(identity) = FileIdentityKey::from_path(path) {
+            self.identities.insert(identity, value);
         }
     }
 }
 
+/// Deduplicates paths by the same evidence model as [`PathIdentityIndex`].
 #[derive(Default)]
 pub struct PathIdentitySet {
     aliases: FxHashSet<PathKey>,
-    handles: Vec<Handle>,
+    identities: FxHashSet<FileIdentityKey>,
 }
 
 impl PathIdentitySet {
@@ -125,17 +151,13 @@ impl PathIdentitySet {
     /// seen.
     pub fn insert_path(&mut self, path: &AbsPath) -> bool {
         let keys = path_alias_keys(path);
-        let handle = Handle::from_path(path).ok();
+        let identity = FileIdentityKey::from_path(path);
         let is_new = keys.iter().all(|key| !self.aliases.contains(key))
-            && handle
-                .as_ref()
-                .is_none_or(|handle| self.handles.iter().all(|known| known != handle));
+            && identity.as_ref().is_none_or(|identity| !self.identities.contains(identity));
 
         self.aliases.extend(keys);
-        if let Some(handle) = handle
-            && self.handles.iter().all(|known| known != &handle)
-        {
-            self.handles.push(handle);
+        if let Some(identity) = identity {
+            self.identities.insert(identity);
         }
 
         is_new
@@ -145,8 +167,31 @@ impl PathIdentitySet {
 fn canonical_path(path: impl AsRef<Path>) -> Option<AbsPathBuf> {
     // `dunce` wraps `std::fs::canonicalize` but smooths over Windows
     // extended-length path spelling. It is still only an optional, OS-proven
-    // spelling; file identity checks use `same-file::Handle`.
+    // spelling; file identity checks use a value key derived from metadata.
     dunce::canonicalize(path).ok().and_then(|path| AbsPathBuf::try_from(path).ok())
+}
+
+#[cfg(unix)]
+fn platform_file_identity_key(path: &Path) -> Option<FileIdentityKey> {
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = std::fs::metadata(path).ok()?;
+    Some(FileIdentityKey(FileIdentityKeyRepr::Unix { dev: metadata.dev(), ino: metadata.ino() }))
+}
+
+#[cfg(windows)]
+fn platform_file_identity_key(path: &Path) -> Option<FileIdentityKey> {
+    let handle = winapi_util::Handle::from_path_any(path).ok()?;
+    let info = winapi_util::file::information(&handle).ok()?;
+    Some(FileIdentityKey(FileIdentityKeyRepr::Windows {
+        volume: info.volume_serial_number(),
+        index: info.file_index(),
+    }))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn platform_file_identity_key(_path: &Path) -> Option<FileIdentityKey> {
+    None
 }
 
 fn normalize_path_key(path: &str) -> String {
@@ -214,14 +259,17 @@ mod tests {
     }
 
     #[test]
-    fn path_identity_index_resolves_existing_path_by_handle() {
-        let dir = crate::test_support::TestDir::new("same-file-handle");
+    fn path_identity_index_resolves_existing_path_by_file_identity() {
+        let dir = crate::test_support::TestDir::new("file-identity");
         let path = dir.write("source.sv", "module top; endmodule\n");
+        let alias = dir.join("alias.sv");
         let mut index = PathIdentityIndex::default();
 
         index.insert_path(path.as_path(), 1);
 
-        assert_eq!(index.get_path(path.as_path()), Some(1));
+        std::fs::hard_link(&path, &alias).unwrap();
+
+        assert_eq!(index.get_path(alias.as_path()), Some(1));
     }
 
     #[test]

--- a/crates/vfs/src/file_set.rs
+++ b/crates/vfs/src/file_set.rs
@@ -10,6 +10,11 @@ use crate::{
     vfs_path::VfsPath,
 };
 
+/// Bidirectional path map for a single source root.
+///
+/// A `FileSet` stores the path spelling selected during source-root
+/// partitioning. That spelling may be a VFS alias rather than the primary path
+/// if the alias is the one that belongs to this root.
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct FileSet {
     files: FxHashMap<VfsPath, FileId>,
@@ -50,6 +55,12 @@ impl FileSet {
     }
 }
 
+/// Rules for partitioning VFS files into ordered source roots.
+///
+/// Root order is significant. For one VFS file with several aliases,
+/// classification evaluates every alias and chooses the earliest non-ignored
+/// root. Within a single alias, normal prefix matching still picks the most
+/// specific configured root.
 #[derive(Debug)]
 pub struct FileSetConfig {
     // Number of sets that can partition into.
@@ -60,12 +71,19 @@ pub struct FileSetConfig {
     filters: Vec<FileSetFilter>,
 }
 
+/// A source-root partition plus the subset that matched semantic source rules.
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct PartitionedFileSet {
     pub file_set: FileSet,
     pub source_files: Option<FxHashSet<FileId>>,
 }
 
+/// Matcher used separately for source classification, directory scans, and
+/// include/search roots.
+///
+/// Keeping those roles separate lets exact source files participate in source
+/// ownership without forcing the loader or watcher to scan their parent
+/// directories recursively.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct PathMatcher {
     scan_roots: Vec<AbsPathBuf>,
@@ -118,6 +136,7 @@ impl PathMatcher {
     }
 }
 
+/// Include/source/exclude policy for one file-set root.
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct FileSetFilter {
     pub include: Vec<PathMatcher>,
@@ -176,7 +195,7 @@ impl FileSetConfig {
             })
             .collect::<Vec<_>>();
         for (file_id, path) in vfs.iter() {
-            let root = self.classify(path, &mut scratch_space);
+            let (root, path) = self.classify_vfs_file(vfs, file_id, path, &mut scratch_space);
             if let Some(partition) = set.get_mut(root) {
                 partition.file_set.insert(file_id, path.clone());
                 if self.filters.get(root).is_some_and(|filter| filter.is_source(path))
@@ -187,6 +206,24 @@ impl FileSetConfig {
             }
         }
         set
+    }
+
+    fn classify_vfs_file<'a>(
+        &self,
+        vfs: &'a Vfs,
+        file_id: FileId,
+        primary_path: &'a VfsPath,
+        scratch_space: &mut Vec<u8>,
+    ) -> (usize, &'a VfsPath) {
+        let ignored = self.len - 1;
+        let mut best = None;
+        for path in vfs.file_paths(file_id) {
+            let root = self.classify(path, scratch_space);
+            if root != ignored && best.is_none_or(|(best_root, _)| root < best_root) {
+                best = Some((root, path));
+            }
+        }
+        best.unwrap_or((ignored, primary_path))
     }
 
     fn classify(&self, path: &VfsPath, scratch_space: &mut Vec<u8>) -> usize {
@@ -291,5 +328,83 @@ impl fst::Automaton for PrefixOf<'_> {
 
     fn accept(&self, &state: &usize, byte: u8) -> usize {
         if self.prefix_of.get(state) == Some(&byte) { state + 1 } else { !0 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use utils::lines::LineEnding;
+
+    use super::*;
+    use crate::{loader::LoadResult, test_support::TestDir};
+
+    #[test]
+    fn partition_uses_project_alias_when_first_ingress_was_another_path() {
+        let dir = TestDir::new("alias-partition");
+        let workspace = dir.join("workspace");
+        let source = dir.write("workspace/top.sv", "module top; endmodule\n");
+        let alias = dir.join("alias/top.sv");
+        if let Some(parent) = alias.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::hard_link(&source, &alias).unwrap();
+
+        let alias_vfs_path = VfsPath::from(alias);
+        let source_vfs_path = VfsPath::from(source);
+        let mut vfs = Vfs::default();
+        vfs.set_file_contents(
+            &alias_vfs_path,
+            LoadResult::Loaded("module top; endmodule\n".to_owned(), LineEnding::Unix),
+        );
+        let file_id = vfs.file_id(&alias_vfs_path).unwrap();
+        vfs.set_file_contents(
+            &source_vfs_path,
+            LoadResult::Loaded("module top; endmodule\n".to_owned(), LineEnding::Unix),
+        );
+        assert_eq!(vfs.file_id(&source_vfs_path), Some(file_id));
+
+        let mut builder = FileSetConfig::builder();
+        builder.add_file_set(vec![VfsPath::from(workspace)]);
+        let partitions = builder.build().partition(&vfs);
+
+        assert_eq!(partitions[0].get_path(&file_id), Some(&source_vfs_path));
+        assert_eq!(partitions[1].get_path(&file_id), None);
+    }
+
+    #[test]
+    fn partition_prefers_earlier_root_when_aliases_match_multiple_roots() {
+        let dir = TestDir::new("alias-root-priority");
+        let local_root = dir.join("local");
+        let library_root = dir.join("library");
+        let local = dir.join("local/top.sv");
+        let library = dir.write("library/top.sv", "module top; endmodule\n");
+        if let Some(parent) = local.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::hard_link(&library, &local).unwrap();
+
+        let local_vfs_path = VfsPath::from(local);
+        let library_vfs_path = VfsPath::from(library);
+        let mut vfs = Vfs::default();
+        vfs.set_file_contents(
+            &library_vfs_path,
+            LoadResult::Loaded("module top; endmodule\n".to_owned(), LineEnding::Unix),
+        );
+        let file_id = vfs.file_id(&library_vfs_path).unwrap();
+        vfs.set_file_contents(
+            &local_vfs_path,
+            LoadResult::Loaded("module top; endmodule\n".to_owned(), LineEnding::Unix),
+        );
+
+        let mut builder = FileSetConfig::builder();
+        builder.add_file_set(vec![VfsPath::from(local_root)]);
+        builder.add_file_set(vec![VfsPath::from(library_root)]);
+        let partitions = builder.build().partition(&vfs);
+
+        assert_eq!(partitions[0].get_path(&file_id), Some(&local_vfs_path));
+        assert_eq!(partitions[1].get_path(&file_id), None);
+        assert_eq!(partitions[2].get_path(&file_id), None);
     }
 }

--- a/crates/vfs/src/lib.rs
+++ b/crates/vfs/src/lib.rs
@@ -2,6 +2,8 @@ pub mod anchored_path;
 mod file_set;
 pub mod loader;
 mod path_glob;
+#[cfg(test)]
+mod test_support;
 mod vfs;
 mod vfs_path;
 

--- a/crates/vfs/src/loader.rs
+++ b/crates/vfs/src/loader.rs
@@ -8,12 +8,23 @@ use utils::{
 
 use crate::{PathGlobMatcher, PathMatcher};
 
+/// File extensions loaded from recursive directory entries.
+///
+/// Exact file entries are represented by [`Entry::Files`] and do not rely on
+/// extension expansion.
+pub const SOURCE_FILE_EXTENSIONS: &[&str] = &["v", "sv", "vh", "svh", "svi", "map"];
+
+/// A loader input boundary.
+///
+/// Exact files are loaded as listed. Directory entries are expanded using
+/// extension and matcher rules and are also eligible for recursive watching.
 #[derive(Debug, Clone)]
 pub enum Entry {
     Files(Vec<AbsPathBuf>),
     Directories(Directories),
 }
 
+/// Recursive directory load policy.
 #[derive(Debug, Clone, Default)]
 pub struct Directories {
     pub extensions: Vec<String>,
@@ -22,6 +33,7 @@ pub struct Directories {
     pub exclude_globs: Option<PathGlobMatcher>,
 }
 
+/// Complete loader configuration for one generation.
 #[derive(Debug)]
 pub struct Config {
     pub version: u32,
@@ -29,6 +41,7 @@ pub struct Config {
     pub to_watch: Vec<usize>,
 }
 
+/// Messages sent by a loader generation back to the main loop.
 pub enum Message {
     Progress { n_total: usize, n_done: usize, config_version: u32 },
     Loaded { files: Vec<(AbsPathBuf, LoadResult)>, config_version: u32 },
@@ -36,6 +49,7 @@ pub enum Message {
 
 pub type Sender = crossbeam_channel::Sender<Message>;
 
+/// Result of reading one file from the loader.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum LoadResult {
     Loaded(String, LineEnding),

--- a/crates/vfs/src/test_support.rs
+++ b/crates/vfs/src/test_support.rs
@@ -1,0 +1,53 @@
+use std::{
+    fs,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use utils::paths::{AbsPathBuf, Utf8Path};
+
+pub(crate) struct TestDir {
+    path: AbsPathBuf,
+}
+
+impl TestDir {
+    pub(crate) fn new(name: &str) -> Self {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let path =
+            std::env::temp_dir().join(format!("vizsla-vfs-{name}-{}-{suffix}", std::process::id()));
+        fs::create_dir_all(&path).unwrap_or_else(|err| {
+            panic!("failed to create test directory {}: {err}", path.display());
+        });
+        let path = AbsPathBuf::assert_utf8(path);
+        Self { path }
+    }
+
+    pub(crate) fn join(&self, path: impl AsRef<Utf8Path>) -> AbsPathBuf {
+        self.path.absolutize(path)
+    }
+
+    pub(crate) fn write(
+        &self,
+        path: impl AsRef<Utf8Path>,
+        contents: impl AsRef<[u8]>,
+    ) -> AbsPathBuf {
+        let path = self.join(path);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap_or_else(|err| {
+                panic!("failed to create test directory {parent}: {err}");
+            });
+        }
+        fs::write(&path, contents).unwrap_or_else(|err| {
+            panic!("failed to write test file {path}: {err}");
+        });
+        path
+    }
+}
+
+impl Drop for TestDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}

--- a/crates/vfs/src/vfs.rs
+++ b/crates/vfs/src/vfs.rs
@@ -253,6 +253,16 @@ impl Vfs {
         self.identities.file_path(file_id)
     }
 
+    /// Registers a path at the VFS identity boundary without changing file
+    /// contents.
+    ///
+    /// LSP open notifications use this to learn whether a URI aliases an
+    /// already-open analysis buffer before deciding whether the incoming text
+    /// should become the canonical VFS text.
+    pub fn register_file_ingress(&mut self, path: &VfsPath) -> FileId {
+        self.file_id_or_alloc(path)
+    }
+
     /// Returns the first path spelling recorded for this exact [`FileId`].
     ///
     /// Unlike [`Self::file_path`], this does not follow identity redirects.

--- a/crates/vfs/src/vfs.rs
+++ b/crates/vfs/src/vfs.rs
@@ -381,7 +381,9 @@ impl fmt::Debug for Vfs {
 mod tests {
     use std::fs;
 
-    use utils::{lines::LineEnding, paths::AbsPathBuf};
+    use utils::lines::LineEnding;
+    #[cfg(windows)]
+    use utils::paths::AbsPathBuf;
 
     use super::*;
     use crate::test_support::TestDir;

--- a/crates/vfs/src/vfs.rs
+++ b/crates/vfs/src/vfs.rs
@@ -1,9 +1,11 @@
-use std::{fmt, hash::BuildHasherDefault, mem};
+use std::{fmt, mem};
 
-use indexmap::IndexSet;
-use rustc_hash::FxHasher;
+use rustc_hash::FxHashMap;
 use triomphe::Arc;
-use utils::lines::LineEnding;
+use utils::{
+    lines::LineEnding,
+    path_identity::{FileIdentityKey, PathKey, path_alias_paths},
+};
 
 use crate::{loader::LoadResult, vfs_path::VfsPath};
 
@@ -14,7 +16,7 @@ impl nohash_hasher::IsEnabled for FileId {}
 
 #[derive(Default)]
 pub struct Vfs {
-    paths: IndexSet<VfsPath, BuildHasherDefault<FxHasher>>,
+    identities: VfsIdentityIndex,
     file_states: Vec<FileState>,
     changes: Vec<ChangedFile>,
 }
@@ -58,13 +60,210 @@ pub enum ChangeKind {
     Delete,
 }
 
+/// Identity service behind [`Vfs`].
+///
+/// A single [`FileId`] can be reached through several path spellings. The
+/// primary path preserves the first spelling for legacy callers, while aliases
+/// record every proven spelling for identity-aware consumers such as file-set
+/// partitioning. Every ingress path is registered, including paths that resolve
+/// to an existing [`FileId`], so later loader passes can add canonical or
+/// filesystem identity evidence for files that were opened before they existed
+/// on disk.
+#[derive(Default)]
+struct VfsIdentityIndex {
+    primary_paths: Vec<VfsPath>,
+    aliases: Vec<Vec<VfsPath>>,
+    exact_paths: FxHashMap<VfsPath, FileId>,
+    real_path_keys: FxHashMap<PathKey, FileId>,
+    real_paths: FxHashMap<FileIdentityKey, FileId>,
+    redirects: Vec<FileId>,
+}
+
+/// Result of registering a path ingress with the VFS identity service.
+///
+/// `file_id` is the canonical owner after all alias evidence has been applied.
+/// `merged` contains duplicate ids that were redirected to that owner and whose
+/// file state still needs to be reconciled by [`Vfs`].
+struct IdentityRegistration {
+    file_id: FileId,
+    merged: Vec<FileId>,
+}
+
+impl VfsIdentityIndex {
+    fn file_id(&self, path: &VfsPath) -> Option<FileId> {
+        if let Some(file_id) = self.exact_paths.get(path).copied() {
+            return Some(self.canonical_file_id(file_id));
+        }
+
+        let path = path.as_abs_path()?;
+        if let Some(file_id) = self.real_path_keys.get(&PathKey::from_abs_path(path)).copied() {
+            return Some(self.canonical_file_id(file_id));
+        }
+        for alias in path_alias_paths(path).into_iter().map(VfsPath::from) {
+            if let Some(file_id) = self.exact_paths.get(&alias).copied() {
+                return Some(self.canonical_file_id(file_id));
+            }
+        }
+
+        let identity = FileIdentityKey::from_path(path)?;
+        self.real_paths.get(&identity).copied().map(|file_id| self.canonical_file_id(file_id))
+    }
+
+    fn file_path(&self, file_id: FileId) -> Option<&VfsPath> {
+        let file_id = self.canonical_file_id(file_id);
+        self.primary_paths.get(file_id.0 as usize)
+    }
+
+    fn original_file_path(&self, file_id: FileId) -> Option<&VfsPath> {
+        self.primary_paths.get(file_id.0 as usize)
+    }
+
+    fn file_paths(&self, file_id: FileId) -> &[VfsPath] {
+        let file_id = self.canonical_file_id(file_id);
+        self.aliases.get(file_id.0 as usize).map_or(&[], Vec::as_slice)
+    }
+
+    /// Resolves or allocates a file id and records the current path as alias
+    /// evidence for that id.
+    fn file_id_or_alloc(&mut self, path: &VfsPath) -> IdentityRegistration {
+        let file_id = self.file_id(path).unwrap_or_else(|| self.alloc_file_id(path));
+        self.register_path(path, file_id)
+    }
+
+    fn len(&self) -> usize {
+        self.primary_paths.len()
+    }
+
+    fn canonical_file_id(&self, file_id: FileId) -> FileId {
+        let mut current = file_id;
+        while let Some(next) = self.redirects.get(current.0 as usize).copied()
+            && next != current
+        {
+            current = next;
+        }
+        current
+    }
+
+    fn alloc_file_id(&mut self, path: &VfsPath) -> FileId {
+        let id = self.primary_paths.len();
+        assert!(id < u32::MAX as usize);
+        let file_id = FileId(id as u32);
+        self.primary_paths.push(path.clone());
+        self.aliases.push(Vec::new());
+        self.redirects.push(file_id);
+        file_id
+    }
+
+    fn register_path(&mut self, path: &VfsPath, file_id: FileId) -> IdentityRegistration {
+        let mut owner = self.canonical_file_id(file_id);
+        let mut merged = Vec::new();
+
+        if let Some(path) = path.as_abs_path() {
+            let aliases = path_alias_paths(path).into_iter().map(VfsPath::from).collect::<Vec<_>>();
+            for alias in &aliases {
+                if let Some(existing) = self.exact_paths.get(alias).copied() {
+                    owner = self.merge_file_ids(owner, existing, &mut merged);
+                }
+                if let Some(path) = alias.as_abs_path()
+                    && let Some(existing) =
+                        self.real_path_keys.get(&PathKey::from_abs_path(path)).copied()
+                {
+                    owner = self.merge_file_ids(owner, existing, &mut merged);
+                }
+            }
+            if let Some(identity) = FileIdentityKey::from_path(path)
+                && let Some(existing) = self.real_paths.get(&identity).copied()
+            {
+                owner = self.merge_file_ids(owner, existing, &mut merged);
+            }
+
+            for alias in aliases {
+                self.register_exact_path(alias, owner);
+            }
+            if let Some(identity) = FileIdentityKey::from_path(path) {
+                self.real_paths.insert(identity, owner);
+            }
+        } else {
+            if let Some(existing) = self.exact_paths.get(path).copied() {
+                owner = self.merge_file_ids(owner, existing, &mut merged);
+            }
+            self.register_exact_path(path.clone(), owner);
+        }
+
+        IdentityRegistration { file_id: owner, merged }
+    }
+
+    fn register_exact_path(&mut self, path: VfsPath, file_id: FileId) {
+        let file_id = self.canonical_file_id(file_id);
+        if let Some(path) = path.as_abs_path() {
+            self.real_path_keys.insert(PathKey::from_abs_path(path), file_id);
+        }
+        self.exact_paths.insert(path.clone(), file_id);
+
+        let Some(aliases) = self.aliases.get_mut(file_id.0 as usize) else {
+            return;
+        };
+        if !aliases.contains(&path) {
+            aliases.push(path);
+        }
+    }
+
+    fn merge_file_ids(&mut self, lhs: FileId, rhs: FileId, merged: &mut Vec<FileId>) -> FileId {
+        let lhs = self.canonical_file_id(lhs);
+        let rhs = self.canonical_file_id(rhs);
+        if lhs == rhs {
+            return lhs;
+        }
+
+        let (owner, duplicate) = if lhs <= rhs { (lhs, rhs) } else { (rhs, lhs) };
+        self.redirects[duplicate.0 as usize] = owner;
+        merged.push(duplicate);
+
+        let duplicate_aliases = std::mem::take(&mut self.aliases[duplicate.0 as usize]);
+        for alias in duplicate_aliases {
+            self.register_exact_path(alias, owner);
+        }
+        for file_id in self.real_paths.values_mut() {
+            if *file_id == duplicate {
+                *file_id = owner;
+            }
+        }
+        for file_id in self.real_path_keys.values_mut() {
+            if *file_id == duplicate {
+                *file_id = owner;
+            }
+        }
+
+        owner
+    }
+}
+
+impl Vfs {
+    pub(crate) fn file_paths(&self, file_id: FileId) -> &[VfsPath] {
+        self.identities.file_paths(file_id)
+    }
+}
+
 impl Vfs {
     pub fn file_id(&self, path: &VfsPath) -> Option<FileId> {
-        self.paths.get_index_of(path).map(|id| FileId(id as u32)).filter(|id| self.exists(*id))
+        self.identities.file_id(path).filter(|id| self.exists(*id))
     }
 
     pub fn file_path(&self, file_id: FileId) -> Option<&VfsPath> {
-        self.paths.get_index(file_id.0 as usize)
+        self.identities.file_path(file_id)
+    }
+
+    /// Returns the first path spelling recorded for this exact [`FileId`].
+    ///
+    /// Unlike [`Self::file_path`], this does not follow identity redirects.
+    /// It is intended for cleanup of historical changes, for example clearing
+    /// diagnostics that were published before a duplicate id was merged.
+    pub fn original_file_path(&self, file_id: FileId) -> Option<&VfsPath> {
+        self.identities.original_file_path(file_id)
+    }
+
+    pub fn canonical_file_id(&self, file_id: FileId) -> FileId {
+        self.identities.canonical_file_id(file_id)
     }
 
     pub fn line_ending(&self, file_id: FileId) -> Option<LineEnding> {
@@ -129,18 +328,42 @@ impl Vfs {
     }
 
     fn file_id_or_alloc(&mut self, path: &VfsPath) -> FileId {
-        let id = match self.paths.get_index_of(path) {
-            Some(id) => id,
-            None => {
-                let path = path.clone();
-                self.paths.insert_full(path).0
-            }
-        };
-        assert!(id < u32::MAX as usize);
-
+        let registration = self.identities.file_id_or_alloc(path);
+        let file_id = registration.file_id;
+        let id = file_id.0 as usize;
         let len = self.file_states.len().max(id + 1);
         self.file_states.resize(len, FileState::Deleted);
-        FileId(id as u32)
+        for duplicate in registration.merged {
+            self.merge_file_state(file_id, duplicate);
+        }
+        file_id
+    }
+
+    fn merge_file_state(&mut self, owner: FileId, duplicate: FileId) {
+        if owner == duplicate {
+            return;
+        }
+
+        let owner_idx = owner.0 as usize;
+        let duplicate_idx = duplicate.0 as usize;
+        let Some(duplicate_state) = self.file_states.get(duplicate_idx).cloned() else {
+            return;
+        };
+
+        if matches!(self.file_states.get(owner_idx), Some(FileState::Deleted))
+            && let FileState::Exists(text, ending) = duplicate_state.clone()
+        {
+            self.file_states[owner_idx] = FileState::Exists(text.clone(), ending);
+            self.changes.push(ChangedFile {
+                file_id: owner,
+                change_kind: ChangeKind::Create(Arc::from(text.as_str()), ending),
+            });
+        }
+
+        if matches!(duplicate_state, FileState::Exists(_, _)) {
+            self.file_states[duplicate_idx] = FileState::Deleted;
+            self.changes.push(ChangedFile { file_id: duplicate, change_kind: ChangeKind::Delete });
+        }
     }
 
     fn file_state(&self, file_id: FileId) -> Option<&FileState> {
@@ -150,15 +373,18 @@ impl Vfs {
 
 impl fmt::Debug for Vfs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Vfs").field("n_files", &self.file_states.len()).finish()
+        f.debug_struct("Vfs").field("n_files", &self.identities.len()).finish()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use utils::lines::LineEnding;
+    use std::fs;
+
+    use utils::{lines::LineEnding, paths::AbsPathBuf};
 
     use super::*;
+    use crate::test_support::TestDir;
 
     #[test]
     fn load_error_marks_existing_file_deleted() {
@@ -179,5 +405,142 @@ mod tests {
         let changes = vfs.take_changes();
         assert_eq!(changes.len(), 1);
         assert!(matches!(changes[0].change_kind, ChangeKind::Delete));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn real_paths_with_different_drive_letter_case_share_file_id() {
+        let path = AbsPathBuf::assert_utf8(std::env::current_dir().unwrap()).join("top.sv");
+        let mut lower_drive_path = path.to_string();
+        assert_eq!(lower_drive_path.as_bytes().get(1), Some(&b':'));
+        lower_drive_path.replace_range(0..1, &lower_drive_path[0..1].to_ascii_lowercase());
+        let lower_drive_path = AbsPathBuf::try_from(lower_drive_path.as_str()).unwrap();
+
+        let mut vfs = Vfs::default();
+        let upper_vfs_path = VfsPath::from(path);
+        let lower_vfs_path = VfsPath::from(lower_drive_path);
+
+        vfs.set_file_contents(
+            &upper_vfs_path,
+            LoadResult::Loaded("module top; endmodule\n".to_owned(), LineEnding::Unix),
+        );
+        let first_file_id = vfs.file_id(&upper_vfs_path).unwrap();
+
+        vfs.set_file_contents(
+            &lower_vfs_path,
+            LoadResult::Loaded("module top; endmodule\n".to_owned(), LineEnding::Unix),
+        );
+        let second_file_id = vfs.file_id(&lower_vfs_path).unwrap();
+
+        assert_eq!(first_file_id, second_file_id);
+        assert_eq!(vfs.iter().count(), 1);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn real_paths_with_verbatim_and_normal_spelling_share_file_id() {
+        let path = AbsPathBuf::assert_utf8(std::env::current_dir().unwrap()).join("top.sv");
+        let verbatim_path = AbsPathBuf::try_from(format!(r"\\?\{path}").as_str()).unwrap();
+
+        let mut vfs = Vfs::default();
+        let normal_vfs_path = VfsPath::from(path);
+        let verbatim_vfs_path = VfsPath::from(verbatim_path);
+
+        vfs.set_file_contents(
+            &normal_vfs_path,
+            LoadResult::Loaded("module top; endmodule\n".to_owned(), LineEnding::Unix),
+        );
+        let first_file_id = vfs.file_id(&normal_vfs_path).unwrap();
+
+        vfs.set_file_contents(
+            &verbatim_vfs_path,
+            LoadResult::Loaded("module top; endmodule\n".to_owned(), LineEnding::Unix),
+        );
+        let second_file_id = vfs.file_id(&verbatim_vfs_path).unwrap();
+
+        assert_eq!(first_file_id, second_file_id);
+        assert_eq!(vfs.iter().count(), 1);
+    }
+
+    #[test]
+    fn real_identity_is_registered_when_missing_file_is_created() {
+        let dir = TestDir::new("created-identity");
+        let source = dir.join("workspace/top.sv");
+        let alias = dir.join("alias/top.sv");
+        let source_vfs_path = VfsPath::from(source.clone());
+        let alias_vfs_path = VfsPath::from(alias.clone());
+        let mut vfs = Vfs::default();
+
+        vfs.set_file_contents(
+            &source_vfs_path,
+            LoadResult::Loaded("module top; endmodule\n".to_owned(), LineEnding::Unix),
+        );
+        let file_id = vfs.file_id(&source_vfs_path).unwrap();
+
+        if let Some(parent) = source.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        if let Some(parent) = alias.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&source, "module top; endmodule\n").unwrap();
+        fs::hard_link(&source, &alias).unwrap();
+
+        vfs.set_file_contents(
+            &source_vfs_path,
+            LoadResult::Loaded("module top; endmodule\n".to_owned(), LineEnding::Unix),
+        );
+
+        assert_eq!(vfs.file_id(&alias_vfs_path), Some(file_id));
+    }
+
+    #[test]
+    fn real_identity_conflict_merges_previously_split_file_ids() {
+        let dir = TestDir::new("identity-conflict");
+        let source = dir.join("workspace/top.sv");
+        let alias = dir.join("alias/top.sv");
+        let source_vfs_path = VfsPath::from(source.clone());
+        let alias_vfs_path = VfsPath::from(alias.clone());
+        let mut vfs = Vfs::default();
+
+        vfs.set_file_contents(
+            &source_vfs_path,
+            LoadResult::Loaded("module top; endmodule\n".to_owned(), LineEnding::Unix),
+        );
+        let source_file_id = vfs.file_id(&source_vfs_path).unwrap();
+        vfs.set_file_contents(
+            &alias_vfs_path,
+            LoadResult::Loaded("module top; endmodule\n".to_owned(), LineEnding::Unix),
+        );
+        let alias_file_id = vfs.file_id(&alias_vfs_path).unwrap();
+        assert_ne!(source_file_id, alias_file_id);
+        vfs.take_changes();
+
+        if let Some(parent) = source.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        if let Some(parent) = alias.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&source, "module top; endmodule\n").unwrap();
+        fs::hard_link(&source, &alias).unwrap();
+
+        vfs.set_file_contents(
+            &source_vfs_path,
+            LoadResult::Loaded("module top; endmodule\n".to_owned(), LineEnding::Unix),
+        );
+        vfs.set_file_contents(
+            &alias_vfs_path,
+            LoadResult::Loaded("module top; endmodule\n".to_owned(), LineEnding::Unix),
+        );
+
+        let merged_file_id = vfs.file_id(&alias_vfs_path).unwrap();
+        assert_eq!(merged_file_id, source_file_id);
+        assert_eq!(vfs.file_id(&source_vfs_path), Some(source_file_id));
+        assert_eq!(vfs.iter().count(), 1);
+        assert!(!vfs.exists(alias_file_id));
+        let changes = vfs.take_changes();
+        assert!(changes.iter().any(|change| change.file_id == alias_file_id
+            && matches!(change.change_kind, ChangeKind::Delete)));
     }
 }

--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -34,7 +34,7 @@ use utils::{
 use vfs::{self, FileId, Vfs};
 
 use self::{
-    main_loop::{DiagnosticPublishKey, Task},
+    main_loop::{DiagnosticPublishFreshness, DiagnosticPublishKey, Task},
     mem_docs::MemDocs,
     snapshot::GlobalStateSnapshot,
     trace::LspTrace,
@@ -124,6 +124,7 @@ pub(crate) struct GlobalState {
     // the normal change-processing boundary.
     pub(crate) pending_document_diagnostic_targets: FxHashSet<FileId>,
     pub(crate) diagnostics_revision: u64,
+    pub(crate) diagnostic_target_revision: u64,
     pub(crate) qihe_diagnostics: Arc<Mutex<FxHashMap<FileId, QiheDiagnosticState>>>,
     // Only the latest Qihe run is allowed to commit diagnostics or logs.
     pub(crate) qihe_run_generation: qihe::QiheRunId,
@@ -183,6 +184,7 @@ impl GlobalState {
             published_diagnostics: FxHashMap::default(),
             pending_document_diagnostic_targets: FxHashSet::default(),
             diagnostics_revision: 0,
+            diagnostic_target_revision: 0,
             qihe_diagnostics: Arc::new(Mutex::new(FxHashMap::default())),
             qihe_run_generation: qihe::QiheRunId::default(),
             qihe_active_progress_token: None,
@@ -208,7 +210,12 @@ impl GlobalState {
             sema_tokens_cache: Arc::clone(&self.semantic_tokens_cache),
             qihe_diagnostics: Arc::clone(&self.qihe_diagnostics),
             diagnostics_revision: self.diagnostics_revision,
+            diagnostic_publish_freshness: self.diagnostic_publish_freshness(),
         }
+    }
+
+    pub(crate) fn diagnostic_publish_freshness(&self) -> DiagnosticPublishFreshness {
+        DiagnosticPublishFreshness::new(self.diagnostics_revision, self.diagnostic_target_revision)
     }
 }
 

--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -125,6 +125,9 @@ pub(crate) struct GlobalState {
     pub(crate) pending_document_diagnostic_targets: FxHashSet<FileId>,
     pub(crate) diagnostics_revision: u64,
     pub(crate) qihe_diagnostics: Arc<Mutex<FxHashMap<FileId, QiheDiagnosticState>>>,
+    // Only the latest Qihe run is allowed to commit diagnostics or logs.
+    pub(crate) qihe_run_generation: qihe::QiheRunId,
+    pub(crate) qihe_active_progress_token: Option<String>,
 
     pub(crate) vfs_loader: Handle<Box<dyn vfs::loader::Handle>, Receiver<vfs::loader::Message>>,
     pub(crate) vfs: Arc<RwLock<(Vfs, IntMap<FileId, LineEnding>)>>,
@@ -181,6 +184,8 @@ impl GlobalState {
             pending_document_diagnostic_targets: FxHashSet::default(),
             diagnostics_revision: 0,
             qihe_diagnostics: Arc::new(Mutex::new(FxHashMap::default())),
+            qihe_run_generation: qihe::QiheRunId::default(),
+            qihe_active_progress_token: None,
 
             vfs_loader,
             vfs: Arc::new(RwLock::new((Vfs::default(), IntMap::default()))),

--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -24,7 +24,7 @@ use lsp_types::{TraceValue, Url};
 use nohash_hasher::IntMap;
 use parking_lot::{Mutex, RwLock};
 use project_model::Workspace;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use triomphe::Arc;
 use utils::{
     excl_task::ExclTask,
@@ -33,7 +33,12 @@ use utils::{
 };
 use vfs::{self, FileId, Vfs};
 
-use self::{main_loop::Task, mem_docs::MemDocs, snapshot::GlobalStateSnapshot, trace::LspTrace};
+use self::{
+    main_loop::{DiagnosticPublishKey, Task},
+    mem_docs::MemDocs,
+    snapshot::GlobalStateSnapshot,
+    trace::LspTrace,
+};
 use crate::config::{Config, ConfigError};
 
 pub(crate) struct TaskPool<T> {
@@ -113,7 +118,11 @@ pub(crate) struct GlobalState {
     pub(crate) shutdown_requested: bool,
 
     pub(crate) semantic_tokens_cache: Arc<Mutex<FxHashMap<Url, lsp_types::SemanticTokens>>>,
-    pub(crate) diagnostics: FxHashMap<FileId, Vec<lsp_types::Diagnostic>>,
+    pub(crate) published_diagnostics: FxHashMap<DiagnosticPublishKey, Vec<lsp_types::Diagnostic>>,
+    // didOpen/didClose can change the URI set for a file without changing its
+    // text. Keep those target changes explicit so push diagnostics converge at
+    // the normal change-processing boundary.
+    pub(crate) pending_document_diagnostic_targets: FxHashSet<FileId>,
     pub(crate) diagnostics_revision: u64,
     pub(crate) qihe_diagnostics: Arc<Mutex<FxHashMap<FileId, QiheDiagnosticState>>>,
 
@@ -168,7 +177,8 @@ impl GlobalState {
             project_config: Arc::new(ProjectConfig::default()),
 
             semantic_tokens_cache: Arc::new(Default::default()),
-            diagnostics: FxHashMap::default(),
+            published_diagnostics: FxHashMap::default(),
+            pending_document_diagnostic_targets: FxHashSet::default(),
             diagnostics_revision: 0,
             qihe_diagnostics: Arc::new(Mutex::new(FxHashMap::default())),
 

--- a/src/global_state/handlers/notification.rs
+++ b/src/global_state/handlers/notification.rs
@@ -37,7 +37,14 @@ pub(crate) fn handle_did_open_text_document(
     params: DidOpenTextDocumentParams,
 ) -> anyhow::Result<()> {
     if let Ok(path) = from_proto::vfs_path(&params.text_document.uri) {
-        let file_id = set_vfs_file_contents(state, &path, params.text_document.text.clone())?;
+        let file_id = open_vfs_file_contents(state, &path, &params.text_document.text)?;
+        if state.mem_docs.text(file_id).is_some_and(|text| text != params.text_document.text) {
+            tracing::warn!(
+                ?file_id,
+                path = %path,
+                "open document alias has different text; keeping canonical analysis buffer"
+            );
+        }
         if state.mem_docs.insert(
             file_id,
             path.clone(),
@@ -60,21 +67,31 @@ pub(crate) fn handle_did_change_text_document(
             tracing::error!("unexpected DidChangeTextDocument: {}", path);
             return Ok(());
         };
-        let data = match state.mem_docs.text_mut_for_change(
-            &path,
-            file_id,
-            params.text_document.version,
-        ) {
-            Some(data) => data,
+        let text = match state.mem_docs.text_for_change(&path, file_id) {
+            Some(text) => text.to_owned(),
             None => {
                 tracing::error!("unexpected DidChangeTextDocument: {}", path);
                 return Ok(());
             }
         };
 
-        if let Some(text) =
-            update_document_text(state.config.position_encoding(), data, params.content_changes)
+        let text = match update_document_text(
+            state.config.position_encoding(),
+            &text,
+            params.content_changes,
+        ) {
+            Ok(text) => text,
+            Err(error) => {
+                tracing::error!("invalid DidChangeTextDocument for {path}: {error:#}");
+                return Ok(());
+            }
+        };
+        if !state.mem_docs.apply_change(&path, file_id, params.text_document.version, text.clone())
         {
+            tracing::error!("unexpected DidChangeTextDocument: {}", path);
+            return Ok(());
+        }
+        if let Some(text) = text {
             set_vfs_file_contents(state, &path, text)?;
         }
     }
@@ -238,6 +255,22 @@ fn set_vfs_file_contents(
     vfs.0.file_id(path).ok_or_else(|| anyhow::format_err!("loaded file has no FileId: {path}"))
 }
 
+fn open_vfs_file_contents(
+    state: &mut GlobalState,
+    path: &VfsPath,
+    text: &str,
+) -> anyhow::Result<vfs::FileId> {
+    let mut vfs = state.vfs.write();
+    let file_id = vfs.0.register_file_ingress(path);
+    if state.mem_docs.contains_file_id(file_id) {
+        return Ok(file_id);
+    }
+
+    let (text, endings) = LineEnding::normalize(text.to_owned());
+    vfs.0.set_file_contents(path, LoadResult::Loaded(text, endings));
+    vfs.0.file_id(path).ok_or_else(|| anyhow::format_err!("loaded file has no FileId: {path}"))
+}
+
 fn open_mem_doc_file_id(state: &GlobalState, path: &VfsPath) -> Option<FileId> {
     state.mem_docs.file_id(path).or_else(|| {
         state.vfs.read().0.file_id(path).filter(|file_id| state.mem_docs.contains_file_id(*file_id))
@@ -246,24 +279,19 @@ fn open_mem_doc_file_id(state: &GlobalState, path: &VfsPath) -> Option<FileId> {
 
 fn update_document_text(
     encoding: PositionEncoding,
-    data: &mut String,
+    data: &str,
     content_changes: Vec<lsp_types::TextDocumentContentChangeEvent>,
-) -> Option<String> {
-    let text = apply_document_changes(encoding, data, content_changes);
+) -> anyhow::Result<Option<String>> {
+    let text = apply_document_changes(encoding, data, content_changes)?;
 
-    if *data == text {
-        None
-    } else {
-        *data = text.clone();
-        Some(text)
-    }
+    if data == text { Ok(None) } else { Ok(Some(text)) }
 }
 
 fn apply_document_changes(
     encoding: PositionEncoding,
     file_contents: &str,
     content_changes: Vec<lsp_types::TextDocumentContentChangeEvent>,
-) -> String {
+) -> anyhow::Result<String> {
     // Skip to the last full document change and peek at the first content change
     let (mut text, content_changes) = {
         match content_changes.iter().rposition(|change| change.range.is_none()) {
@@ -279,7 +307,7 @@ fn apply_document_changes(
     };
 
     if content_changes.is_empty() {
-        return text;
+        return Ok(text);
     }
 
     // The changes can cross lines so we have to keep our line index updated.
@@ -306,11 +334,10 @@ fn apply_document_changes(
             *Arc::make_mut(&mut line_info.index) = LineIndex::new(&text);
         }
         index_valid_until = range.start.line;
-        if let Ok(range) = from_proto::text_range(&line_info, range) {
-            text.replace_range(Range::<usize>::from(range), &change.text);
-        }
+        let range = from_proto::text_range(&line_info, range)?;
+        text.replace_range(Range::<usize>::from(range), &change.text);
     }
-    text
+    Ok(text)
 }
 
 #[cfg(test)]
@@ -319,13 +346,18 @@ mod tests {
 
     use lsp_server::Connection;
     use lsp_types::{
-        DidChangeWatchedFilesParams, FileChangeType, FileEvent, SetTraceParams,
-        TextDocumentContentChangeEvent, TraceValue, Url,
+        DidChangeTextDocumentParams, DidChangeWatchedFilesParams, DidOpenTextDocumentParams,
+        FileChangeType, FileEvent, SetTraceParams, TextDocumentContentChangeEvent,
+        TextDocumentItem, TraceValue, Url, VersionedTextDocumentIdentifier,
     };
     use project_model::project_manifest;
     use utils::{lines::PositionEncoding, paths::AbsPathBuf, test_support::TestDir};
+    use vfs::VfsPath;
 
-    use super::{handle_did_change_watched_files, handle_set_trace, update_document_text};
+    use super::{
+        handle_did_change_text_document, handle_did_change_watched_files,
+        handle_did_open_text_document, handle_set_trace, update_document_text,
+    };
     use crate::{
         Opt,
         config::{self, user_config::UserConfig},
@@ -360,36 +392,159 @@ mod tests {
 
     #[test]
     fn clearing_document_updates_mem_doc_and_vfs_text() {
-        let mut text = "module top;\nendmodule\n".to_owned();
+        let text = "module top;\nendmodule\n".to_owned();
         let vfs_text = update_document_text(
             PositionEncoding::Utf8,
-            &mut text,
+            &text,
             vec![TextDocumentContentChangeEvent {
                 range: None,
                 range_length: None,
                 text: String::new(),
             }],
-        );
+        )
+        .unwrap();
 
-        assert_eq!(text, "");
         assert_eq!(vfs_text.as_deref(), Some(""));
     }
 
     #[test]
     fn unchanged_document_skips_vfs_update() {
-        let mut text = "module top;\nendmodule\n".to_owned();
+        let text = "module top;\nendmodule\n".to_owned();
         let vfs_text = update_document_text(
             PositionEncoding::Utf8,
-            &mut text,
+            &text,
             vec![TextDocumentContentChangeEvent {
                 range: None,
                 range_length: None,
                 text: "module top;\nendmodule\n".to_owned(),
             }],
+        )
+        .unwrap();
+
+        assert!(vfs_text.is_none());
+    }
+
+    #[test]
+    fn invalid_range_change_does_not_apply_partial_text() {
+        let text = "module top;\nendmodule\n".to_owned();
+        let result = update_document_text(
+            PositionEncoding::Utf8,
+            &text,
+            vec![TextDocumentContentChangeEvent {
+                range: Some(lsp_types::Range::new(
+                    lsp_types::Position::new(99, 0),
+                    lsp_types::Position::new(99, 1),
+                )),
+                range_length: None,
+                text: "broken".to_owned(),
+            }],
         );
 
-        assert_eq!(text, "module top;\nendmodule\n");
-        assert!(vfs_text.is_none());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn invalid_did_change_keeps_open_document_version_and_text() {
+        let root = TestDir::new("invalid-did-change");
+        let (mut state, _client) = test_state_with_root(root.path().to_path_buf());
+        let file_path = root.join("top.sv");
+        let uri = Url::from_file_path(file_path.as_path()).unwrap();
+        let vfs_path = VfsPath::from(file_path);
+
+        handle_did_open_text_document(
+            &mut state,
+            DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: uri.clone(),
+                    language_id: "systemverilog".to_owned(),
+                    version: 1,
+                    text: "module top;\nendmodule\n".to_owned(),
+                },
+            },
+        )
+        .unwrap();
+        let file_id = state.mem_docs.file_id(&vfs_path).unwrap();
+
+        handle_did_change_text_document(
+            &mut state,
+            DidChangeTextDocumentParams {
+                text_document: VersionedTextDocumentIdentifier { uri, version: 2 },
+                content_changes: vec![TextDocumentContentChangeEvent {
+                    range: Some(lsp_types::Range::new(
+                        lsp_types::Position::new(99, 0),
+                        lsp_types::Position::new(99, 1),
+                    )),
+                    range_length: None,
+                    text: "broken".to_owned(),
+                }],
+            },
+        )
+        .unwrap();
+
+        assert_eq!(state.mem_docs.version_for_path(&vfs_path), Some(1));
+        assert_eq!(state.mem_docs.text(file_id), Some("module top;\nendmodule\n"));
+    }
+
+    #[test]
+    fn divergent_alias_did_change_does_not_update_canonical_buffer() {
+        let root = TestDir::new("divergent-alias-change");
+        let (mut state, _client) = test_state_with_root(root.path().to_path_buf());
+        let source_path = root.join("workspace/top.sv");
+        let alias_path = root.join("alias/top.sv");
+        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(alias_path.parent().unwrap()).unwrap();
+        std::fs::write(&source_path, "module top;\nendmodule\n").unwrap();
+        std::fs::hard_link(&source_path, &alias_path).unwrap();
+        let source_uri = Url::from_file_path(source_path.as_path()).unwrap();
+        let alias_uri = Url::from_file_path(alias_path.as_path()).unwrap();
+        let source_vfs_path = VfsPath::from(source_path);
+        let alias_vfs_path = VfsPath::from(alias_path);
+
+        handle_did_open_text_document(
+            &mut state,
+            DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: source_uri,
+                    language_id: "systemverilog".to_owned(),
+                    version: 1,
+                    text: "module top;\nendmodule\n".to_owned(),
+                },
+            },
+        )
+        .unwrap();
+        let file_id = state.mem_docs.file_id(&source_vfs_path).unwrap();
+        handle_did_open_text_document(
+            &mut state,
+            DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: alias_uri.clone(),
+                    language_id: "systemverilog".to_owned(),
+                    version: 12,
+                    text: "module broken(;\nendmodule\n".to_owned(),
+                },
+            },
+        )
+        .unwrap();
+
+        assert_eq!(state.mem_docs.file_id(&alias_vfs_path), Some(file_id));
+        assert_eq!(state.mem_docs.text(file_id), Some("module top;\nendmodule\n"));
+        assert_eq!(state.mem_docs.open_documents(file_id).len(), 1);
+
+        handle_did_change_text_document(
+            &mut state,
+            DidChangeTextDocumentParams {
+                text_document: VersionedTextDocumentIdentifier { uri: alias_uri, version: 13 },
+                content_changes: vec![TextDocumentContentChangeEvent {
+                    range: None,
+                    range_length: None,
+                    text: "module still_broken(;\nendmodule\n".to_owned(),
+                }],
+            },
+        )
+        .unwrap();
+
+        assert_eq!(state.mem_docs.version_for_path(&alias_vfs_path), Some(12));
+        assert_eq!(state.mem_docs.text(file_id), Some("module top;\nendmodule\n"));
     }
 
     #[test]

--- a/src/global_state/handlers/notification.rs
+++ b/src/global_state/handlers/notification.rs
@@ -46,6 +46,7 @@ pub(crate) fn handle_did_open_text_document(
         ) {
             tracing::error!("duplicate DidOpenTextDocument: {}", path);
         }
+        state.pending_document_diagnostic_targets.insert(file_id);
     }
     Ok(())
 }
@@ -85,8 +86,12 @@ pub(crate) fn handle_did_close_text_document(
     params: DidCloseTextDocumentParams,
 ) -> anyhow::Result<()> {
     if let Ok(path) = from_proto::vfs_path(&params.text_document.uri) {
+        let file_id = state.mem_docs.file_id(&path);
         if !state.mem_docs.remove_path(&path) {
             tracing::error!("orphan DidCloseTextDocument: {}", path);
+        }
+        if let Some(file_id) = file_id {
+            state.pending_document_diagnostic_targets.insert(file_id);
         }
 
         if let Some(path) = path.as_abs_path() {

--- a/src/global_state/handlers/notification.rs
+++ b/src/global_state/handlers/notification.rs
@@ -11,7 +11,7 @@ use utils::{
     line_index::LineIndex,
     lines::{LineEnding, LineInfo, PositionEncoding},
 };
-use vfs::{VfsPath, loader::LoadResult};
+use vfs::{FileId, VfsPath, loader::LoadResult};
 
 use crate::{
     DEFAULT_PROCESS_NAME,
@@ -38,11 +38,12 @@ pub(crate) fn handle_did_open_text_document(
 ) -> anyhow::Result<()> {
     if let Ok(path) = from_proto::vfs_path(&params.text_document.uri) {
         let file_id = set_vfs_file_contents(state, &path, params.text_document.text.clone())?;
-        if state
-            .mem_docs
-            .insert(file_id, path.clone(), params.text_document.version, params.text_document.text)
-            .is_some()
-        {
+        if state.mem_docs.insert(
+            file_id,
+            path.clone(),
+            params.text_document.version,
+            params.text_document.text,
+        ) {
             tracing::error!("duplicate DidOpenTextDocument: {}", path);
         }
     }
@@ -54,13 +55,16 @@ pub(crate) fn handle_did_change_text_document(
     params: DidChangeTextDocumentParams,
 ) -> anyhow::Result<()> {
     if let Ok(path) = from_proto::vfs_path(&params.text_document.uri) {
-        let data = match state.mem_docs.get_mut_by_path(&path) {
-            Some(doc) => {
-                // The version in DidChangeTextDocument is the one after all edits,
-                // so we should apply it before the vfs is notified.
-                doc.version = params.text_document.version;
-                &mut doc.data
-            }
+        let Some(file_id) = open_mem_doc_file_id(state, &path) else {
+            tracing::error!("unexpected DidChangeTextDocument: {}", path);
+            return Ok(());
+        };
+        let data = match state.mem_docs.text_mut_for_change(
+            &path,
+            file_id,
+            params.text_document.version,
+        ) {
+            Some(data) => data,
             None => {
                 tracing::error!("unexpected DidChangeTextDocument: {}", path);
                 return Ok(());
@@ -81,7 +85,7 @@ pub(crate) fn handle_did_close_text_document(
     params: DidCloseTextDocumentParams,
 ) -> anyhow::Result<()> {
     if let Ok(path) = from_proto::vfs_path(&params.text_document.uri) {
-        if state.mem_docs.remove_path(&path).is_none() {
+        if !state.mem_docs.remove_path(&path) {
             tracing::error!("orphan DidCloseTextDocument: {}", path);
         }
 
@@ -227,6 +231,12 @@ fn set_vfs_file_contents(
     let mut vfs = state.vfs.write();
     vfs.0.set_file_contents(path, LoadResult::Loaded(text, endings));
     vfs.0.file_id(path).ok_or_else(|| anyhow::format_err!("loaded file has no FileId: {path}"))
+}
+
+fn open_mem_doc_file_id(state: &GlobalState, path: &VfsPath) -> Option<FileId> {
+    state.mem_docs.file_id(path).or_else(|| {
+        state.vfs.read().0.file_id(path).filter(|file_id| state.mem_docs.contains_file_id(*file_id))
+    })
 }
 
 fn update_document_text(

--- a/src/global_state/handlers/request.rs
+++ b/src/global_state/handlers/request.rs
@@ -181,13 +181,14 @@ pub(crate) fn handle_workspace_diagnostic(
         diag_items.extend(snap.qihe_diagnostics(file_id));
 
         for target in targets {
-            seen.insert(target.uri.clone());
-            let result_id = snap.diagnostic_result_id(file_id, &target.uri);
-            let version = target.version.map(|version| version as i64);
-            let previous_result_id = previous_result_ids.get(&target.uri).map(String::as_str);
+            let uri = target.uri().clone();
+            seen.insert(uri.clone());
+            let result_id = snap.diagnostic_result_id(file_id, &uri);
+            let version = target.version().map(|version| version as i64);
+            let previous_result_id = previous_result_ids.get(&uri).map(String::as_str);
 
             items.push(workspace_diagnostic_report(
-                target.uri,
+                uri,
                 version,
                 result_id,
                 diag_items.clone(),

--- a/src/global_state/handlers/request.rs
+++ b/src/global_state/handlers/request.rs
@@ -114,7 +114,7 @@ pub(crate) fn handle_document_diagnostic(
     params: lsp_types::DocumentDiagnosticParams,
 ) -> anyhow::Result<lsp_types::DocumentDiagnosticReportResult> {
     let file_id = from_proto::file_id(&snap, &params.text_document.uri)?;
-    let result_id = snap.diagnostic_result_id(file_id);
+    let result_id = snap.diagnostic_result_id(file_id, &params.text_document.uri);
     let items = snap.lsp_diagnostics(file_id);
     Ok(document_diagnostic_report(result_id, items, params.previous_result_id.as_deref()).into())
 }
@@ -163,14 +163,13 @@ pub(crate) fn handle_workspace_diagnostic(
     }
 
     for file_id in diagnostic_file_ids {
-        let uri = match to_proto::url(&snap, file_id) {
-            Ok(uri) => uri,
+        let targets = match snap.workspace_diagnostic_targets(file_id) {
+            Ok(targets) => targets,
             Err(error) => {
                 tracing::debug!(?file_id, "skipping diagnostics for file without URI: {error:#}");
                 continue;
             }
         };
-        seen.insert(uri.clone());
 
         let diagnostics = diagnostics_by_file.remove(&file_id).unwrap_or_default();
 
@@ -181,17 +180,20 @@ pub(crate) fn handle_workspace_diagnostic(
             .collect::<Vec<_>>();
         diag_items.extend(snap.qihe_diagnostics(file_id));
 
-        let result_id = snap.diagnostic_result_id(file_id);
-        let version = snap.file_version(file_id).map(|version| version as i64);
-        let previous_result_id = previous_result_ids.get(&uri).map(String::as_str);
+        for target in targets {
+            seen.insert(target.uri.clone());
+            let result_id = snap.diagnostic_result_id(file_id, &target.uri);
+            let version = target.version.map(|version| version as i64);
+            let previous_result_id = previous_result_ids.get(&target.uri).map(String::as_str);
 
-        items.push(workspace_diagnostic_report(
-            uri,
-            version,
-            result_id,
-            diag_items,
-            previous_result_id,
-        ));
+            items.push(workspace_diagnostic_report(
+                target.uri,
+                version,
+                result_id,
+                diag_items.clone(),
+                previous_result_id,
+            ));
+        }
     }
 
     for (uri, _) in previous_result_ids {

--- a/src/global_state/handlers/request/code_action.rs
+++ b/src/global_state/handlers/request/code_action.rs
@@ -45,8 +45,9 @@ pub(crate) fn handle_code_action(
 
     let mut res = Vec::new();
     for (id, mut assist) in action.into_iter().enumerate() {
-        let resolve_data =
-            resolve_strategy.is_none().then(|| (id, params.clone(), snap.file_version(file_id)));
+        let resolve_data = resolve_strategy
+            .is_none()
+            .then(|| (id, params.clone(), snap.url_file_version(&params.text_document.uri)));
         let action_diags =
             if let Some(filtered) = quick_fix_diagnostics(assist.id.repair, &server_diagnostics) {
                 assist.id.kind = CodeActionKind::QuickFix;
@@ -195,7 +196,7 @@ pub(crate) fn handle_code_action_resolve(
     )?;
 
     let file_id = from_proto::file_id(&snap, &data.code_action_params.text_document.uri)?;
-    if snap.file_version(file_id) != data.version {
+    if snap.url_file_version(&data.code_action_params.text_document.uri) != data.version {
         return Err(to_proto::code_action_resolve_error(
             snap.config.i18n,
             CodeActionResolveError::Stable,

--- a/src/global_state/main_loop.rs
+++ b/src/global_state/main_loop.rs
@@ -14,7 +14,7 @@ use super::{
     GlobalState, VfsProgress,
     dispatcher::{NotifDispatcher, ReqDispatcher},
     handlers,
-    qihe::QiheUpdate,
+    qihe::{QiheRunId, QiheUpdate},
     reload::FetchWorkspaceProgress,
     respond::Progress,
     snapshot::DiagnosticPublishTarget,
@@ -107,7 +107,7 @@ mod tests {
     }
 
     fn publish_batch(tasks: Vec<PublishDiagnosticsTask>) -> PublishDiagnosticsBatch {
-        PublishDiagnosticsBatch::from_tasks(tasks)
+        PublishDiagnosticsBatch::from_tasks(tasks, 0)
     }
 
     #[test]
@@ -225,7 +225,11 @@ mod tests {
         assert!(!published.diagnostics.is_empty());
 
         state.publish_diagnostics_tasks(
-            PublishDiagnosticsBatch::for_touched_files(FxHashSet::from_iter([file_id]), Vec::new()),
+            PublishDiagnosticsBatch::for_touched_files(
+                FxHashSet::from_iter([file_id]),
+                Vec::new(),
+                0,
+            ),
             false,
         );
 
@@ -237,6 +241,50 @@ mod tests {
                 .published_diagnostics
                 .contains_key(&DiagnosticPublishKey::for_test(file_id, alias_uri))
         );
+    }
+
+    #[test]
+    fn stale_diagnostics_batch_does_not_publish() {
+        let root = TestDir::new("stale-diagnostics-batch");
+        let root_path = root.path().to_path_buf();
+        let config = Config::new(
+            Opt {
+                process_name: "vizsla-test".to_string(),
+                log: "error".to_string(),
+                log_filename: None,
+                profile_trace: None,
+            },
+            root_path.clone(),
+            lsp_types::ClientCapabilities::default(),
+            vec![root_path],
+            I18n::default(),
+            UserConfig::default(),
+            Vec::new(),
+        );
+        let (server, client) = Connection::memory();
+        let mut state = GlobalState::new(server.sender, config, lsp_types::TraceValue::Off);
+        state.diagnostics_revision = 2;
+        let file_id = FileId(0);
+        let uri =
+            to_proto::url_from_abs_path(root.write("workspace/top.sv", "").as_path()).unwrap();
+        let diagnostic = Diagnostic {
+            range: Range::new(Position::new(0, 0), Position::new(0, 1)),
+            severity: Some(DiagnosticSeverity::ERROR),
+            source: Some("test".to_owned()),
+            message: "stale diagnostic".to_owned(),
+            ..Diagnostic::default()
+        };
+
+        state.publish_diagnostics_tasks(
+            PublishDiagnosticsBatch::from_tasks(
+                vec![PublishDiagnosticsTask::for_test(file_id, uri, None, vec![diagnostic])],
+                1,
+            ),
+            false,
+        );
+
+        assert!(client.receiver.recv_timeout(Duration::from_millis(50)).is_err());
+        assert!(state.published_diagnostics.is_empty());
     }
 
     #[test]
@@ -272,14 +320,18 @@ pub(crate) struct PublishDiagnosticsTask {
 
 #[derive(Debug)]
 pub(crate) struct PublishDiagnosticsBatch {
+    diagnostics_revision: u64,
     touched_file_ids: FxHashSet<FileId>,
     tasks: Vec<PublishDiagnosticsTask>,
 }
 
 impl PublishDiagnosticsBatch {
-    pub(crate) fn from_tasks(tasks: Vec<PublishDiagnosticsTask>) -> Self {
+    pub(crate) fn from_tasks(
+        tasks: Vec<PublishDiagnosticsTask>,
+        diagnostics_revision: u64,
+    ) -> Self {
         let touched_file_ids = tasks.iter().map(|task| task.file_id).collect();
-        Self { touched_file_ids, tasks }
+        Self { diagnostics_revision, touched_file_ids, tasks }
     }
 
     /// Builds a diagnostics batch for files whose publish target set may have
@@ -290,8 +342,9 @@ impl PublishDiagnosticsBatch {
     pub(crate) fn for_touched_files(
         touched_file_ids: FxHashSet<FileId>,
         tasks: Vec<PublishDiagnosticsTask>,
+        diagnostics_revision: u64,
     ) -> Self {
-        Self { touched_file_ids, tasks }
+        Self { diagnostics_revision, touched_file_ids, tasks }
     }
 
     #[cfg(test)]
@@ -389,9 +442,9 @@ pub(crate) enum Task {
 
 #[derive(Debug)]
 pub(crate) enum QiheTask {
-    Log { token: String, message: String },
-    Finished { update: QiheUpdate, progress_token: String },
-    Failed { message: String, progress_token: String },
+    Log { run_id: QiheRunId, token: String, message: String },
+    Finished { run_id: QiheRunId, update: QiheUpdate, progress_token: String },
+    Failed { run_id: QiheRunId, message: String, progress_token: String },
 }
 
 impl Task {
@@ -445,13 +498,13 @@ impl QiheTask {
 
     fn summary(&self) -> String {
         match self {
-            QiheTask::Log { token, message } => {
+            QiheTask::Log { token, message, .. } => {
                 format!("task qihe log token={token} bytes={}", message.len())
             }
             QiheTask::Finished { progress_token, .. } => {
                 format!("task qihe finished token={progress_token}")
             }
-            QiheTask::Failed { progress_token, message } => {
+            QiheTask::Failed { progress_token, message, .. } => {
                 format!("task qihe failed token={progress_token} message={message}")
             }
         }
@@ -864,7 +917,15 @@ impl GlobalState {
         let mut published_files = 0usize;
         let mut published_diagnostics = 0usize;
         let mut skipped_files = 0usize;
-        let PublishDiagnosticsBatch { touched_file_ids, tasks } = batch;
+        let PublishDiagnosticsBatch { diagnostics_revision, touched_file_ids, tasks } = batch;
+        if diagnostics_revision != self.diagnostics_revision {
+            tracing::debug!(
+                diagnostics_revision,
+                current_diagnostics_revision = self.diagnostics_revision,
+                "stale diagnostics batch ignored"
+            );
+            return;
+        }
         let current_targets =
             tasks.iter().map(PublishDiagnosticsTask::cache_key).collect::<FxHashSet<_>>();
         let stale_targets = self

--- a/src/global_state/main_loop.rs
+++ b/src/global_state/main_loop.rs
@@ -17,6 +17,7 @@ use super::{
     qihe::QiheUpdate,
     reload::FetchWorkspaceProgress,
     respond::Progress,
+    snapshot::DiagnosticPublishTarget,
 };
 use crate::{config::Config, global_state::DEFAULT_REQ_HANDLER, i18n::keys};
 
@@ -143,12 +144,12 @@ mod tests {
         };
 
         state.publish_diagnostics_tasks(
-            publish_batch(vec![PublishDiagnosticsTask {
+            publish_batch(vec![PublishDiagnosticsTask::for_test(
                 file_id,
-                uri: primary_uri.clone(),
-                version: None,
-                diagnostics: vec![diagnostic.clone()],
-            }]),
+                primary_uri.clone(),
+                None,
+                vec![diagnostic.clone()],
+            )]),
             false,
         );
         let first = recv_publish(&client);
@@ -156,12 +157,12 @@ mod tests {
         assert_eq!(first.diagnostics, vec![diagnostic.clone()]);
 
         state.publish_diagnostics_tasks(
-            publish_batch(vec![PublishDiagnosticsTask {
+            publish_batch(vec![PublishDiagnosticsTask::for_test(
                 file_id,
-                uri: alias_uri.clone(),
-                version: Some(7),
-                diagnostics: vec![diagnostic.clone()],
-            }]),
+                alias_uri.clone(),
+                Some(7),
+                vec![diagnostic.clone()],
+            )]),
             false,
         );
 
@@ -175,7 +176,7 @@ mod tests {
         assert!(
             state
                 .published_diagnostics
-                .contains_key(&DiagnosticPublishKey { file_id, uri: alias_uri })
+                .contains_key(&DiagnosticPublishKey::for_test(file_id, alias_uri))
         );
     }
 
@@ -211,12 +212,12 @@ mod tests {
         };
 
         state.publish_diagnostics_tasks(
-            publish_batch(vec![PublishDiagnosticsTask {
+            publish_batch(vec![PublishDiagnosticsTask::for_test(
                 file_id,
-                uri: alias_uri.clone(),
-                version: Some(9),
-                diagnostics: vec![diagnostic],
-            }]),
+                alias_uri.clone(),
+                Some(9),
+                vec![diagnostic],
+            )]),
             false,
         );
         let published = recv_publish(&client);
@@ -224,10 +225,7 @@ mod tests {
         assert!(!published.diagnostics.is_empty());
 
         state.publish_diagnostics_tasks(
-            PublishDiagnosticsBatch {
-                touched_file_ids: FxHashSet::from_iter([file_id]),
-                tasks: Vec::new(),
-            },
+            PublishDiagnosticsBatch::for_touched_files(FxHashSet::from_iter([file_id]), Vec::new()),
             false,
         );
 
@@ -237,7 +235,7 @@ mod tests {
         assert!(
             !state
                 .published_diagnostics
-                .contains_key(&DiagnosticPublishKey { file_id, uri: alias_uri })
+                .contains_key(&DiagnosticPublishKey::for_test(file_id, alias_uri))
         );
     }
 
@@ -266,22 +264,49 @@ mod tests {
 
 #[derive(Debug)]
 pub(crate) struct PublishDiagnosticsTask {
-    pub(crate) file_id: FileId,
-    pub(crate) uri: lsp_types::Url,
-    pub(crate) version: Option<i32>,
-    pub(crate) diagnostics: Vec<lsp_types::Diagnostic>,
+    file_id: FileId,
+    uri: lsp_types::Url,
+    version: Option<i32>,
+    diagnostics: Vec<lsp_types::Diagnostic>,
 }
 
 #[derive(Debug)]
 pub(crate) struct PublishDiagnosticsBatch {
-    pub(crate) touched_file_ids: FxHashSet<FileId>,
-    pub(crate) tasks: Vec<PublishDiagnosticsTask>,
+    touched_file_ids: FxHashSet<FileId>,
+    tasks: Vec<PublishDiagnosticsTask>,
 }
 
 impl PublishDiagnosticsBatch {
     pub(crate) fn from_tasks(tasks: Vec<PublishDiagnosticsTask>) -> Self {
         let touched_file_ids = tasks.iter().map(|task| task.file_id).collect();
         Self { touched_file_ids, tasks }
+    }
+
+    /// Builds a diagnostics batch for files whose publish target set may have
+    /// changed independently from diagnostics contents.
+    ///
+    /// This is what lets didClose clear stale URI diagnostics even when the
+    /// remaining target set is empty.
+    pub(crate) fn for_touched_files(
+        touched_file_ids: FxHashSet<FileId>,
+        tasks: Vec<PublishDiagnosticsTask>,
+    ) -> Self {
+        Self { touched_file_ids, tasks }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn touched_file_ids(&self) -> &FxHashSet<FileId> {
+        &self.touched_file_ids
+    }
+
+    #[cfg(test)]
+    pub(crate) fn tasks(&self) -> &[PublishDiagnosticsTask] {
+        &self.tasks
+    }
+
+    #[cfg(test)]
+    pub(crate) fn into_tasks(self) -> Vec<PublishDiagnosticsTask> {
+        self.tasks
     }
 }
 
@@ -290,13 +315,66 @@ pub(crate) struct DiagnosticPublishKey {
     /// Diagnostics are computed per analysis file but delivered per LSP URI.
     /// Keeping both parts in the cache key prevents an alias URI from being
     /// skipped just because the same diagnostic list was sent to another URI.
-    pub(crate) file_id: FileId,
-    pub(crate) uri: lsp_types::Url,
+    file_id: FileId,
+    uri: lsp_types::Url,
+}
+
+impl DiagnosticPublishKey {
+    fn new(file_id: FileId, uri: lsp_types::Url) -> Self {
+        Self { file_id, uri }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(file_id: FileId, uri: lsp_types::Url) -> Self {
+        Self::new(file_id, uri)
+    }
 }
 
 impl PublishDiagnosticsTask {
+    pub(crate) fn from_target(
+        target: DiagnosticPublishTarget,
+        diagnostics: Vec<lsp_types::Diagnostic>,
+    ) -> Self {
+        let (file_id, uri, version) = target.into_parts();
+        Self { file_id, uri, version, diagnostics }
+    }
+
+    /// Clears diagnostics previously published to a concrete URI that is no
+    /// longer a live target, such as a deleted duplicate identity spelling.
+    ///
+    /// Normal diagnostics publishing should use [`Self::from_target`] so URI
+    /// and version always come from the same document target.
+    pub(crate) fn clear_stale_uri(file_id: FileId, uri: lsp_types::Url) -> Self {
+        Self { file_id, uri, version: None, diagnostics: Vec::new() }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn file_id(&self) -> FileId {
+        self.file_id
+    }
+
+    #[cfg(test)]
+    pub(crate) fn uri(&self) -> &lsp_types::Url {
+        &self.uri
+    }
+
+    #[cfg(test)]
+    pub(crate) fn version(&self) -> Option<i32> {
+        self.version
+    }
+
     fn cache_key(&self) -> DiagnosticPublishKey {
-        DiagnosticPublishKey { file_id: self.file_id, uri: self.uri.clone() }
+        DiagnosticPublishKey::new(self.file_id, self.uri.clone())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(
+        file_id: FileId,
+        uri: lsp_types::Url,
+        version: Option<i32>,
+        diagnostics: Vec<lsp_types::Diagnostic>,
+    ) -> Self {
+        Self { file_id, uri, version, diagnostics }
     }
 }
 

--- a/src/global_state/main_loop.rs
+++ b/src/global_state/main_loop.rs
@@ -107,7 +107,7 @@ mod tests {
     }
 
     fn publish_batch(tasks: Vec<PublishDiagnosticsTask>) -> PublishDiagnosticsBatch {
-        PublishDiagnosticsBatch::from_tasks(tasks, 0)
+        PublishDiagnosticsBatch::from_tasks(tasks, DiagnosticPublishFreshness::default())
     }
 
     #[test]
@@ -228,7 +228,7 @@ mod tests {
             PublishDiagnosticsBatch::for_touched_files(
                 FxHashSet::from_iter([file_id]),
                 Vec::new(),
-                0,
+                DiagnosticPublishFreshness::default(),
             ),
             false,
         );
@@ -278,7 +278,7 @@ mod tests {
         state.publish_diagnostics_tasks(
             PublishDiagnosticsBatch::from_tasks(
                 vec![PublishDiagnosticsTask::for_test(file_id, uri, None, vec![diagnostic])],
-                1,
+                DiagnosticPublishFreshness::new(1, 0),
             ),
             false,
         );
@@ -320,18 +320,37 @@ pub(crate) struct PublishDiagnosticsTask {
 
 #[derive(Debug)]
 pub(crate) struct PublishDiagnosticsBatch {
-    diagnostics_revision: u64,
+    freshness: DiagnosticPublishFreshness,
     touched_file_ids: FxHashSet<FileId>,
     tasks: Vec<PublishDiagnosticsTask>,
+}
+
+/// Freshness token for a diagnostics publish batch.
+///
+/// Diagnostic contents and diagnostic publish targets can change
+/// independently. VFS/content/config changes advance `diagnostics_revision`;
+/// didOpen/didClose and identity remaps advance `target_revision` because they
+/// change which URIs are live publish targets without necessarily changing the
+/// analysis text.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct DiagnosticPublishFreshness {
+    diagnostics_revision: u64,
+    target_revision: u64,
+}
+
+impl DiagnosticPublishFreshness {
+    pub(crate) fn new(diagnostics_revision: u64, target_revision: u64) -> Self {
+        Self { diagnostics_revision, target_revision }
+    }
 }
 
 impl PublishDiagnosticsBatch {
     pub(crate) fn from_tasks(
         tasks: Vec<PublishDiagnosticsTask>,
-        diagnostics_revision: u64,
+        freshness: DiagnosticPublishFreshness,
     ) -> Self {
         let touched_file_ids = tasks.iter().map(|task| task.file_id).collect();
-        Self { diagnostics_revision, touched_file_ids, tasks }
+        Self { freshness, touched_file_ids, tasks }
     }
 
     /// Builds a diagnostics batch for files whose publish target set may have
@@ -342,9 +361,9 @@ impl PublishDiagnosticsBatch {
     pub(crate) fn for_touched_files(
         touched_file_ids: FxHashSet<FileId>,
         tasks: Vec<PublishDiagnosticsTask>,
-        diagnostics_revision: u64,
+        freshness: DiagnosticPublishFreshness,
     ) -> Self {
-        Self { diagnostics_revision, touched_file_ids, tasks }
+        Self { freshness, touched_file_ids, tasks }
     }
 
     #[cfg(test)]
@@ -917,13 +936,10 @@ impl GlobalState {
         let mut published_files = 0usize;
         let mut published_diagnostics = 0usize;
         let mut skipped_files = 0usize;
-        let PublishDiagnosticsBatch { diagnostics_revision, touched_file_ids, tasks } = batch;
-        if diagnostics_revision != self.diagnostics_revision {
-            tracing::debug!(
-                diagnostics_revision,
-                current_diagnostics_revision = self.diagnostics_revision,
-                "stale diagnostics batch ignored"
-            );
+        let PublishDiagnosticsBatch { freshness, touched_file_ids, tasks } = batch;
+        let current_freshness = self.diagnostic_publish_freshness();
+        if freshness != current_freshness {
+            tracing::debug!(?freshness, ?current_freshness, "stale diagnostics batch ignored");
             return;
         }
         let current_targets =

--- a/src/global_state/main_loop.rs
+++ b/src/global_state/main_loop.rs
@@ -5,6 +5,7 @@ use crossbeam_channel::{Receiver, select};
 use lsp_server::{Connection, Message, Notification, Request, Response};
 use lsp_types::{TraceValue, notification::Notification as _};
 use project_model::project_manifest;
+use rustc_hash::FxHashSet;
 use triomphe::Arc;
 use utils::thread::ThreadIntent;
 use vfs::{FileId, VfsPath, loader as vfs_loader};
@@ -62,12 +63,18 @@ impl Event {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use lsp_server::Connection;
+    use lsp_types::{
+        Diagnostic, DiagnosticSeverity, Position, PublishDiagnosticsParams, Range,
+        notification::Notification as _,
+    };
     use utils::{lines::LineEnding, paths::AbsPathBuf, test_support::TestDir};
     use vfs::loader::LoadResult;
 
     use super::*;
-    use crate::{Opt, config::user_config::UserConfig, i18n::I18n};
+    use crate::{Opt, config::user_config::UserConfig, i18n::I18n, lsp_ext::to_proto};
 
     fn test_state(root_path: AbsPathBuf) -> GlobalState {
         let config = Config::new(
@@ -87,6 +94,151 @@ mod tests {
 
         let (server, _client) = Connection::memory();
         GlobalState::new(server.sender, config, lsp_types::TraceValue::Off)
+    }
+
+    fn recv_publish(client: &Connection) -> PublishDiagnosticsParams {
+        let message = client.receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+        let lsp_server::Message::Notification(notification) = message else {
+            panic!("expected publishDiagnostics notification");
+        };
+        assert_eq!(notification.method, lsp_types::notification::PublishDiagnostics::METHOD);
+        serde_json::from_value(notification.params).unwrap()
+    }
+
+    fn publish_batch(tasks: Vec<PublishDiagnosticsTask>) -> PublishDiagnosticsBatch {
+        PublishDiagnosticsBatch::from_tasks(tasks)
+    }
+
+    #[test]
+    fn publish_diagnostics_cache_is_scoped_by_file_and_uri() {
+        let root = TestDir::new("diagnostics-cache-by-uri");
+        let root_path = root.path().to_path_buf();
+        let config = Config::new(
+            Opt {
+                process_name: "vizsla-test".to_string(),
+                log: "error".to_string(),
+                log_filename: None,
+                profile_trace: None,
+            },
+            root_path.clone(),
+            lsp_types::ClientCapabilities::default(),
+            vec![root_path],
+            I18n::default(),
+            UserConfig::default(),
+            Vec::new(),
+        );
+        let (server, client) = Connection::memory();
+        let mut state = GlobalState::new(server.sender, config, lsp_types::TraceValue::Off);
+        let file_id = FileId(0);
+        let primary_uri =
+            to_proto::url_from_abs_path(root.write("workspace/top.sv", "").as_path()).unwrap();
+        let alias_uri =
+            to_proto::url_from_abs_path(root.write("alias/top.sv", "").as_path()).unwrap();
+        let diagnostic = Diagnostic {
+            range: Range::new(Position::new(0, 0), Position::new(0, 1)),
+            severity: Some(DiagnosticSeverity::ERROR),
+            source: Some("test".to_owned()),
+            message: "same diagnostic".to_owned(),
+            ..Diagnostic::default()
+        };
+
+        state.publish_diagnostics_tasks(
+            publish_batch(vec![PublishDiagnosticsTask {
+                file_id,
+                uri: primary_uri.clone(),
+                version: None,
+                diagnostics: vec![diagnostic.clone()],
+            }]),
+            false,
+        );
+        let first = recv_publish(&client);
+        assert_eq!(first.uri, primary_uri);
+        assert_eq!(first.diagnostics, vec![diagnostic.clone()]);
+
+        state.publish_diagnostics_tasks(
+            publish_batch(vec![PublishDiagnosticsTask {
+                file_id,
+                uri: alias_uri.clone(),
+                version: Some(7),
+                diagnostics: vec![diagnostic.clone()],
+            }]),
+            false,
+        );
+
+        let clear_primary = recv_publish(&client);
+        assert_eq!(clear_primary.uri, primary_uri);
+        assert!(clear_primary.diagnostics.is_empty());
+        let publish_alias = recv_publish(&client);
+        assert_eq!(publish_alias.uri, alias_uri);
+        assert_eq!(publish_alias.version, Some(7));
+        assert_eq!(publish_alias.diagnostics, vec![diagnostic]);
+        assert!(
+            state
+                .published_diagnostics
+                .contains_key(&DiagnosticPublishKey { file_id, uri: alias_uri })
+        );
+    }
+
+    #[test]
+    fn publish_diagnostics_clears_stale_targets_when_target_set_is_empty() {
+        let root = TestDir::new("diagnostics-clear-empty-target-set");
+        let root_path = root.path().to_path_buf();
+        let config = Config::new(
+            Opt {
+                process_name: "vizsla-test".to_string(),
+                log: "error".to_string(),
+                log_filename: None,
+                profile_trace: None,
+            },
+            root_path.clone(),
+            lsp_types::ClientCapabilities::default(),
+            vec![root_path],
+            I18n::default(),
+            UserConfig::default(),
+            Vec::new(),
+        );
+        let (server, client) = Connection::memory();
+        let mut state = GlobalState::new(server.sender, config, lsp_types::TraceValue::Off);
+        let file_id = FileId(0);
+        let alias_uri =
+            to_proto::url_from_abs_path(root.write("alias/top.sv", "").as_path()).unwrap();
+        let diagnostic = Diagnostic {
+            range: Range::new(Position::new(0, 0), Position::new(0, 1)),
+            severity: Some(DiagnosticSeverity::ERROR),
+            source: Some("test".to_owned()),
+            message: "stale alias diagnostic".to_owned(),
+            ..Diagnostic::default()
+        };
+
+        state.publish_diagnostics_tasks(
+            publish_batch(vec![PublishDiagnosticsTask {
+                file_id,
+                uri: alias_uri.clone(),
+                version: Some(9),
+                diagnostics: vec![diagnostic],
+            }]),
+            false,
+        );
+        let published = recv_publish(&client);
+        assert_eq!(published.uri, alias_uri);
+        assert!(!published.diagnostics.is_empty());
+
+        state.publish_diagnostics_tasks(
+            PublishDiagnosticsBatch {
+                touched_file_ids: FxHashSet::from_iter([file_id]),
+                tasks: Vec::new(),
+            },
+            false,
+        );
+
+        let cleared = recv_publish(&client);
+        assert_eq!(cleared.uri, alias_uri);
+        assert!(cleared.diagnostics.is_empty());
+        assert!(
+            !state
+                .published_diagnostics
+                .contains_key(&DiagnosticPublishKey { file_id, uri: alias_uri })
+        );
     }
 
     #[test]
@@ -121,11 +273,39 @@ pub(crate) struct PublishDiagnosticsTask {
 }
 
 #[derive(Debug)]
+pub(crate) struct PublishDiagnosticsBatch {
+    pub(crate) touched_file_ids: FxHashSet<FileId>,
+    pub(crate) tasks: Vec<PublishDiagnosticsTask>,
+}
+
+impl PublishDiagnosticsBatch {
+    pub(crate) fn from_tasks(tasks: Vec<PublishDiagnosticsTask>) -> Self {
+        let touched_file_ids = tasks.iter().map(|task| task.file_id).collect();
+        Self { touched_file_ids, tasks }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct DiagnosticPublishKey {
+    /// Diagnostics are computed per analysis file but delivered per LSP URI.
+    /// Keeping both parts in the cache key prevents an alias URI from being
+    /// skipped just because the same diagnostic list was sent to another URI.
+    pub(crate) file_id: FileId,
+    pub(crate) uri: lsp_types::Url,
+}
+
+impl PublishDiagnosticsTask {
+    fn cache_key(&self) -> DiagnosticPublishKey {
+        DiagnosticPublishKey { file_id: self.file_id, uri: self.uri.clone() }
+    }
+}
+
+#[derive(Debug)]
 pub(crate) enum Task {
     Response(lsp_server::Response),
     Retry(lsp_server::Request),
     FetchWorkspace(FetchWorkspaceProgress),
-    Diagnostics(Vec<PublishDiagnosticsTask>),
+    Diagnostics(PublishDiagnosticsBatch),
     Qihe(QiheTask),
 }
 
@@ -165,8 +345,11 @@ impl Task {
                 )
             }
             Task::Diagnostics(tasks) => {
-                let diagnostic_count = diagnostic_task_item_count(tasks);
-                format!("task diagnostics files={} diagnostics={diagnostic_count}", tasks.len())
+                let diagnostic_count = diagnostic_task_item_count(&tasks.tasks);
+                format!(
+                    "task diagnostics files={} diagnostics={diagnostic_count}",
+                    tasks.touched_file_ids.len()
+                )
             }
             Task::Qihe(task) => task.summary(),
         }
@@ -586,11 +769,11 @@ impl GlobalState {
 
     pub(super) fn publish_diagnostics_tasks(
         &mut self,
-        diagnostics: Vec<PublishDiagnosticsTask>,
+        batch: PublishDiagnosticsBatch,
         force_push: bool,
     ) {
-        let task_count = diagnostics.len();
-        let diagnostic_count = diagnostic_task_item_count(&diagnostics);
+        let task_count = batch.touched_file_ids.len();
+        let diagnostic_count = diagnostic_task_item_count(&batch.tasks);
         let _span =
             tracing::info_span!("diagnostics.publish", task_count, diagnostic_count, force_push)
                 .entered();
@@ -603,9 +786,31 @@ impl GlobalState {
         let mut published_files = 0usize;
         let mut published_diagnostics = 0usize;
         let mut skipped_files = 0usize;
-        for diag in diagnostics {
+        let PublishDiagnosticsBatch { touched_file_ids, tasks } = batch;
+        let current_targets =
+            tasks.iter().map(PublishDiagnosticsTask::cache_key).collect::<FxHashSet<_>>();
+        let stale_targets = self
+            .published_diagnostics
+            .keys()
+            .filter(|key| touched_file_ids.contains(&key.file_id) && !current_targets.contains(key))
+            .cloned()
+            .collect::<Vec<_>>();
+        for key in stale_targets {
+            self.published_diagnostics.remove(&key);
+            self.send_notification::<lsp_types::notification::PublishDiagnostics>(
+                lsp_types::PublishDiagnosticsParams {
+                    uri: key.uri,
+                    diagnostics: Vec::new(),
+                    version: None,
+                },
+            );
+            published_files += 1;
+        }
+
+        for diag in tasks {
             let file_diagnostics = diag.diagnostics.len();
-            let should_publish = match self.diagnostics.get(&diag.file_id) {
+            let cache_key = diag.cache_key();
+            let should_publish = match self.published_diagnostics.get(&cache_key) {
                 Some(prev) => prev != &diag.diagnostics,
                 None => !diag.diagnostics.is_empty(),
             };
@@ -616,9 +821,9 @@ impl GlobalState {
             }
 
             if diag.diagnostics.is_empty() {
-                self.diagnostics.remove(&diag.file_id);
+                self.published_diagnostics.remove(&cache_key);
             } else {
-                self.diagnostics.insert(diag.file_id, diag.diagnostics.clone());
+                self.published_diagnostics.insert(cache_key, diag.diagnostics.clone());
             }
 
             self.send_notification::<lsp_types::notification::PublishDiagnostics>(

--- a/src/global_state/main_loop.rs
+++ b/src/global_state/main_loop.rs
@@ -573,7 +573,10 @@ impl GlobalState {
 
                 for (path, content) in files {
                     let path = VfsPath::from(path);
-                    if !self.mem_docs.contains_path(&path) {
+                    let open_file_id = vfs
+                        .file_id(&path)
+                        .is_some_and(|file_id| self.mem_docs.contains_file_id(file_id));
+                    if !self.mem_docs.contains_path(&path) && !open_file_id {
                         vfs.set_file_contents(&path, content);
                     }
                 }

--- a/src/global_state/mem_docs.rs
+++ b/src/global_state/mem_docs.rs
@@ -24,13 +24,17 @@ pub(crate) struct OpenDocument {
 struct OpenDocumentAlias {
     file_id: FileId,
     version: i32,
+    buffer_attached: bool,
 }
 
 // Files managed by client via textDocument/didOpen and textDocument/didClose.
 //
 // MemDocs keeps one analysis buffer per canonical FileId and one LSP document
 // version per open URI spelling. Multiple open URI aliases therefore share
-// text, but their version numbers remain URI-local.
+// text when their didOpen contents agree, but their version numbers remain
+// URI-local. An alias opened with divergent text is tracked for close/version
+// bookkeeping but is detached from the canonical analysis buffer; supporting
+// multiple unsaved alias buffers is a separate design.
 #[derive(Default, Clone)]
 pub(crate) struct MemDocs {
     buffers: FxHashMap<FileId, OpenBuffer>,
@@ -57,8 +61,10 @@ impl MemDocs {
             return true;
         }
 
-        if let Some(old_alias) =
-            self.open_paths.insert(path.clone(), OpenDocumentAlias { file_id, version })
+        let buffer_attached = self.buffers.get(&file_id).is_none_or(|buffer| buffer.data == data);
+        if let Some(old_alias) = self
+            .open_paths
+            .insert(path.clone(), OpenDocumentAlias { file_id, version, buffer_attached })
             && old_alias.file_id != file_id
         {
             self.reconcile_buffer_path(old_alias.file_id);
@@ -90,9 +96,13 @@ impl MemDocs {
         }
 
         let duplicate_buffer = self.buffers.remove(&from);
+        let attaches_to_existing_buffer = duplicate_buffer.as_ref().is_none_or(|buffer| {
+            self.buffers.get(&to).is_none_or(|existing| existing.data == buffer.data)
+        });
         for alias in self.open_paths.values_mut() {
             if alias.file_id == from {
                 alias.file_id = to;
+                alias.buffer_attached &= attaches_to_existing_buffer;
             }
         }
         if !self.buffers.contains_key(&to)
@@ -103,18 +113,34 @@ impl MemDocs {
         self.reconcile_buffer_path(to);
     }
 
-    pub(crate) fn text_mut_for_change(
+    pub(crate) fn text_for_change(&self, path: &VfsPath, file_id: FileId) -> Option<&str> {
+        let alias = self.open_paths.get(path)?;
+        if alias.file_id != file_id || !alias.buffer_attached {
+            return None;
+        }
+        self.text(file_id)
+    }
+
+    pub(crate) fn apply_change(
         &mut self,
         path: &VfsPath,
         file_id: FileId,
         version: i32,
-    ) -> Option<&mut String> {
-        let alias = self.open_paths.get_mut(path)?;
-        if alias.file_id != file_id {
-            return None;
+        data: Option<String>,
+    ) -> bool {
+        let Some(alias) = self.open_paths.get_mut(path) else {
+            return false;
+        };
+        if alias.file_id != file_id || !alias.buffer_attached {
+            return false;
         }
         alias.version = version;
-        self.buffers.get_mut(&file_id).map(|buffer| &mut buffer.data)
+        if let Some(data) = data
+            && let Some(buffer) = self.buffers.get_mut(&file_id)
+        {
+            buffer.data = data;
+        }
+        true
     }
 
     pub(crate) fn version(&self, file_id: FileId) -> Option<i32> {
@@ -122,11 +148,15 @@ impl MemDocs {
         self.version_for_path(path)
     }
 
+    pub(crate) fn text(&self, file_id: FileId) -> Option<&str> {
+        Some(self.buffers.get(&file_id)?.data.as_str())
+    }
+
     pub(crate) fn open_documents(&self, file_id: FileId) -> Vec<OpenDocument> {
         let mut documents = self
             .open_paths
             .iter()
-            .filter(|(_, alias)| alias.file_id == file_id)
+            .filter(|(_, alias)| alias.file_id == file_id && alias.buffer_attached)
             .map(|(path, alias)| OpenDocument { path: path.clone(), version: alias.version })
             .collect::<Vec<_>>();
         documents.sort_unstable_by(|lhs, rhs| lhs.path.cmp(&rhs.path));
@@ -150,14 +180,17 @@ impl MemDocs {
         else {
             return;
         };
-        if self.open_paths.get(&current_path).is_some_and(|alias| alias.file_id == file_id) {
+        if self
+            .open_paths
+            .get(&current_path)
+            .is_some_and(|alias| alias.file_id == file_id && alias.buffer_attached)
+        {
             return;
         }
 
-        let replacement_path = self
-            .open_paths
-            .iter()
-            .find_map(|(path, alias)| (alias.file_id == file_id).then(|| path.clone()));
+        let replacement_path = self.open_paths.iter().find_map(|(path, alias)| {
+            (alias.file_id == file_id && alias.buffer_attached).then(|| path.clone())
+        });
         match replacement_path {
             Some(path) => {
                 if let Some(buffer) = self.buffers.get_mut(&file_id) {
@@ -211,6 +244,11 @@ mod tests {
         assert_eq!(docs.file_id(&alias_path), Some(canonical));
         assert_eq!(docs.version_for_path(&canonical_path), Some(1));
         assert_eq!(docs.version_for_path(&alias_path), Some(2));
+        assert_eq!(docs.text_for_change(&alias_path, canonical), None);
+        assert_eq!(
+            docs.open_documents(canonical).into_iter().map(|doc| doc.path).collect::<Vec<_>>(),
+            vec![canonical_path]
+        );
     }
 
     #[test]
@@ -220,7 +258,7 @@ mod tests {
         let canonical = FileId(0);
         let mut docs = MemDocs::default();
         docs.insert(canonical, canonical_path.clone(), 1, "canonical text".to_owned());
-        docs.insert(canonical, alias_path.clone(), 2, "alias text".to_owned());
+        docs.insert(canonical, alias_path.clone(), 2, "canonical text".to_owned());
 
         assert!(docs.remove_path(&alias_path));
 
@@ -240,7 +278,7 @@ mod tests {
         let canonical = FileId(0);
         let mut docs = MemDocs::default();
         docs.insert(canonical, canonical_path.clone(), 1, "canonical text".to_owned());
-        docs.insert(canonical, alias_path.clone(), 2, "alias text".to_owned());
+        docs.insert(canonical, alias_path.clone(), 2, "canonical text".to_owned());
 
         assert!(docs.remove_path(&canonical_path));
 
@@ -263,8 +301,9 @@ mod tests {
         docs.insert(canonical, canonical_path.clone(), 1, "module top; endmodule\n".to_owned());
         docs.insert(canonical, alias_path.clone(), 7, "module top; endmodule\n".to_owned());
 
-        let data = docs.text_mut_for_change(&alias_path, canonical, 8).unwrap();
+        let mut data = docs.text_for_change(&alias_path, canonical).unwrap().to_owned();
         data.push_str("// alias edit\n");
+        assert!(docs.apply_change(&alias_path, canonical, 8, Some(data)));
 
         assert_eq!(
             docs.buffers.get(&canonical).unwrap().data,
@@ -273,6 +312,26 @@ mod tests {
         assert_eq!(docs.version_for_path(&canonical_path), Some(1));
         assert_eq!(docs.version_for_path(&alias_path), Some(8));
         assert_eq!(docs.version(canonical), Some(1));
+    }
+
+    #[test]
+    fn divergent_alias_open_is_detached_from_canonical_buffer() {
+        let canonical_path = VfsPath::new_virtual_path("/workspace/top.sv".to_owned());
+        let alias_path = VfsPath::new_virtual_path("/alias/top.sv".to_owned());
+        let canonical = FileId(0);
+        let mut docs = MemDocs::default();
+        docs.insert(canonical, canonical_path.clone(), 1, "canonical text".to_owned());
+        docs.insert(canonical, alias_path.clone(), 7, "alias text".to_owned());
+
+        assert_eq!(docs.version_for_path(&alias_path), Some(7));
+        assert_eq!(docs.file_id(&alias_path), Some(canonical));
+        assert_eq!(docs.text_for_change(&alias_path, canonical), None);
+        assert!(!docs.apply_change(&alias_path, canonical, 8, Some("new alias text".to_owned())));
+        assert_eq!(docs.buffers.get(&canonical).unwrap().data, "canonical text");
+        assert_eq!(
+            docs.open_documents(canonical).into_iter().map(|doc| doc.path).collect::<Vec<_>>(),
+            vec![canonical_path]
+        );
     }
 
     #[test]

--- a/src/global_state/mem_docs.rs
+++ b/src/global_state/mem_docs.rs
@@ -35,6 +35,10 @@ struct OpenDocumentAlias {
 // URI-local. An alias opened with divergent text is tracked for close/version
 // bookkeeping but is detached from the canonical analysis buffer; supporting
 // multiple unsaved alias buffers is a separate design.
+//
+// TODO: Allow detached aliases to reattach on a full-document change that
+// matches the canonical analysis buffer, or expose an explicit unsupported
+// multi-alias-unsaved-buffer status to the client.
 #[derive(Default, Clone)]
 pub(crate) struct MemDocs {
     buffers: FxHashMap<FileId, OpenBuffer>,

--- a/src/global_state/mem_docs.rs
+++ b/src/global_state/mem_docs.rs
@@ -2,28 +2,41 @@ use rustc_hash::FxHashMap;
 use vfs::{FileId, VfsPath};
 
 #[derive(Debug, Clone)]
-pub(crate) struct OpenDocument {
+pub(crate) struct OpenBuffer {
     pub(crate) path: VfsPath,
-    pub(crate) version: i32,
     pub(crate) data: String,
 }
 
-impl OpenDocument {
-    pub(crate) fn new(path: VfsPath, version: i32, data: String) -> Self {
-        Self { path, version, data }
+impl OpenBuffer {
+    pub(crate) fn new(path: VfsPath, data: String) -> Self {
+        Self { path, data }
     }
 }
 
+#[derive(Debug, Clone)]
+struct OpenDocumentAlias {
+    file_id: FileId,
+    version: i32,
+}
+
 // Files managed by client via textDocument/didOpen and textDocument/didClose.
+//
+// MemDocs keeps one analysis buffer per canonical FileId and one LSP document
+// version per open URI spelling. Multiple open URI aliases therefore share
+// text, but their version numbers remain URI-local.
 #[derive(Default, Clone)]
 pub(crate) struct MemDocs {
-    docs: FxHashMap<FileId, OpenDocument>,
-    file_id_by_path: FxHashMap<VfsPath, FileId>,
+    buffers: FxHashMap<FileId, OpenBuffer>,
+    open_paths: FxHashMap<VfsPath, OpenDocumentAlias>,
 }
 
 impl MemDocs {
     pub(crate) fn contains_path(&self, path: &VfsPath) -> bool {
-        self.file_id_by_path.contains_key(path)
+        self.open_paths.contains_key(path)
+    }
+
+    pub(crate) fn contains_file_id(&self, file_id: FileId) -> bool {
+        self.buffers.contains_key(&file_id)
     }
 
     pub(crate) fn insert(
@@ -32,43 +45,215 @@ impl MemDocs {
         path: VfsPath,
         version: i32,
         data: String,
-    ) -> Option<OpenDocument> {
-        if let Some(old_file_id) = self.file_id_by_path.insert(path.clone(), file_id)
-            && old_file_id != file_id
-        {
-            self.docs.remove(&old_file_id);
+    ) -> bool {
+        if self.open_paths.get(&path).is_some_and(|alias| alias.file_id == file_id) {
+            return true;
         }
 
-        if let Some(old_doc) =
-            self.docs.insert(file_id, OpenDocument::new(path.clone(), version, data))
+        if let Some(old_alias) =
+            self.open_paths.insert(path.clone(), OpenDocumentAlias { file_id, version })
+            && old_alias.file_id != file_id
         {
-            self.file_id_by_path.remove(&old_doc.path);
-            self.file_id_by_path.insert(path, file_id);
-            return Some(old_doc);
+            self.reconcile_buffer_path(old_alias.file_id);
         }
 
-        None
+        if self.buffers.contains_key(&file_id) {
+            // TODO: Support multiple independent unsaved buffers for URI
+            // aliases of the same physical file. That is intentionally not
+            // done in this T1 change; VFS and analysis currently have one text
+            // slot per canonical FileId.
+            return false;
+        }
+
+        self.buffers.insert(file_id, OpenBuffer::new(path, data));
+        false
     }
 
-    pub(crate) fn remove_path(&mut self, path: &VfsPath) -> Option<OpenDocument> {
-        let file_id = self.file_id_by_path.remove(path)?;
-        self.docs.remove(&file_id)
+    pub(crate) fn remove_path(&mut self, path: &VfsPath) -> bool {
+        let Some(alias) = self.open_paths.remove(path) else {
+            return false;
+        };
+        self.reconcile_buffer_path(alias.file_id);
+        true
     }
 
-    pub(crate) fn get_mut_by_path(&mut self, path: &VfsPath) -> Option<&mut OpenDocument> {
-        let file_id = self.file_id_by_path.get(path)?;
-        self.docs.get_mut(file_id)
+    pub(crate) fn remap_file_id(&mut self, from: FileId, to: FileId) {
+        if from == to {
+            return;
+        }
+
+        let duplicate_buffer = self.buffers.remove(&from);
+        for alias in self.open_paths.values_mut() {
+            if alias.file_id == from {
+                alias.file_id = to;
+            }
+        }
+        if !self.buffers.contains_key(&to)
+            && let Some(buffer) = duplicate_buffer
+        {
+            self.buffers.insert(to, buffer);
+        }
+        self.reconcile_buffer_path(to);
+    }
+
+    pub(crate) fn text_mut_for_change(
+        &mut self,
+        path: &VfsPath,
+        file_id: FileId,
+        version: i32,
+    ) -> Option<&mut String> {
+        let alias = self.open_paths.get_mut(path)?;
+        if alias.file_id != file_id {
+            return None;
+        }
+        alias.version = version;
+        self.buffers.get_mut(&file_id).map(|buffer| &mut buffer.data)
     }
 
     pub(crate) fn version(&self, file_id: FileId) -> Option<i32> {
-        Some(self.docs.get(&file_id)?.version)
+        let path = &self.buffers.get(&file_id)?.path;
+        self.version_for_path(path)
+    }
+
+    pub(crate) fn version_for_path(&self, path: &VfsPath) -> Option<i32> {
+        Some(self.open_paths.get(path)?.version)
     }
 
     pub(crate) fn file_id(&self, path: &VfsPath) -> Option<FileId> {
-        self.file_id_by_path.get(path).copied()
+        Some(self.open_paths.get(path)?.file_id)
     }
 
     pub(crate) fn file_ids(&self) -> impl Iterator<Item = FileId> + '_ {
-        self.docs.keys().copied()
+        self.buffers.keys().copied()
+    }
+
+    fn reconcile_buffer_path(&mut self, file_id: FileId) {
+        let Some(current_path) = self.buffers.get(&file_id).map(|buffer| buffer.path.clone())
+        else {
+            return;
+        };
+        if self.open_paths.get(&current_path).is_some_and(|alias| alias.file_id == file_id) {
+            return;
+        }
+
+        let replacement_path = self
+            .open_paths
+            .iter()
+            .find_map(|(path, alias)| (alias.file_id == file_id).then(|| path.clone()));
+        match replacement_path {
+            Some(path) => {
+                if let Some(buffer) = self.buffers.get_mut(&file_id) {
+                    buffer.path = path;
+                }
+            }
+            None => {
+                self.buffers.remove(&file_id);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remap_file_id_moves_open_document_to_canonical_id() {
+        let path = VfsPath::new_virtual_path("/workspace/top.sv".to_owned());
+        let duplicate = FileId(1);
+        let canonical = FileId(0);
+        let mut docs = MemDocs::default();
+        docs.insert(duplicate, path.clone(), 7, "module top; endmodule\n".to_owned());
+
+        docs.remap_file_id(duplicate, canonical);
+
+        assert!(!docs.contains_file_id(duplicate));
+        assert!(docs.contains_file_id(canonical));
+        assert_eq!(docs.file_id(&path), Some(canonical));
+        assert_eq!(docs.buffers.get(&canonical).unwrap().data, "module top; endmodule\n");
+        assert_eq!(docs.version(canonical), Some(7));
+        assert_eq!(docs.version_for_path(&path), Some(7));
+    }
+
+    #[test]
+    fn remap_file_id_preserves_existing_canonical_document() {
+        let canonical_path = VfsPath::new_virtual_path("/workspace/top.sv".to_owned());
+        let alias_path = VfsPath::new_virtual_path("/alias/top.sv".to_owned());
+        let duplicate = FileId(1);
+        let canonical = FileId(0);
+        let mut docs = MemDocs::default();
+        docs.insert(canonical, canonical_path.clone(), 1, "canonical text".to_owned());
+        docs.insert(duplicate, alias_path.clone(), 2, "alias text".to_owned());
+
+        docs.remap_file_id(duplicate, canonical);
+
+        let buffer = docs.buffers.get(&canonical).unwrap();
+        assert_eq!(buffer.path, canonical_path);
+        assert_eq!(buffer.data, "canonical text");
+        assert_eq!(docs.file_id(&alias_path), Some(canonical));
+        assert_eq!(docs.version_for_path(&canonical_path), Some(1));
+        assert_eq!(docs.version_for_path(&alias_path), Some(2));
+    }
+
+    #[test]
+    fn remove_path_closes_alias_without_removing_open_document() {
+        let canonical_path = VfsPath::new_virtual_path("/workspace/top.sv".to_owned());
+        let alias_path = VfsPath::new_virtual_path("/alias/top.sv".to_owned());
+        let canonical = FileId(0);
+        let mut docs = MemDocs::default();
+        docs.insert(canonical, canonical_path.clone(), 1, "canonical text".to_owned());
+        docs.insert(canonical, alias_path.clone(), 2, "alias text".to_owned());
+
+        assert!(docs.remove_path(&alias_path));
+
+        let buffer = docs.buffers.get(&canonical).unwrap();
+        assert_eq!(buffer.path, canonical_path);
+        assert_eq!(buffer.data, "canonical text");
+        assert_eq!(docs.file_id(&alias_path), None);
+        assert_eq!(docs.file_id(&canonical_path), Some(canonical));
+        assert_eq!(docs.version_for_path(&alias_path), None);
+        assert_eq!(docs.version_for_path(&canonical_path), Some(1));
+    }
+
+    #[test]
+    fn remove_path_promotes_remaining_alias_when_owner_path_closes() {
+        let canonical_path = VfsPath::new_virtual_path("/workspace/top.sv".to_owned());
+        let alias_path = VfsPath::new_virtual_path("/alias/top.sv".to_owned());
+        let canonical = FileId(0);
+        let mut docs = MemDocs::default();
+        docs.insert(canonical, canonical_path.clone(), 1, "canonical text".to_owned());
+        docs.insert(canonical, alias_path.clone(), 2, "alias text".to_owned());
+
+        assert!(docs.remove_path(&canonical_path));
+
+        let buffer = docs.buffers.get(&canonical).unwrap();
+        assert_eq!(buffer.path, alias_path);
+        assert_eq!(buffer.data, "canonical text");
+        assert_eq!(docs.file_id(&canonical_path), None);
+        assert_eq!(docs.file_id(&alias_path), Some(canonical));
+        assert_eq!(docs.version_for_path(&canonical_path), None);
+        assert_eq!(docs.version_for_path(&alias_path), Some(2));
+        assert_eq!(docs.version(canonical), Some(2));
+    }
+
+    #[test]
+    fn changes_update_only_the_changed_uri_version() {
+        let canonical_path = VfsPath::new_virtual_path("/workspace/top.sv".to_owned());
+        let alias_path = VfsPath::new_virtual_path("/alias/top.sv".to_owned());
+        let canonical = FileId(0);
+        let mut docs = MemDocs::default();
+        docs.insert(canonical, canonical_path.clone(), 1, "module top; endmodule\n".to_owned());
+        docs.insert(canonical, alias_path.clone(), 7, "module top; endmodule\n".to_owned());
+
+        let data = docs.text_mut_for_change(&alias_path, canonical, 8).unwrap();
+        data.push_str("// alias edit\n");
+
+        assert_eq!(
+            docs.buffers.get(&canonical).unwrap().data,
+            "module top; endmodule\n// alias edit\n"
+        );
+        assert_eq!(docs.version_for_path(&canonical_path), Some(1));
+        assert_eq!(docs.version_for_path(&alias_path), Some(8));
+        assert_eq!(docs.version(canonical), Some(1));
     }
 }

--- a/src/global_state/mem_docs.rs
+++ b/src/global_state/mem_docs.rs
@@ -13,6 +13,13 @@ impl OpenBuffer {
     }
 }
 
+/// One open URI spelling and its LSP document version.
+#[derive(Debug, Clone)]
+pub(crate) struct OpenDocument {
+    pub(crate) path: VfsPath,
+    pub(crate) version: i32,
+}
+
 #[derive(Debug, Clone)]
 struct OpenDocumentAlias {
     file_id: FileId,
@@ -113,6 +120,17 @@ impl MemDocs {
     pub(crate) fn version(&self, file_id: FileId) -> Option<i32> {
         let path = &self.buffers.get(&file_id)?.path;
         self.version_for_path(path)
+    }
+
+    pub(crate) fn open_documents(&self, file_id: FileId) -> Vec<OpenDocument> {
+        let mut documents = self
+            .open_paths
+            .iter()
+            .filter(|(_, alias)| alias.file_id == file_id)
+            .map(|(path, alias)| OpenDocument { path: path.clone(), version: alias.version })
+            .collect::<Vec<_>>();
+        documents.sort_unstable_by(|lhs, rhs| lhs.path.cmp(&rhs.path));
+        documents
     }
 
     pub(crate) fn version_for_path(&self, path: &VfsPath) -> Option<i32> {
@@ -255,5 +273,23 @@ mod tests {
         assert_eq!(docs.version_for_path(&canonical_path), Some(1));
         assert_eq!(docs.version_for_path(&alias_path), Some(8));
         assert_eq!(docs.version(canonical), Some(1));
+    }
+
+    #[test]
+    fn open_documents_return_every_uri_version() {
+        let canonical_path = VfsPath::new_virtual_path("/workspace/top.sv".to_owned());
+        let alias_path = VfsPath::new_virtual_path("/alias/top.sv".to_owned());
+        let canonical = FileId(0);
+        let mut docs = MemDocs::default();
+        docs.insert(canonical, canonical_path.clone(), 1, "module top; endmodule\n".to_owned());
+        docs.insert(canonical, alias_path.clone(), 7, "module top; endmodule\n".to_owned());
+
+        let documents = docs
+            .open_documents(canonical)
+            .into_iter()
+            .map(|document| (document.path, document.version))
+            .collect::<Vec<_>>();
+
+        assert_eq!(documents, vec![(alias_path, 7), (canonical_path, 1)]);
     }
 }

--- a/src/global_state/process_changes.rs
+++ b/src/global_state/process_changes.rs
@@ -201,7 +201,10 @@ impl GlobalState {
             })
             .collect();
 
-        self.publish_diagnostics_tasks(PublishDiagnosticsBatch::from_tasks(diagnostics), false);
+        self.publish_diagnostics_tasks(
+            PublishDiagnosticsBatch::from_tasks(diagnostics, self.diagnostics_revision),
+            false,
+        );
     }
 
     fn collect_changes(
@@ -308,8 +311,8 @@ impl GlobalState {
 
         let snapshot = self.make_snapshot();
         self.task_pool.handle.spawn_and_send(ThreadIntent::Worker, move || {
-            let touched_file_ids = files.iter().copied().collect();
             let mut results = Vec::with_capacity(files.len());
+            let mut touched_file_ids = FxHashSet::default();
             for file_id in files {
                 let targets = match snapshot.diagnostic_publish_targets(file_id) {
                     Ok(targets) => targets,
@@ -321,12 +324,17 @@ impl GlobalState {
                         continue;
                     }
                 };
+                touched_file_ids.insert(file_id);
                 let diagnostics = snapshot.lsp_diagnostics(file_id);
                 results.extend(targets.into_iter().map(|target| {
                     PublishDiagnosticsTask::from_target(target, diagnostics.clone())
                 }));
             }
-            Task::Diagnostics(PublishDiagnosticsBatch::for_touched_files(touched_file_ids, results))
+            Task::Diagnostics(PublishDiagnosticsBatch::for_touched_files(
+                touched_file_ids,
+                results,
+                snapshot.diagnostics_revision,
+            ))
         });
     }
 }
@@ -575,6 +583,11 @@ mod tests {
         let mut expected = vec![(source_uri.clone(), Some(3)), (alias_uri.clone(), Some(12))];
         expected.sort_unstable_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
         assert_eq!(targets, expected);
+        assert_eq!(
+            &*state.make_snapshot().file_text(file_id).unwrap(),
+            "module top; endmodule\n",
+            "second open URI aliases the same FileId but must not replace the canonical analysis buffer"
+        );
         state.published_diagnostics.insert(
             DiagnosticPublishKey::for_test(file_id, alias_uri.clone()),
             vec![Diagnostic {

--- a/src/global_state/process_changes.rs
+++ b/src/global_state/process_changes.rs
@@ -27,6 +27,7 @@ impl GlobalState {
     pub(crate) fn process_changes(&mut self) -> bool {
         let pending_diagnostic_targets =
             std::mem::take(&mut self.pending_document_diagnostic_targets);
+        let mut diagnostic_targets_changed = !pending_diagnostic_targets.is_empty();
         let mut write_guard = self.vfs.write();
         let changed_files = write_guard.0.take_changes();
         // downgrade earlier to allow more reader
@@ -39,6 +40,7 @@ impl GlobalState {
                 (canonical != changed_file.file_id).then_some((changed_file.file_id, canonical))
             })
             .collect_vec();
+        diagnostic_targets_changed |= !file_id_redirects.is_empty();
         for (from, to) in file_id_redirects {
             self.mem_docs.remap_file_id(from, to);
         }
@@ -47,6 +49,7 @@ impl GlobalState {
         let Some(changed_files) = Self::colease_modifications(changed_files) else {
             std::mem::drop(read_guard);
             if !pending_diagnostic_targets.is_empty() {
+                self.diagnostic_target_revision += 1;
                 self.request_diagnostics(pending_diagnostic_targets.into_iter().collect());
             }
             return false;
@@ -97,6 +100,9 @@ impl GlobalState {
 
         self.analysis_host.apply_change(change);
         self.diagnostics_revision += 1;
+        if diagnostic_targets_changed {
+            self.diagnostic_target_revision += 1;
+        }
         self.remove_deleted_qihe_diagnostics(&deleted_file_ids);
         self.clear_deleted_push_diagnostics(&deleted_push_diagnostics);
         if has_structure_changes {
@@ -202,7 +208,7 @@ impl GlobalState {
             .collect();
 
         self.publish_diagnostics_tasks(
-            PublishDiagnosticsBatch::from_tasks(diagnostics, self.diagnostics_revision),
+            PublishDiagnosticsBatch::from_tasks(diagnostics, self.diagnostic_publish_freshness()),
             false,
         );
     }
@@ -333,7 +339,7 @@ impl GlobalState {
             Task::Diagnostics(PublishDiagnosticsBatch::for_touched_files(
                 touched_file_ids,
                 results,
-                snapshot.diagnostics_revision,
+                snapshot.diagnostic_publish_freshness,
             ))
         });
     }
@@ -364,7 +370,9 @@ mod tests {
             handlers::notification::{
                 handle_did_close_text_document, handle_did_open_text_document,
             },
-            main_loop::{DiagnosticPublishKey, Task},
+            main_loop::{
+                DiagnosticPublishKey, PublishDiagnosticsBatch, PublishDiagnosticsTask, Task,
+            },
         },
         i18n::I18n,
         lsp_ext::to_proto,
@@ -588,6 +596,22 @@ mod tests {
             "module top; endmodule\n",
             "second open URI aliases the same FileId but must not replace the canonical analysis buffer"
         );
+        let stale_alias_batch = PublishDiagnosticsBatch::for_touched_files(
+            FxHashSet::from_iter([file_id]),
+            vec![PublishDiagnosticsTask::for_test(
+                file_id,
+                alias_uri.clone(),
+                Some(12),
+                vec![Diagnostic {
+                    range: Range::new(Position::new(0, 0), Position::new(0, 1)),
+                    severity: Some(DiagnosticSeverity::ERROR),
+                    source: Some("test".to_owned()),
+                    message: "stale alias diagnostic".to_owned(),
+                    ..Diagnostic::default()
+                }],
+            )],
+            state.diagnostic_publish_freshness(),
+        );
         state.published_diagnostics.insert(
             DiagnosticPublishKey::for_test(file_id, alias_uri.clone()),
             vec![Diagnostic {
@@ -626,5 +650,15 @@ mod tests {
         let params: PublishDiagnosticsParams = serde_json::from_value(notification.params).unwrap();
         assert_eq!(params.uri, alias_uri);
         assert!(params.diagnostics.is_empty());
+        state.publish_diagnostics_tasks(stale_alias_batch, false);
+        assert!(
+            client.receiver.recv_timeout(Duration::from_millis(50)).is_err(),
+            "stale target batch must not republish diagnostics to a closed alias URI"
+        );
+        assert!(
+            !state
+                .published_diagnostics
+                .contains_key(&DiagnosticPublishKey::for_test(file_id, alias_uri))
+        );
     }
 }

--- a/src/global_state/process_changes.rs
+++ b/src/global_state/process_changes.rs
@@ -197,12 +197,7 @@ impl GlobalState {
                         return None;
                     }
                 };
-                Some(PublishDiagnosticsTask {
-                    file_id: *file_id,
-                    uri,
-                    version: None,
-                    diagnostics: Vec::new(),
-                })
+                Some(PublishDiagnosticsTask::clear_stale_uri(*file_id, uri))
             })
             .collect();
 
@@ -327,14 +322,11 @@ impl GlobalState {
                     }
                 };
                 let diagnostics = snapshot.lsp_diagnostics(file_id);
-                results.extend(targets.into_iter().map(|target| PublishDiagnosticsTask {
-                    file_id: target.file_id,
-                    uri: target.uri,
-                    version: target.version,
-                    diagnostics: diagnostics.clone(),
+                results.extend(targets.into_iter().map(|target| {
+                    PublishDiagnosticsTask::from_target(target, diagnostics.clone())
                 }));
             }
-            Task::Diagnostics(PublishDiagnosticsBatch { touched_file_ids, tasks: results })
+            Task::Diagnostics(PublishDiagnosticsBatch::for_touched_files(touched_file_ids, results))
         });
     }
 }
@@ -447,7 +439,7 @@ mod tests {
         let alias_uri = to_proto::url_from_abs_path(alias.as_path()).unwrap();
 
         state.published_diagnostics.insert(
-            DiagnosticPublishKey { file_id: alias_file_id, uri: alias_uri.clone() },
+            DiagnosticPublishKey::for_test(alias_file_id, alias_uri.clone()),
             vec![Diagnostic {
                 range: Range::new(Position::new(0, 0), Position::new(0, 1)),
                 severity: Some(DiagnosticSeverity::ERROR),
@@ -548,10 +540,10 @@ mod tests {
         else {
             panic!("expected diagnostics task");
         };
-        let tasks = batch.tasks;
+        let tasks = batch.into_tasks();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].uri, source_uri);
-        assert_eq!(tasks[0].version, Some(3));
+        assert_eq!(tasks[0].uri(), &source_uri);
+        assert_eq!(tasks[0].version(), Some(3));
 
         handle_did_open_text_document(
             &mut state,
@@ -571,20 +563,20 @@ mod tests {
         let Task::Diagnostics(batch) = task else {
             panic!("expected diagnostics task");
         };
-        let mut tasks = batch.tasks;
-        tasks.sort_unstable_by(|lhs, rhs| lhs.uri.cmp(&rhs.uri));
+        let mut tasks = batch.into_tasks();
+        tasks.sort_unstable_by(|lhs, rhs| lhs.uri().cmp(rhs.uri()));
         let targets = tasks
             .into_iter()
             .map(|task| {
-                assert_eq!(task.file_id, file_id);
-                (task.uri, task.version)
+                assert_eq!(task.file_id(), file_id);
+                (task.uri().clone(), task.version())
             })
             .collect::<Vec<_>>();
         let mut expected = vec![(source_uri.clone(), Some(3)), (alias_uri.clone(), Some(12))];
         expected.sort_unstable_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
         assert_eq!(targets, expected);
         state.published_diagnostics.insert(
-            DiagnosticPublishKey { file_id, uri: alias_uri.clone() },
+            DiagnosticPublishKey::for_test(file_id, alias_uri.clone()),
             vec![Diagnostic {
                 range: Range::new(Position::new(0, 0), Position::new(0, 1)),
                 severity: Some(DiagnosticSeverity::ERROR),
@@ -607,11 +599,11 @@ mod tests {
         let Task::Diagnostics(batch) = task else {
             panic!("expected diagnostics task");
         };
-        assert_eq!(batch.touched_file_ids, FxHashSet::from_iter([file_id]));
-        assert_eq!(batch.tasks.len(), 1);
-        assert_eq!(batch.tasks[0].file_id, file_id);
-        assert_eq!(batch.tasks[0].uri, source_uri);
-        assert_eq!(batch.tasks[0].version, Some(3));
+        assert_eq!(batch.touched_file_ids(), &FxHashSet::from_iter([file_id]));
+        assert_eq!(batch.tasks().len(), 1);
+        assert_eq!(batch.tasks()[0].file_id(), file_id);
+        assert_eq!(batch.tasks()[0].uri(), &source_uri);
+        assert_eq!(batch.tasks()[0].version(), Some(3));
         state.publish_diagnostics_tasks(batch, false);
         let message = client.receiver.recv_timeout(Duration::from_secs(1)).unwrap();
         let lsp_server::Message::Notification(notification) = message else {

--- a/src/global_state/process_changes.rs
+++ b/src/global_state/process_changes.rs
@@ -11,7 +11,7 @@ use vfs::{ChangedFile, FileId, Vfs, VfsPath};
 
 use super::{
     DEFAULT_REQ_HANDLER, GlobalState,
-    main_loop::{PublishDiagnosticsTask, Task},
+    main_loop::{PublishDiagnosticsBatch, PublishDiagnosticsTask, Task},
     reload::should_refresh_for_change,
 };
 use crate::{config::user_config::DiagnosticsUpdateUserConfig, lsp_ext::to_proto};
@@ -25,6 +25,8 @@ pub(crate) enum DiagnosticInvalidation {
 // Apply changes
 impl GlobalState {
     pub(crate) fn process_changes(&mut self) -> bool {
+        let pending_diagnostic_targets =
+            std::mem::take(&mut self.pending_document_diagnostic_targets);
         let mut write_guard = self.vfs.write();
         let changed_files = write_guard.0.take_changes();
         // downgrade earlier to allow more reader
@@ -43,6 +45,10 @@ impl GlobalState {
 
         // collect changes
         let Some(changed_files) = Self::colease_modifications(changed_files) else {
+            std::mem::drop(read_guard);
+            if !pending_diagnostic_targets.is_empty() {
+                self.request_diagnostics(pending_diagnostic_targets.into_iter().collect());
+            }
             return false;
         };
 
@@ -79,6 +85,9 @@ impl GlobalState {
             changed_file_ids.insert(changed_file.file_id);
             bytes.push(changed_file);
         }
+        if self.config.user_config.diagnostics.update == DiagnosticsUpdateUserConfig::OnType {
+            changed_file_ids.extend(pending_diagnostic_targets.iter().copied());
+        }
 
         let mut write_guard = RwLockUpgradableReadGuard::upgrade(read_guard);
         let (vfs, line_endings_map) = &mut *write_guard;
@@ -95,6 +104,13 @@ impl GlobalState {
         } else if self.config.user_config.diagnostics.update == DiagnosticsUpdateUserConfig::OnType
         {
             self.invalidate_diagnostics(DiagnosticInvalidation::FileChanges(changed_file_ids));
+        }
+        if !pending_diagnostic_targets.is_empty()
+            && (has_structure_changes
+                || self.config.user_config.diagnostics.update
+                    != DiagnosticsUpdateUserConfig::OnType)
+        {
+            self.request_diagnostics(pending_diagnostic_targets.into_iter().collect());
         }
 
         if let Some(path) = workspace_structure_change {
@@ -190,7 +206,7 @@ impl GlobalState {
             })
             .collect();
 
-        self.publish_diagnostics_tasks(diagnostics, false);
+        self.publish_diagnostics_tasks(PublishDiagnosticsBatch::from_tasks(diagnostics), false);
     }
 
     fn collect_changes(
@@ -297,10 +313,11 @@ impl GlobalState {
 
         let snapshot = self.make_snapshot();
         self.task_pool.handle.spawn_and_send(ThreadIntent::Worker, move || {
+            let touched_file_ids = files.iter().copied().collect();
             let mut results = Vec::with_capacity(files.len());
             for file_id in files {
-                let uri = match snapshot.url(file_id) {
-                    Ok(uri) => uri,
+                let targets = match snapshot.diagnostic_publish_targets(file_id) {
+                    Ok(targets) => targets,
                     Err(error) => {
                         tracing::debug!(
                             ?file_id,
@@ -309,11 +326,15 @@ impl GlobalState {
                         continue;
                     }
                 };
-                let version = snapshot.file_version(file_id);
                 let diagnostics = snapshot.lsp_diagnostics(file_id);
-                results.push(PublishDiagnosticsTask { file_id, uri, version, diagnostics });
+                results.extend(targets.into_iter().map(|target| PublishDiagnosticsTask {
+                    file_id: target.file_id,
+                    uri: target.uri,
+                    version: target.version,
+                    diagnostics: diagnostics.clone(),
+                }));
             }
-            Task::Diagnostics(results)
+            Task::Diagnostics(PublishDiagnosticsBatch { touched_file_ids, tasks: results })
         });
     }
 }
@@ -324,16 +345,27 @@ mod tests {
 
     use lsp_server::Connection;
     use lsp_types::{
-        ClientCapabilities, Diagnostic, DiagnosticSeverity, Position, PublishDiagnosticsParams,
-        Range, TraceValue, notification::Notification,
+        ClientCapabilities, Diagnostic, DiagnosticSeverity, DidCloseTextDocumentParams,
+        DidOpenTextDocumentParams, Position, PublishDiagnosticsParams, Range,
+        TextDocumentIdentifier, TextDocumentItem, TraceValue, notification::Notification,
     };
+    use rustc_hash::FxHashSet;
     use utils::{lines::LineEnding, test_support::TestDir};
     use vfs::{VfsPath, loader::LoadResult};
 
     use crate::{
         Opt,
-        config::{self, user_config::UserConfig},
-        global_state::GlobalState,
+        config::{
+            self,
+            user_config::{DiagnosticsUpdateUserConfig, UserConfig},
+        },
+        global_state::{
+            GlobalState,
+            handlers::notification::{
+                handle_did_close_text_document, handle_did_open_text_document,
+            },
+            main_loop::{DiagnosticPublishKey, Task},
+        },
         i18n::I18n,
         lsp_ext::to_proto,
     };
@@ -412,9 +444,10 @@ mod tests {
         let source_file_id = state.vfs.read().0.file_id(&source_vfs_path).unwrap();
         let alias_file_id = state.vfs.read().0.file_id(&alias_vfs_path).unwrap();
         assert_ne!(source_file_id, alias_file_id);
+        let alias_uri = to_proto::url_from_abs_path(alias.as_path()).unwrap();
 
-        state.diagnostics.insert(
-            alias_file_id,
+        state.published_diagnostics.insert(
+            DiagnosticPublishKey { file_id: alias_file_id, uri: alias_uri.clone() },
             vec![Diagnostic {
                 range: Range::new(Position::new(0, 0), Position::new(0, 1)),
                 severity: Some(DiagnosticSeverity::ERROR),
@@ -453,9 +486,140 @@ mod tests {
         assert_eq!(notification.method, lsp_types::notification::PublishDiagnostics::METHOD);
         let params: PublishDiagnosticsParams = serde_json::from_value(notification.params).unwrap();
         let source_uri = to_proto::url_from_abs_path(source.as_path()).unwrap();
-        let alias_uri = to_proto::url_from_abs_path(alias.as_path()).unwrap();
         assert_eq!(params.uri, alias_uri);
         assert_ne!(params.uri, source_uri);
+        assert!(params.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn opening_alias_requests_diagnostics_for_every_open_uri() {
+        let root = TestDir::new("diagnostics-target-open-alias");
+        let root_path = root.path().to_path_buf();
+        let mut user_config = UserConfig::default();
+        user_config.diagnostics.update = DiagnosticsUpdateUserConfig::OnType;
+        let config = config::Config::new(
+            Opt {
+                process_name: "vizsla-test".to_string(),
+                log: "error".to_string(),
+                log_filename: None,
+                profile_trace: None,
+            },
+            root_path.clone(),
+            ClientCapabilities::default(),
+            vec![root_path],
+            I18n::default(),
+            user_config,
+            Vec::new(),
+        );
+        let (server, client) = Connection::memory();
+        let mut state = GlobalState::new(server.sender, config, TraceValue::Off);
+        let source = root.write("workspace/top.sv", "module top; endmodule\n");
+        let alias = root.join("alias/top.sv");
+        if let Some(parent) = alias.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::hard_link(&source, &alias).unwrap();
+        let source_vfs_path = VfsPath::from(source.clone());
+        let source_uri = to_proto::url_from_abs_path(source.as_path()).unwrap();
+        let alias_uri = to_proto::url_from_abs_path(alias.as_path()).unwrap();
+
+        state.vfs.write().0.set_file_contents(
+            &source_vfs_path,
+            LoadResult::Loaded("module top; endmodule\n".to_owned(), LineEnding::Unix),
+        );
+        assert!(state.process_changes());
+        let file_id = state.vfs.read().0.file_id(&source_vfs_path).unwrap();
+
+        handle_did_open_text_document(
+            &mut state,
+            DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: source_uri.clone(),
+                    language_id: "systemverilog".to_owned(),
+                    version: 3,
+                    text: "module top; endmodule\n".to_owned(),
+                },
+            },
+        )
+        .unwrap();
+        assert!(!state.process_changes());
+        let Task::Diagnostics(batch) =
+            state.task_pool.receiver.recv_timeout(Duration::from_secs(1)).unwrap()
+        else {
+            panic!("expected diagnostics task");
+        };
+        let tasks = batch.tasks;
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].uri, source_uri);
+        assert_eq!(tasks[0].version, Some(3));
+
+        handle_did_open_text_document(
+            &mut state,
+            DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: alias_uri.clone(),
+                    language_id: "systemverilog".to_owned(),
+                    version: 12,
+                    text: "module top; endmodule\n".to_owned(),
+                },
+            },
+        )
+        .unwrap();
+
+        assert!(!state.process_changes());
+        let task = state.task_pool.receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+        let Task::Diagnostics(batch) = task else {
+            panic!("expected diagnostics task");
+        };
+        let mut tasks = batch.tasks;
+        tasks.sort_unstable_by(|lhs, rhs| lhs.uri.cmp(&rhs.uri));
+        let targets = tasks
+            .into_iter()
+            .map(|task| {
+                assert_eq!(task.file_id, file_id);
+                (task.uri, task.version)
+            })
+            .collect::<Vec<_>>();
+        let mut expected = vec![(source_uri.clone(), Some(3)), (alias_uri.clone(), Some(12))];
+        expected.sort_unstable_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
+        assert_eq!(targets, expected);
+        state.published_diagnostics.insert(
+            DiagnosticPublishKey { file_id, uri: alias_uri.clone() },
+            vec![Diagnostic {
+                range: Range::new(Position::new(0, 0), Position::new(0, 1)),
+                severity: Some(DiagnosticSeverity::ERROR),
+                source: Some("test".to_owned()),
+                message: "stale alias diagnostic".to_owned(),
+                ..Diagnostic::default()
+            }],
+        );
+
+        handle_did_close_text_document(
+            &mut state,
+            DidCloseTextDocumentParams {
+                text_document: TextDocumentIdentifier { uri: alias_uri.clone() },
+            },
+        )
+        .unwrap();
+
+        assert!(!state.process_changes());
+        let task = state.task_pool.receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+        let Task::Diagnostics(batch) = task else {
+            panic!("expected diagnostics task");
+        };
+        assert_eq!(batch.touched_file_ids, FxHashSet::from_iter([file_id]));
+        assert_eq!(batch.tasks.len(), 1);
+        assert_eq!(batch.tasks[0].file_id, file_id);
+        assert_eq!(batch.tasks[0].uri, source_uri);
+        assert_eq!(batch.tasks[0].version, Some(3));
+        state.publish_diagnostics_tasks(batch, false);
+        let message = client.receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+        let lsp_server::Message::Notification(notification) = message else {
+            panic!("expected publishDiagnostics notification");
+        };
+        assert_eq!(notification.method, lsp_types::notification::PublishDiagnostics::METHOD);
+        let params: PublishDiagnosticsParams = serde_json::from_value(notification.params).unwrap();
+        assert_eq!(params.uri, alias_uri);
         assert!(params.diagnostics.is_empty());
     }
 }

--- a/src/global_state/process_changes.rs
+++ b/src/global_state/process_changes.rs
@@ -7,14 +7,14 @@ use nohash_hasher::IntMap;
 use parking_lot::{RwLockUpgradableReadGuard, RwLockWriteGuard};
 use rustc_hash::{FxHashMap, FxHashSet};
 use utils::{lines::LineEnding, thread::ThreadIntent};
-use vfs::{ChangedFile, FileId, Vfs};
+use vfs::{ChangedFile, FileId, Vfs, VfsPath};
 
 use super::{
     DEFAULT_REQ_HANDLER, GlobalState,
     main_loop::{PublishDiagnosticsTask, Task},
     reload::should_refresh_for_change,
 };
-use crate::config::user_config::DiagnosticsUpdateUserConfig;
+use crate::{config::user_config::DiagnosticsUpdateUserConfig, lsp_ext::to_proto};
 
 #[derive(Debug)]
 pub(crate) enum DiagnosticInvalidation {
@@ -30,6 +30,16 @@ impl GlobalState {
         // downgrade earlier to allow more reader
         let read_guard = RwLockWriteGuard::downgrade_to_upgradable(write_guard);
         let vfs = &read_guard.0;
+        let file_id_redirects = changed_files
+            .iter()
+            .filter_map(|changed_file| {
+                let canonical = vfs.canonical_file_id(changed_file.file_id);
+                (canonical != changed_file.file_id).then_some((changed_file.file_id, canonical))
+            })
+            .collect_vec();
+        for (from, to) in file_id_redirects {
+            self.mem_docs.remap_file_id(from, to);
+        }
 
         // collect changes
         let Some(changed_files) = Self::colease_modifications(changed_files) else {
@@ -41,20 +51,30 @@ impl GlobalState {
         let mut bytes = vec![];
         let mut changed_file_ids = FxHashSet::default();
         let mut deleted_file_ids = FxHashSet::default();
+        let mut deleted_push_diagnostics = Vec::new();
         for changed_file in changed_files {
-            let path = vfs.file_path(changed_file.file_id);
+            let is_identity_redirect =
+                vfs.canonical_file_id(changed_file.file_id) != changed_file.file_id;
+            let path = if is_identity_redirect {
+                vfs.original_file_path(changed_file.file_id)
+            } else {
+                vfs.file_path(changed_file.file_id)
+            };
             if let Some(path) =
                 path.and_then(|path| path.as_abs_path()).map(|apath| apath.to_path_buf())
             {
                 let created_or_deleted = changed_file.is_created_or_deleted();
                 has_structure_changes |= created_or_deleted;
-                if should_refresh_for_change(&path, created_or_deleted) {
+                if !is_identity_redirect && should_refresh_for_change(&path, created_or_deleted) {
                     workspace_structure_change = Some(path.clone());
                 }
             }
 
             if matches!(&changed_file.change_kind, vfs::ChangeKind::Delete) {
                 deleted_file_ids.insert(changed_file.file_id);
+                if let Some(path) = path.cloned() {
+                    deleted_push_diagnostics.push((changed_file.file_id, path));
+                }
             }
             changed_file_ids.insert(changed_file.file_id);
             bytes.push(changed_file);
@@ -69,7 +89,7 @@ impl GlobalState {
         self.analysis_host.apply_change(change);
         self.diagnostics_revision += 1;
         self.remove_deleted_qihe_diagnostics(&deleted_file_ids);
-        self.clear_deleted_push_diagnostics(&deleted_file_ids);
+        self.clear_deleted_push_diagnostics(&deleted_push_diagnostics);
         if has_structure_changes {
             self.invalidate_diagnostics(DiagnosticInvalidation::WorkspaceChanged);
         } else if self.config.user_config.diagnostics.update == DiagnosticsUpdateUserConfig::OnType
@@ -134,20 +154,28 @@ impl GlobalState {
         }
     }
 
-    fn clear_deleted_push_diagnostics(&mut self, deleted_file_ids: &FxHashSet<FileId>) {
-        if deleted_file_ids.is_empty() || self.config.cli_pull_diagnostics_support() {
+    fn clear_deleted_push_diagnostics(&mut self, deleted_files: &[(FileId, VfsPath)]) {
+        if deleted_files.is_empty() || self.config.cli_pull_diagnostics_support() {
             return;
         }
 
-        let snapshot = self.make_snapshot();
-        let diagnostics = deleted_file_ids
+        let diagnostics = deleted_files
             .iter()
-            .filter_map(|file_id| {
-                let uri = match snapshot.url(*file_id) {
+            .filter_map(|(file_id, path)| {
+                let Some(path) = path.as_abs_path() else {
+                    tracing::debug!(
+                        ?file_id,
+                        ?path,
+                        "skipping deleted diagnostic clear for non-file path"
+                    );
+                    return None;
+                };
+                let uri = match to_proto::url_from_abs_path(path) {
                     Ok(uri) => uri,
                     Err(error) => {
                         tracing::debug!(
                             ?file_id,
+                            ?path,
                             "skipping deleted diagnostic clear for file without URI: {error:#}"
                         );
                         return None;
@@ -292,8 +320,13 @@ impl GlobalState {
 
 #[cfg(test)]
 mod tests {
+    use std::{fs, time::Duration};
+
     use lsp_server::Connection;
-    use lsp_types::{ClientCapabilities, TraceValue};
+    use lsp_types::{
+        ClientCapabilities, Diagnostic, DiagnosticSeverity, Position, PublishDiagnosticsParams,
+        Range, TraceValue, notification::Notification,
+    };
     use utils::{lines::LineEnding, test_support::TestDir};
     use vfs::{VfsPath, loader::LoadResult};
 
@@ -302,6 +335,7 @@ mod tests {
         config::{self, user_config::UserConfig},
         global_state::GlobalState,
         i18n::I18n,
+        lsp_ext::to_proto,
     };
 
     #[test]
@@ -336,5 +370,92 @@ mod tests {
             !state.fetch_workspaces_task.has_op_requested(),
             "loading an ordinary source file should not queue a project configuration reload"
         );
+    }
+
+    #[test]
+    fn identity_redirect_delete_clears_duplicate_uri_not_canonical_uri() {
+        let root = TestDir::new("identity-redirect-delete-diagnostics");
+        let root_path = root.path().to_path_buf();
+        let config = config::Config::new(
+            Opt {
+                process_name: "vizsla-test".to_string(),
+                log: "error".to_string(),
+                log_filename: None,
+                profile_trace: None,
+            },
+            root_path.clone(),
+            ClientCapabilities::default(),
+            vec![root_path],
+            I18n::default(),
+            UserConfig::default(),
+            Vec::new(),
+        );
+        let (server, client) = Connection::memory();
+        let mut state = GlobalState::new(server.sender, config, TraceValue::Off);
+        let source = root.join("workspace/top.sv");
+        let alias = root.join("alias/top.sv");
+        let source_vfs_path = VfsPath::from(source.clone());
+        let alias_vfs_path = VfsPath::from(alias.clone());
+
+        {
+            let mut vfs = state.vfs.write();
+            vfs.0.set_file_contents(
+                &source_vfs_path,
+                LoadResult::Loaded("module top; endmodule\n".to_owned(), LineEnding::Unix),
+            );
+            vfs.0.set_file_contents(
+                &alias_vfs_path,
+                LoadResult::Loaded("module top; endmodule\n".to_owned(), LineEnding::Unix),
+            );
+        }
+        assert!(state.process_changes());
+        let source_file_id = state.vfs.read().0.file_id(&source_vfs_path).unwrap();
+        let alias_file_id = state.vfs.read().0.file_id(&alias_vfs_path).unwrap();
+        assert_ne!(source_file_id, alias_file_id);
+
+        state.diagnostics.insert(
+            alias_file_id,
+            vec![Diagnostic {
+                range: Range::new(Position::new(0, 0), Position::new(0, 1)),
+                severity: Some(DiagnosticSeverity::ERROR),
+                source: Some("test".to_owned()),
+                message: "stale alias diagnostic".to_owned(),
+                ..Diagnostic::default()
+            }],
+        );
+
+        if let Some(parent) = source.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        if let Some(parent) = alias.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&source, "module top; endmodule\n").unwrap();
+        fs::hard_link(&source, &alias).unwrap();
+        {
+            let mut vfs = state.vfs.write();
+            vfs.0.set_file_contents(
+                &source_vfs_path,
+                LoadResult::Loaded("module top; endmodule\n".to_owned(), LineEnding::Unix),
+            );
+            vfs.0.set_file_contents(
+                &alias_vfs_path,
+                LoadResult::Loaded("module top; endmodule\n".to_owned(), LineEnding::Unix),
+            );
+        }
+
+        assert!(state.process_changes());
+
+        let message = client.receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+        let lsp_server::Message::Notification(notification) = message else {
+            panic!("expected publishDiagnostics notification");
+        };
+        assert_eq!(notification.method, lsp_types::notification::PublishDiagnostics::METHOD);
+        let params: PublishDiagnosticsParams = serde_json::from_value(notification.params).unwrap();
+        let source_uri = to_proto::url_from_abs_path(source.as_path()).unwrap();
+        let alias_uri = to_proto::url_from_abs_path(alias.as_path()).unwrap();
+        assert_eq!(params.uri, alias_uri);
+        assert_ne!(params.uri, source_uri);
+        assert!(params.diagnostics.is_empty());
     }
 }

--- a/src/global_state/qihe.rs
+++ b/src/global_state/qihe.rs
@@ -238,7 +238,6 @@ impl GlobalState {
             return;
         }
 
-        let diagnostics_revision = self.diagnostics_revision;
         let snapshot = self.make_snapshot();
         let mut publish_tasks = Vec::with_capacity(changed_files.len());
         let mut touched_file_ids = FxHashSet::default();
@@ -266,7 +265,7 @@ impl GlobalState {
             PublishDiagnosticsBatch::for_touched_files(
                 touched_file_ids,
                 publish_tasks,
-                diagnostics_revision,
+                snapshot.diagnostic_publish_freshness,
             ),
             true,
         );

--- a/src/global_state/qihe.rs
+++ b/src/global_state/qihe.rs
@@ -176,15 +176,14 @@ impl GlobalState {
             };
             let diagnostics = snapshot.lsp_diagnostics(file_id);
 
-            publish_tasks.extend(targets.into_iter().map(|target| PublishDiagnosticsTask {
-                file_id: target.file_id,
-                uri: target.uri,
-                version: target.version,
-                diagnostics: diagnostics.clone(),
-            }));
+            publish_tasks.extend(
+                targets
+                    .into_iter()
+                    .map(|target| PublishDiagnosticsTask::from_target(target, diagnostics.clone())),
+            );
         }
         self.publish_diagnostics_tasks(
-            PublishDiagnosticsBatch { touched_file_ids: changed_files, tasks: publish_tasks },
+            PublishDiagnosticsBatch::for_touched_files(changed_files, publish_tasks),
             true,
         );
     }

--- a/src/global_state/qihe.rs
+++ b/src/global_state/qihe.rs
@@ -54,19 +54,42 @@ const QIHE: &str = "qihe";
 static ANSI_ESCAPE_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\x1B\[[0-?]*[ -/]*[@-~]").unwrap());
 
+/// Monotonic identity for a Qihe analysis run.
+///
+/// The server keeps latest-run semantics for Qihe: logs, diagnostics, and
+/// progress completion from older runs are ignored once a newer run starts.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash)]
+pub(crate) struct QiheRunId(u64);
+
+impl QiheRunId {
+    fn next(self) -> Self {
+        Self(self.0.saturating_add(1))
+    }
+
+    #[cfg(test)]
+    fn new(value: u64) -> Self {
+        Self(value)
+    }
+}
+
 #[derive(Clone)]
 struct QiheLogSink {
     sender: crossbeam_channel::Sender<Task>,
+    run_id: QiheRunId,
     token: String,
 }
 
 impl QiheLogSink {
-    fn new(sender: crossbeam_channel::Sender<Task>, token: String) -> Self {
-        Self { sender, token }
+    fn new(sender: crossbeam_channel::Sender<Task>, run_id: QiheRunId, token: String) -> Self {
+        Self { sender, run_id, token }
     }
 
     fn log(&self, message: impl Into<String>) {
-        let task = Task::Qihe(QiheTask::Log { token: self.token.clone(), message: message.into() });
+        let task = Task::Qihe(QiheTask::Log {
+            run_id: self.run_id,
+            token: self.token.clone(),
+            message: message.into(),
+        });
         if self.sender.send(task).is_err() {
             tracing::debug!("qihe log dropped because main loop receiver is closed");
         }
@@ -100,15 +123,20 @@ impl QiheUpdate {
 
 impl GlobalState {
     pub(crate) fn spawn_qihe_analysis(&mut self, params: RunQiheAnalysisParams) {
+        self.end_superseded_qihe_progress();
+        self.qihe_run_generation = self.qihe_run_generation.next();
+        let run_id = self.qihe_run_generation;
         let progress_token = format!("qihe-analysis:{}", params.uri);
         let progress_label = params.uri.path().to_string();
         let snapshot = self.make_snapshot();
 
+        self.qihe_active_progress_token = Some(progress_token.clone());
         self.begin_qihe_progress(&progress_token, progress_label);
 
         self.task_pool.handle.spawn_and_send_cps(ThreadIntent::Worker, move |sender| {
-            let log_sink = QiheLogSink::new(sender.clone(), progress_token.clone());
-            let task = Task::Qihe(run_qihe_task(snapshot, params, progress_token, log_sink));
+            let log_sink = QiheLogSink::new(sender.clone(), run_id, progress_token.clone());
+            let task =
+                Task::Qihe(run_qihe_task(snapshot, params, run_id, progress_token, log_sink));
             if sender.send(task).is_err() {
                 tracing::debug!("qihe result dropped because main loop receiver is closed");
             }
@@ -117,15 +145,35 @@ impl GlobalState {
 
     pub(crate) fn handle_qihe_task(&mut self, task: QiheTask) {
         match task {
-            QiheTask::Log { token, message } => self.log_qihe_message(token, message),
-            QiheTask::Finished { update, progress_token } => {
+            QiheTask::Log { run_id, token, message } => {
+                if run_id == self.qihe_run_generation {
+                    self.log_qihe_message(token, message);
+                }
+            }
+            QiheTask::Finished { run_id, update, progress_token } => {
+                if run_id != self.qihe_run_generation {
+                    tracing::debug!(
+                        ?run_id,
+                        current = ?self.qihe_run_generation,
+                        "stale qihe result ignored"
+                    );
+                    return;
+                }
                 let summary = update.summary.clone();
                 let changed_files = self.replace_qihe_diagnostics(update.by_file);
                 self.publish_qihe_diagnostics(changed_files);
-                self.end_qihe_progress(progress_token, "end", summary.clone(), summary);
+                self.end_current_qihe_progress(progress_token, "end", summary.clone(), summary);
             }
-            QiheTask::Failed { message, progress_token } => {
-                self.end_qihe_progress(
+            QiheTask::Failed { run_id, message, progress_token } => {
+                if run_id != self.qihe_run_generation {
+                    tracing::debug!(
+                        ?run_id,
+                        current = ?self.qihe_run_generation,
+                        "stale qihe failure ignored"
+                    );
+                    return;
+                }
+                self.end_current_qihe_progress(
                     progress_token,
                     "failed",
                     message.clone(),
@@ -133,6 +181,28 @@ impl GlobalState {
                 );
             }
         }
+    }
+
+    fn end_superseded_qihe_progress(&mut self) {
+        let Some(progress_token) = self.qihe_active_progress_token.take() else {
+            return;
+        };
+
+        let message = "Superseded by newer Qihe analysis".to_owned();
+        self.end_qihe_progress(progress_token, "end", message.clone(), message);
+    }
+
+    fn end_current_qihe_progress(
+        &mut self,
+        progress_token: String,
+        state: &str,
+        message: String,
+        progress_message: String,
+    ) {
+        if self.qihe_active_progress_token.as_deref() == Some(progress_token.as_str()) {
+            self.qihe_active_progress_token = None;
+        }
+        self.end_qihe_progress(progress_token, state, message, progress_message);
     }
 
     fn replace_qihe_diagnostics(
@@ -161,8 +231,17 @@ impl GlobalState {
             return;
         }
 
+        if self.config.cli_pull_diagnostics_support() {
+            self.invalidate_diagnostics(
+                super::process_changes::DiagnosticInvalidation::FileChanges(changed_files),
+            );
+            return;
+        }
+
+        let diagnostics_revision = self.diagnostics_revision;
         let snapshot = self.make_snapshot();
         let mut publish_tasks = Vec::with_capacity(changed_files.len());
+        let mut touched_file_ids = FxHashSet::default();
         for file_id in changed_files.iter().copied() {
             let targets = match snapshot.diagnostic_publish_targets(file_id) {
                 Ok(targets) => targets,
@@ -174,6 +253,7 @@ impl GlobalState {
                     continue;
                 }
             };
+            touched_file_ids.insert(file_id);
             let diagnostics = snapshot.lsp_diagnostics(file_id);
 
             publish_tasks.extend(
@@ -183,7 +263,11 @@ impl GlobalState {
             );
         }
         self.publish_diagnostics_tasks(
-            PublishDiagnosticsBatch::for_touched_files(changed_files, publish_tasks),
+            PublishDiagnosticsBatch::for_touched_files(
+                touched_file_ids,
+                publish_tasks,
+                diagnostics_revision,
+            ),
             true,
         );
     }
@@ -237,12 +321,13 @@ impl GlobalState {
 fn run_qihe_task(
     snapshot: GlobalStateSnapshot,
     params: RunQiheAnalysisParams,
+    run_id: QiheRunId,
     progress_token: String,
     log_sink: QiheLogSink,
 ) -> QiheTask {
     match run_qihe_request(&snapshot, params, &log_sink) {
-        Ok(update) => QiheTask::Finished { update, progress_token },
-        Err(err) => QiheTask::Failed { message: err.to_string(), progress_token },
+        Ok(update) => QiheTask::Finished { run_id, update, progress_token },
+        Err(err) => QiheTask::Failed { run_id, message: err.to_string(), progress_token },
     }
 }
 
@@ -798,17 +883,31 @@ mod tests {
 
     use base_db::compilation_plan::CompilationPlan;
     use crossbeam_channel::unbounded;
-    use utils::paths::AbsPathBuf;
+    use lsp_types::{
+        Diagnostic, DiagnosticClientCapabilities, DiagnosticSeverity,
+        DiagnosticWorkspaceClientCapabilities, Position, Range, TextDocumentClientCapabilities,
+        TraceValue, WorkspaceClientCapabilities, request::Request,
+    };
+    use utils::{paths::AbsPathBuf, test_support::TestDir};
+    use vfs::FileId;
 
     use super::{
-        QiheCompileInput, QiheCompileInputSource, QiheLogSink, command_line, has_compile_mode,
-        join_command_output, parse_source_loc, prepare_qihe_compile_command,
+        QiheCompileInput, QiheCompileInputSource, QiheLogSink, QiheRunId, QiheUpdate, command_line,
+        has_compile_mode, join_command_output, parse_source_loc, prepare_qihe_compile_command,
         qihe_compile_input_from_plan, qihe_working_directory, split_compile_args,
         stream_command_output, strip_ansi,
     };
     use crate::{
-        config::user_config::QiheConfig,
-        global_state::main_loop::{QiheTask, Task},
+        Opt,
+        config::{
+            self,
+            user_config::{QiheConfig, UserConfig},
+        },
+        global_state::{
+            GlobalState, QiheDiagnosticState,
+            main_loop::{QiheTask, Task},
+        },
+        i18n::I18n,
     };
 
     #[test]
@@ -866,7 +965,7 @@ mod tests {
     #[test]
     fn command_output_streamer_strips_ansi_and_logs_lines() {
         let (sender, receiver) = unbounded();
-        let sink = QiheLogSink::new(sender, "test-token".to_owned());
+        let sink = QiheLogSink::new(sender, QiheRunId::new(1), "test-token".to_owned());
         let handle = stream_command_output(
             Cursor::new("\u{1b}[32mfirst\u{1b}[m\nsecond\n".as_bytes().to_vec()),
             "qihe run".to_owned(),
@@ -885,6 +984,138 @@ mod tests {
             })
             .collect::<Vec<_>>();
         assert_eq!(messages, ["qihe run stdout: first", "qihe run stdout: second"]);
+    }
+
+    #[test]
+    fn stale_qihe_result_does_not_replace_current_diagnostics() {
+        let root = TestDir::new("stale-qihe-result");
+        let config = config::Config::new(
+            Opt {
+                process_name: "vizsla-test".to_string(),
+                log: "error".to_string(),
+                log_filename: None,
+                profile_trace: None,
+            },
+            root.path().to_path_buf(),
+            lsp_types::ClientCapabilities::default(),
+            vec![root.path().to_path_buf()],
+            I18n::default(),
+            UserConfig::default(),
+            Vec::new(),
+        );
+        let (server, _client) = lsp_server::Connection::memory();
+        let mut state = GlobalState::new(server.sender, config, TraceValue::Off);
+        state.qihe_run_generation = QiheRunId::new(2);
+        let file_id = FileId(0);
+        let current = Diagnostic {
+            range: Range::new(Position::new(0, 0), Position::new(0, 1)),
+            severity: Some(DiagnosticSeverity::WARNING),
+            source: Some("qihe".to_owned()),
+            message: "current".to_owned(),
+            ..Diagnostic::default()
+        };
+        let stale = Diagnostic { message: "stale".to_owned(), ..current.clone() };
+        state.qihe_diagnostics.lock().insert(
+            file_id,
+            QiheDiagnosticState { generation: 1, diagnostics: vec![current.clone()] },
+        );
+
+        state.handle_qihe_task(QiheTask::Finished {
+            run_id: QiheRunId::new(1),
+            update: QiheUpdate {
+                by_file: rustc_hash::FxHashMap::from_iter([(file_id, vec![stale])]),
+                summary: "old run".to_owned(),
+            },
+            progress_token: "old".to_owned(),
+        });
+
+        let stored = state.qihe_diagnostics.lock().get(&file_id).unwrap().diagnostics.clone();
+        assert_eq!(stored, vec![current]);
+    }
+
+    #[test]
+    fn current_qihe_result_closes_active_progress() {
+        let root = TestDir::new("current-qihe-progress");
+        let config = config::Config::new(
+            Opt {
+                process_name: "vizsla-test".to_string(),
+                log: "error".to_string(),
+                log_filename: None,
+                profile_trace: None,
+            },
+            root.path().to_path_buf(),
+            lsp_types::ClientCapabilities::default(),
+            vec![root.path().to_path_buf()],
+            I18n::default(),
+            UserConfig::default(),
+            Vec::new(),
+        );
+        let (server, _client) = lsp_server::Connection::memory();
+        let mut state = GlobalState::new(server.sender, config, TraceValue::Off);
+        state.qihe_run_generation = QiheRunId::new(1);
+        state.qihe_active_progress_token = Some("current".to_owned());
+
+        state.handle_qihe_task(QiheTask::Finished {
+            run_id: QiheRunId::new(1),
+            update: QiheUpdate {
+                by_file: rustc_hash::FxHashMap::default(),
+                summary: "done".to_owned(),
+            },
+            progress_token: "current".to_owned(),
+        });
+
+        assert_eq!(state.qihe_active_progress_token, None);
+    }
+
+    #[test]
+    fn qihe_diagnostics_use_pull_refresh_for_pull_capable_clients() {
+        let root = TestDir::new("qihe-pull-diagnostics");
+        let caps = lsp_types::ClientCapabilities {
+            text_document: Some(TextDocumentClientCapabilities {
+                diagnostic: Some(DiagnosticClientCapabilities::default()),
+                ..Default::default()
+            }),
+            workspace: Some(WorkspaceClientCapabilities {
+                diagnostic: Some(DiagnosticWorkspaceClientCapabilities {
+                    refresh_support: Some(true),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let config = config::Config::new(
+            Opt {
+                process_name: "vizsla-test".to_string(),
+                log: "error".to_string(),
+                log_filename: None,
+                profile_trace: None,
+            },
+            root.path().to_path_buf(),
+            caps,
+            vec![root.path().to_path_buf()],
+            I18n::default(),
+            UserConfig::default(),
+            Vec::new(),
+        );
+        let (server, client) = lsp_server::Connection::memory();
+        let mut state = GlobalState::new(server.sender, config, TraceValue::Off);
+
+        state.publish_qihe_diagnostics(rustc_hash::FxHashSet::from_iter([FileId(0)]));
+
+        let message = client
+            .receiver
+            .recv_timeout(std::time::Duration::from_millis(50))
+            .expect("expected workspace diagnostic refresh request");
+        match message {
+            lsp_server::Message::Request(request) => {
+                assert_eq!(request.method, lsp_types::request::WorkspaceDiagnosticRefresh::METHOD);
+            }
+            other => panic!("expected workspace diagnostic refresh request, got {other:?}"),
+        }
+        assert!(
+            client.receiver.recv_timeout(std::time::Duration::from_millis(50)).is_err(),
+            "pull-capable clients should not receive forced Qihe publishDiagnostics"
+        );
     }
 
     #[test]

--- a/src/global_state/qihe.rs
+++ b/src/global_state/qihe.rs
@@ -26,7 +26,7 @@ use vfs::FileId;
 
 use super::{
     GlobalState, QiheDiagnosticState,
-    main_loop::{PublishDiagnosticsTask, QiheTask},
+    main_loop::{PublishDiagnosticsBatch, PublishDiagnosticsTask, QiheTask},
     respond::Progress,
     snapshot::GlobalStateSnapshot,
 };
@@ -163,9 +163,9 @@ impl GlobalState {
 
         let snapshot = self.make_snapshot();
         let mut publish_tasks = Vec::with_capacity(changed_files.len());
-        for file_id in changed_files {
-            let uri = match snapshot.url(file_id) {
-                Ok(uri) => uri,
+        for file_id in changed_files.iter().copied() {
+            let targets = match snapshot.diagnostic_publish_targets(file_id) {
+                Ok(targets) => targets,
                 Err(error) => {
                     tracing::debug!(
                         ?file_id,
@@ -174,15 +174,19 @@ impl GlobalState {
                     continue;
                 }
             };
+            let diagnostics = snapshot.lsp_diagnostics(file_id);
 
-            publish_tasks.push(PublishDiagnosticsTask {
-                file_id,
-                uri,
-                version: snapshot.file_version(file_id),
-                diagnostics: snapshot.lsp_diagnostics(file_id),
-            });
+            publish_tasks.extend(targets.into_iter().map(|target| PublishDiagnosticsTask {
+                file_id: target.file_id,
+                uri: target.uri,
+                version: target.version,
+                diagnostics: diagnostics.clone(),
+            }));
         }
-        self.publish_diagnostics_tasks(publish_tasks, true);
+        self.publish_diagnostics_tasks(
+            PublishDiagnosticsBatch { touched_file_ids: changed_files, tasks: publish_tasks },
+            true,
+        );
     }
 
     fn begin_qihe_progress(&mut self, progress_token: &str, label: String) {

--- a/src/global_state/reload.rs
+++ b/src/global_state/reload.rs
@@ -101,7 +101,7 @@ impl GlobalState {
             return;
         };
 
-        if !errors.is_empty() && !self.workspaces.is_empty() {
+        if !errors.is_empty() {
             return;
         }
 
@@ -546,5 +546,33 @@ mod tests {
         state.switch_workspaces("failed reload".into());
 
         assert!(Arc::ptr_eq(&state.workspaces, &existing_workspaces));
+    }
+
+    #[test]
+    fn workspace_reload_errors_do_not_commit_partial_initial_model() {
+        let root = TestDir::new("workspace-reload-error-keeps-empty-model");
+        let root_path = root.path().to_path_buf();
+        std::fs::create_dir_all(root.join("rtl")).unwrap();
+        std::fs::write(root.join(project_manifest::MANIFEST_FILE_NAME), "sources = [\"rtl/**\"]\n")
+            .unwrap();
+        let manifest = ProjectManifest::from_path(&root_path).unwrap();
+        let (model, errors) = ProjectModel::load(vec![manifest]);
+        assert!(errors.is_empty(), "{errors:#?}");
+
+        let (mut state, _client) = test_state_with_root(root_path);
+        let initial_workspaces = Arc::clone(&state.workspaces);
+        assert!(state.workspaces.is_empty());
+
+        state.request_workspace_reload("test reload");
+        assert_eq!(state.fetch_workspaces_task.should_start().as_deref(), Some("test reload"));
+        state.fetch_workspaces_task.complete(Some((
+            Arc::new(model.workspaces),
+            vec![anyhow::anyhow!("failed to load dependency")],
+        )));
+
+        state.switch_workspaces("partial reload".into());
+
+        assert!(Arc::ptr_eq(&state.workspaces, &initial_workspaces));
+        assert!(state.workspaces.is_empty());
     }
 }

--- a/src/global_state/reload.rs
+++ b/src/global_state/reload.rs
@@ -2,7 +2,10 @@ use base_db::{change::Change, source_db::SourceDb};
 use itertools::Itertools;
 use project_model::{ProjectModel, Workspace, get_workspace_folder, project_manifest};
 use triomphe::Arc;
-use utils::{paths::AbsPath, thread::ThreadIntent};
+use utils::{
+    paths::{AbsPath, AbsPathBuf},
+    thread::ThreadIntent,
+};
 
 use super::main_loop::Task;
 use crate::{
@@ -186,7 +189,7 @@ impl GlobalState {
             .flat_map(|root| {
                 project_manifest::MANIFEST_FILE_NAMES
                     .iter()
-                    .map(move |file_name| format!("{root}/{file_name}"))
+                    .map(move |file_name| client_watch_glob(root, file_name))
             })
             .collect_vec();
         globs.extend(
@@ -195,15 +198,13 @@ impl GlobalState {
                 .flat_map(|ws| ws.roots())
                 .filter(|it| !it.role.is_library())
                 .flat_map(|root| {
-                    root.load_paths().into_iter().flat_map(|it| {
-                        [
-                            format!("{it}/**/*.v"),
-                            format!("{it}/**/*.sv"),
-                            format!("{it}/**/*.vh"),
-                            format!("{it}/**/*.svh"),
-                            format!("{it}/**/*.svi"),
-                        ]
-                    })
+                    let mut globs = root.source_files.iter().map(client_watch_path).collect_vec();
+                    globs.extend(root.directory_load_paths().into_iter().flat_map(|it| {
+                        vfs::loader::SOURCE_FILE_EXTENSIONS
+                            .iter()
+                            .map(move |ext| client_watch_glob(&it, &format!("**/*.{ext}")))
+                    }));
+                    globs
                 }),
         );
         globs.sort();
@@ -271,6 +272,19 @@ impl GlobalState {
     }
 }
 
+fn client_watch_glob(root: &AbsPathBuf, suffix: &str) -> String {
+    let root = client_watch_path(root);
+    format!("{root}/{suffix}")
+}
+
+fn client_watch_path(root: &AbsPathBuf) -> String {
+    let mut root = root.to_string().replace('\\', "/");
+    while root.ends_with('/') {
+        root.pop();
+    }
+    root
+}
+
 pub(crate) fn should_refresh_for_change(path: &AbsPath, has_structure_change: bool) -> bool {
     let Some(file_name) = path.file_name() else {
         return false;
@@ -290,7 +304,7 @@ pub(crate) fn should_refresh_for_change(path: &AbsPath, has_structure_change: bo
 #[cfg(test)]
 mod tests {
     use lsp_server::{Connection, Message, Request as LspRequest};
-    use project_model::project_manifest;
+    use project_model::{ProjectModel, project_manifest, project_manifest::ProjectManifest};
     use utils::{paths::AbsPathBuf, test_support::TestDir};
 
     use super::*;
@@ -384,9 +398,91 @@ mod tests {
 
         let globs = state.client_file_watcher_globs();
 
-        assert!(globs.contains(&format!("{root_path}/{}", project_manifest::MANIFEST_FILE_NAME)));
         assert!(
-            globs.contains(&format!("{root_path}/{}", project_manifest::LEGACY_MANIFEST_FILE_NAME))
+            globs.contains(&client_watch_glob(&root_path, project_manifest::MANIFEST_FILE_NAME))
+        );
+        assert!(
+            globs.contains(&client_watch_glob(
+                &root_path,
+                project_manifest::LEGACY_MANIFEST_FILE_NAME
+            ))
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn client_file_watchers_use_lsp_glob_separators() {
+        let root = TestDir::new("client-watch-glob-separators");
+        let root_path = root.path().to_path_buf();
+        let (state, _client) = test_state_with_root(root_path);
+
+        let globs = state.client_file_watcher_globs();
+
+        assert!(
+            globs.iter().all(|glob| !glob.contains('\\')),
+            "client watcher globs must use LSP glob separators: {globs:?}"
+        );
+    }
+
+    #[test]
+    fn client_file_watchers_include_library_map_files() {
+        let root = TestDir::new("client-watch-library-map");
+        let root_path = root.path().to_path_buf();
+        std::fs::create_dir_all(root.join("rtl")).unwrap();
+        std::fs::write(
+            root.join(project_manifest::MANIFEST_FILE_NAME),
+            "sources = [\"rtl/**\"]\ninclude_dirs = []\n",
+        )
+        .unwrap();
+
+        let manifest = ProjectManifest::from_path(&root_path).unwrap();
+        let (model, errors) = ProjectModel::load(vec![manifest]);
+        assert!(errors.is_empty(), "{errors:#?}");
+        let (mut state, _client) = test_state_with_root(root_path);
+        state.workspaces = Arc::new(model.workspaces);
+
+        let globs = state.client_file_watcher_globs();
+
+        assert!(
+            globs.iter().any(|glob| glob.ends_with("/**/*.map")),
+            "client watcher globs must include library map files: {globs:?}"
+        );
+    }
+
+    #[test]
+    fn client_file_watchers_handle_single_file_source_roots() {
+        let root = TestDir::new("client-watch-single-file-source");
+        let root_path = root.path().to_path_buf();
+        std::fs::create_dir_all(root.join("rtl")).unwrap();
+        let top_path = root.join("rtl/top.sv");
+        std::fs::write(&top_path, "module top; endmodule\n").unwrap();
+        std::fs::write(
+            root.join(project_manifest::MANIFEST_FILE_NAME),
+            "sources = [\"rtl/top.sv\"]\ninclude_dirs = []\n",
+        )
+        .unwrap();
+
+        let manifest = ProjectManifest::from_path(&root_path).unwrap();
+        let (model, errors) = ProjectModel::load(vec![manifest]);
+        assert!(errors.is_empty(), "{errors:#?}");
+        let (mut state, _client) = test_state_with_root(root_path);
+        state.workspaces = Arc::new(model.workspaces);
+
+        let globs = state.client_file_watcher_globs();
+        let source_file_glob = top_path.to_string().replace('\\', "/");
+        let source_parent_glob = root.join("rtl").to_string().replace('\\', "/") + "/**/*.sv";
+
+        assert!(
+            globs.contains(&source_file_glob),
+            "client watcher globs must watch the explicit source file: {globs:?}"
+        );
+        assert!(
+            !globs.contains(&source_parent_glob),
+            "client watcher globs must not infer a parent directory from an exact source file: {globs:?}"
+        );
+        assert!(
+            globs.iter().all(|glob| !glob.contains("top.sv/**")),
+            "client watcher globs must not treat explicit source files as directories: {globs:?}"
         );
     }
 
@@ -423,5 +519,32 @@ mod tests {
         state.update_configuration(config);
 
         assert!(state.fetch_workspaces_task.has_op_requested());
+    }
+
+    #[test]
+    fn workspace_reload_errors_keep_existing_workspace_model() {
+        let root = TestDir::new("workspace-reload-error-keeps-old-model");
+        let root_path = root.path().to_path_buf();
+        std::fs::create_dir_all(root.join("rtl")).unwrap();
+        std::fs::write(root.join(project_manifest::MANIFEST_FILE_NAME), "sources = [\"rtl/**\"]\n")
+            .unwrap();
+        let manifest = ProjectManifest::from_path(&root_path).unwrap();
+        let (model, errors) = ProjectModel::load(vec![manifest]);
+        assert!(errors.is_empty(), "{errors:#?}");
+
+        let (mut state, _client) = test_state_with_root(root_path);
+        state.workspaces = Arc::new(model.workspaces);
+        let existing_workspaces = Arc::clone(&state.workspaces);
+
+        state.request_workspace_reload("test reload");
+        assert_eq!(state.fetch_workspaces_task.should_start().as_deref(), Some("test reload"));
+        state.fetch_workspaces_task.complete(Some((
+            Arc::new(Vec::new()),
+            vec![anyhow::anyhow!("failed to reload workspace")],
+        )));
+
+        state.switch_workspaces("failed reload".into());
+
+        assert!(Arc::ptr_eq(&state.workspaces, &existing_workspaces));
     }
 }

--- a/src/global_state/snapshot.rs
+++ b/src/global_state/snapshot.rs
@@ -25,15 +25,33 @@ use crate::{
 #[derive(Debug, Clone)]
 pub(crate) struct DiagnosticPublishTarget {
     /// The analysis identity diagnostics are computed from.
-    pub(crate) file_id: FileId,
+    file_id: FileId,
     /// The URI diagnostics will be published for.
     ///
     /// Diagnostic code should obtain URI/version pairs from
     /// [`GlobalStateSnapshot::diagnostic_publish_targets`] instead of pairing
     /// [`GlobalStateSnapshot::url`] with a file-id-wide document version.
-    pub(crate) uri: Url,
+    uri: Url,
     /// The document version for `uri`, when that URI is currently open.
-    pub(crate) version: Option<i32>,
+    version: Option<i32>,
+}
+
+impl DiagnosticPublishTarget {
+    fn new(file_id: FileId, uri: Url, version: Option<i32>) -> Self {
+        Self { file_id, uri, version }
+    }
+
+    pub(crate) fn uri(&self) -> &Url {
+        &self.uri
+    }
+
+    pub(crate) fn version(&self) -> Option<i32> {
+        self.version
+    }
+
+    pub(crate) fn into_parts(self) -> (FileId, Url, Option<i32>) {
+        (self.file_id, self.uri, self.version)
+    }
 }
 
 // immutable
@@ -216,6 +234,11 @@ impl GlobalStateSnapshot {
         vfs.0.iter().map(|(file_id, _)| file_id).collect()
     }
 
+    /// Returns the VFS primary URI for a file.
+    ///
+    /// This is suitable for protocol features that need a stable file location.
+    /// Push diagnostics must use [`Self::diagnostic_publish_targets`] so the
+    /// URI and document version come from the same open document spelling.
     pub(crate) fn url(&self, id: FileId) -> anyhow::Result<Url> {
         let vfs = &self.vfs_read();
         let path =
@@ -247,7 +270,7 @@ impl GlobalStateSnapshot {
             return Ok(open_targets);
         }
 
-        Ok(vec![DiagnosticPublishTarget { file_id, uri: self.url(file_id)?, version: None }])
+        Ok(vec![DiagnosticPublishTarget::new(file_id, self.url(file_id)?, None)])
     }
 
     fn open_diagnostic_targets(
@@ -262,7 +285,7 @@ impl GlobalStateSnapshot {
                     anyhow::format_err!("open file {file_id:?} has no file URI: {}", document.path)
                 })?;
                 let uri = to_proto::url_from_abs_path(path)?;
-                Ok(DiagnosticPublishTarget { file_id, uri, version: Some(document.version) })
+                Ok(DiagnosticPublishTarget::new(file_id, uri, Some(document.version)))
             })
             .collect()
     }

--- a/src/global_state/snapshot.rs
+++ b/src/global_state/snapshot.rs
@@ -15,7 +15,7 @@ use utils::{
 };
 use vfs::{FileId, Vfs, VfsPath};
 
-use super::mem_docs::MemDocs;
+use super::{main_loop::DiagnosticPublishFreshness, mem_docs::MemDocs};
 use crate::{
     config::Config,
     global_state::QiheDiagnosticState,
@@ -62,6 +62,7 @@ pub(crate) struct GlobalStateSnapshot {
     pub(crate) sema_tokens_cache: Arc<Mutex<FxHashMap<Url, lsp_types::SemanticTokens>>>,
     pub(crate) qihe_diagnostics: Arc<Mutex<FxHashMap<FileId, QiheDiagnosticState>>>,
     pub(crate) diagnostics_revision: u64,
+    pub(crate) diagnostic_publish_freshness: DiagnosticPublishFreshness,
     pub(crate) mem_docs: MemDocs,
     pub(crate) vfs: Arc<RwLock<(Vfs, IntMap<FileId, LineEnding>)>>,
     #[allow(dead_code)]

--- a/src/global_state/snapshot.rs
+++ b/src/global_state/snapshot.rs
@@ -205,6 +205,6 @@ impl GlobalStateSnapshot {
 
     pub(crate) fn url_file_version(&self, url: &Url) -> Option<i32> {
         let path = from_proto::vfs_path(url).ok()?;
-        self.mem_docs.file_id(&path).and_then(|file_id| self.file_version(file_id))
+        self.mem_docs.version_for_path(&path)
     }
 }

--- a/src/global_state/snapshot.rs
+++ b/src/global_state/snapshot.rs
@@ -22,6 +22,20 @@ use crate::{
     lsp_ext::{from_proto, to_proto},
 };
 
+#[derive(Debug, Clone)]
+pub(crate) struct DiagnosticPublishTarget {
+    /// The analysis identity diagnostics are computed from.
+    pub(crate) file_id: FileId,
+    /// The URI diagnostics will be published for.
+    ///
+    /// Diagnostic code should obtain URI/version pairs from
+    /// [`GlobalStateSnapshot::diagnostic_publish_targets`] instead of pairing
+    /// [`GlobalStateSnapshot::url`] with a file-id-wide document version.
+    pub(crate) uri: Url,
+    /// The document version for `uri`, when that URI is currently open.
+    pub(crate) version: Option<i32>,
+}
+
 // immutable
 pub(crate) struct GlobalStateSnapshot {
     pub(crate) config: Arc<Config>,
@@ -132,17 +146,25 @@ impl GlobalStateSnapshot {
         self.qihe_diagnostics.lock().get(&file_id).map(|state| state.generation).unwrap_or(0)
     }
 
-    pub(crate) fn file_version(&self, file_id: FileId) -> Option<i32> {
+    fn file_version(&self, file_id: FileId) -> Option<i32> {
         self.mem_docs.version(file_id)
     }
 
-    pub(crate) fn diagnostic_result_id(&self, file_id: FileId) -> Option<String> {
+    /// Returns a result id scoped to the URI that receives the diagnostics.
+    ///
+    /// The same physical file may be open through an alias URI, so result ids
+    /// must not be derived from [`FileId`] alone.
+    pub(crate) fn diagnostic_result_id(&self, file_id: FileId, target_uri: &Url) -> Option<String> {
         let diagnostics_config = self.config.diagnostics_config();
         let file_ids = if diagnostics_config.semantic.enabled {
             self.analysis.source_root_file_ids(file_id).ok()?
         } else {
             vec![file_id]
         };
+        let target_document = self.url_file_version(target_uri).map_or_else(
+            || target_uri.as_str().to_owned(),
+            |version| format!("{}:{version}", target_uri.as_str()),
+        );
 
         let mut versions = file_ids
             .into_iter()
@@ -156,9 +178,10 @@ impl GlobalStateSnapshot {
             .collect::<Vec<_>>()
             .join(",");
         Some(format!(
-            "diag:{}:rev:{}:{file_versions}:qihe:{}",
+            "diag:{}:rev:{}:target:{}:{file_versions}:qihe:{}",
             diagnostics_config.revision,
             self.diagnostics_revision,
+            target_document,
             self.qihe_generation(file_id)
         ))
     }
@@ -201,6 +224,47 @@ impl GlobalStateSnapshot {
             .as_abs_path()
             .ok_or_else(|| anyhow::format_err!("file {id:?} has no file URI: {path}"))?;
         to_proto::url_from_abs_path(path)
+    }
+
+    /// Returns the open URI/version pairs diagnostics should be published to.
+    ///
+    /// Push diagnostics are scoped to open documents. Workspace diagnostic
+    /// requests use [`GlobalStateSnapshot::workspace_diagnostic_targets`] when
+    /// they need to report unopened workspace files.
+    pub(crate) fn diagnostic_publish_targets(
+        &self,
+        file_id: FileId,
+    ) -> anyhow::Result<Vec<DiagnosticPublishTarget>> {
+        self.open_diagnostic_targets(file_id)
+    }
+
+    pub(crate) fn workspace_diagnostic_targets(
+        &self,
+        file_id: FileId,
+    ) -> anyhow::Result<Vec<DiagnosticPublishTarget>> {
+        let open_targets = self.open_diagnostic_targets(file_id)?;
+        if !open_targets.is_empty() {
+            return Ok(open_targets);
+        }
+
+        Ok(vec![DiagnosticPublishTarget { file_id, uri: self.url(file_id)?, version: None }])
+    }
+
+    fn open_diagnostic_targets(
+        &self,
+        file_id: FileId,
+    ) -> anyhow::Result<Vec<DiagnosticPublishTarget>> {
+        let open_documents = self.mem_docs.open_documents(file_id);
+        open_documents
+            .into_iter()
+            .map(|document| {
+                let path = document.path.as_abs_path().ok_or_else(|| {
+                    anyhow::format_err!("open file {file_id:?} has no file URI: {}", document.path)
+                })?;
+                let uri = to_proto::url_from_abs_path(path)?;
+                Ok(DiagnosticPublishTarget { file_id, uri, version: Some(document.version) })
+            })
+            .collect()
     }
 
     pub(crate) fn url_file_version(&self, url: &Url) -> Option<i32> {


### PR DESCRIPTION
This change moves file identity to the VFS ingress boundary and makes diagnostics publish against explicit document targets. Before this, the same physical file could enter through loader paths, LSP URIs, watcher paths, symlinks, different Windows spellings, or external diagnostic paths and keep inconsistent `FileId`, root ownership, open-buffer, or diagnostic state. That made behavior depend on ingress order and path spelling.

## Previous Shape

```mermaid
flowchart TD
    Loader["Loader path"] --> VFS["VFS path map"]
    LSP["LSP URI path"] --> VFS
    Watcher["Watcher path"] --> VFS
    External["External diagnostics path"] --> VFS

    VFS --> FileId["FileId by first path spelling"]
    FileId --> FileSet["FileSet root classification"]
    FileId --> MemDocs["MemDocs by FileId"]
    FileId --> Diagnostics["Diagnostics cache by FileId"]

    MemDocs --> Version["Document version from current buffer"]
    VFS --> Uri["Primary VFS URI"]
    Version --> Publish["publishDiagnostics"]
    Uri --> Publish
```

## New Shape

```mermaid
flowchart TD
    Loader["Loader path"] --> Identity["VFS identity service"]
    LSP["LSP URI path"] --> Identity
    Watcher["Watcher path"] --> Identity
    Save["Save/change/delete path"] --> Identity
    External["External diagnostics path"] --> Identity

    Identity --> FileId["Stable canonical FileId"]
    Identity --> Aliases["Alias evidence set"]

    FileId --> FileSet["Identity-aware file-set partition"]
    FileId --> MemDocs["One canonical analysis buffer"]
    Aliases --> OpenDocs["Open URI versions"]

    OpenDocs --> Targets["DiagnosticPublishTarget: FileId + URI + version"]
    Targets --> Cache["Diagnostics cache by FileId + URI"]
    Cache --> Publish["publishDiagnostics per open URI"]
```

## Flow Difference

```mermaid
sequenceDiagram
    participant Client
    participant VFS
    participant MemDocs
    participant Diagnostics

    Client->>VFS: didOpen(alias URI)
    VFS->>VFS: register alias evidence and resolve canonical FileId
    VFS->>MemDocs: map alias URI to canonical FileId
    MemDocs->>MemDocs: keep URI-local version
    MemDocs->>Diagnostics: refresh diagnostic targets for FileId
    Diagnostics->>Client: publish to every attached open URI target

    Client->>MemDocs: didClose(alias URI)
    MemDocs->>Diagnostics: refresh diagnostic targets for FileId
    Diagnostics->>Client: clear stale alias diagnostics
```

## What Changed

- Added a VFS identity service that records exact path aliases, normalized path keys, and platform file identity keys without keeping long-lived OS file handles.
- Handles late identity evidence by merging duplicate `FileId`s into a stable owner and redirecting aliases instead of silently preserving split identity.
- Adds an explicit VFS ingress registration path for LSP opens, so URI aliases can be resolved before deciding whether incoming text should become VFS contents.
- Makes file-set partitioning consume VFS alias evidence, so project/root ownership no longer depends only on the first path spelling inserted into VFS.
- Separates exact single-file loads from directory scan roots in the project model.
- Updates `MemDocs` to keep one canonical analysis buffer per `FileId` while tracking every open URI spelling with its own LSP version.
- Detaches divergent alias opens from the canonical analysis buffer instead of letting a second URI’s alternate text overwrite or later corrupt the shared buffer.
- Makes `didChange` atomic: invalid LSP ranges no longer advance URI versions or partially mutate document text.
- Introduces explicit `DiagnosticPublishTarget` values so push diagnostics always use a matching `(FileId, URI, version)` tuple.
- Scopes the diagnostics cache by `(FileId, URI)` and refreshes targets on both open and close, so alias documents receive diagnostics and stale alias diagnostics are cleared promptly.
- Adds diagnostics freshness revisions so stale background diagnostic batches cannot publish or clear newer diagnostic state.
- Keeps workspace diagnostics able to report unopened workspace files through a separate workspace target path, while push diagnostics stay scoped to open documents.
- Adds Qihe run identity so logs, failures, and diagnostics from older runs cannot commit after a newer run starts.
- Makes Qihe diagnostics respect pull-diagnostics clients by requesting diagnostic refresh instead of force-publishing.
- Treats workspace reload as transactional: reload errors keep the existing workspace model instead of committing partial results.

## Alias Buffer Policy

This keeps the current one-analysis-buffer-per-physical-file model explicit. If the same physical file is opened through multiple URI spellings with matching text, those URIs share the canonical analysis buffer and keep URI-local versions. If an alias opens with divergent text, the URI remains tracked for close/version bookkeeping but is detached from the canonical analysis buffer. That avoids silently mixing edits from incompatible URI-local text states.

## Benefits

- Prevents duplicate `FileId`s for the same physical file across symlink, junction, case, verbatim path, and open-before-load scenarios.
- Makes root classification stable across aliases and ingress order.
- Avoids permanently holding one file handle per file in VFS.
- Preserves canonical analysis text while making LSP document versions URI-local.
- Prevents divergent alias text from corrupting the canonical analysis buffer.
- Prevents invalid `didChange` ranges from creating version/text skew.
- Prevents diagnostics from pairing a primary VFS URI with an alias document version.
- Prevents diagnostics cache hits for one URI from suppressing publication to another open URI.
- Clears diagnostics from alias URIs when those documents close, even if file contents do not change.
- Prevents stale diagnostics workers from overwriting or clearing newer diagnostics.
- Prevents stale Qihe runs from replacing current diagnostics or progress state.
- Avoids committing partial workspace models when project reload has errors.

## Scope

This change closes the file-ingress, open-document, diagnostics-target, Qihe diagnostics freshness, and workspace reload transaction issues in this area. It does not replace the whole task runtime or external-process controller. Full external-process cancellation, temp workspace ownership, and log backpressure remain separate runtime/Qihe lifecycle work.

## Validation

- `cargo test -p vfs`
- `cargo test -p project-model`
- `cargo test -p vizsla`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `rustup run nightly cargo test --workspace`
- `git diff --check`