### PR TITLE
fix: named port semantic token range

### DIFF
--- a/crates/hir/src/source_map.rs
+++ b/crates/hir/src/source_map.rs
@@ -26,14 +26,23 @@ pub trait IsSrc: PartialEq + Eq + Hash + Copy + Clone + Debug {
 
     fn kind(&self) -> SyntaxKind;
 
+    /// Returns the full syntactic extent of the mapped AST node.
+    ///
+    /// Use this for containment, folding, diagnostics, and operations that act
+    /// on the whole construct rather than just its defining identifier.
     fn range(&self) -> TextRange;
 }
 
 pub trait IsNamedSrc: IsSrc {
     fn name_kind(&self) -> Option<TokenKind>;
 
+    /// Returns the token range that names this source node, when it has one.
+    ///
+    /// Use this for symbol focus ranges such as navigation targets, document
+    /// symbol selections, rename/reference origins, and semantic tokens.
     fn name_range(&self) -> Option<TextRange>;
 
+    /// Returns the symbol focus range when present, otherwise the full range.
     fn name_or_full_range(&self) -> TextRange {
         self.name_range().unwrap_or_else(|| self.range())
     }

--- a/crates/ide/src/semantic_tokens.rs
+++ b/crates/ide/src/semantic_tokens.rs
@@ -635,4 +635,48 @@ endmodule
             (SemaTokenTag::Port(SemaTokenPort::Others), SemaTokenModifier::WRITE)
         );
     }
+
+    #[test]
+    fn named_port_connection_token_uses_name_range() {
+        let text = "\
+module child(output logic instr_req_o);
+endmodule
+
+module top(output logic instr_req_o);
+child u_child (
+    .instr_req_o (instr_req_o),
+);
+endmodule
+";
+        let (host, file_id) = setup(text);
+        let tokens = host
+            .make_analysis()
+            .semantic_tokens(
+                file_id,
+                SemaTokenConfig { port: SemaTokenPortConfig { clk_rst: false, io: true } },
+                Some(TextRange::up_to(TextSize::of(text))),
+            )
+            .unwrap();
+
+        let named_port_start = text.find(".instr_req_o").unwrap() + 1;
+        let named_port_range = TextRange::new(
+            TextSize::from(named_port_start as u32),
+            TextSize::from((named_port_start + "instr_req_o".len()) as u32),
+        );
+        let expr_start = text.find("(instr_req_o)").unwrap() + 1;
+        let expr_range = TextRange::new(
+            TextSize::from(expr_start as u32),
+            TextSize::from((expr_start + "instr_req_o".len()) as u32),
+        );
+
+        assert!(tokens.iter().any(|token| token.range == named_port_range));
+        assert!(tokens.iter().any(|token| token.range == expr_range));
+        assert!(
+            tokens
+                .iter()
+                .all(|token| token.range
+                    != TextRange::new(named_port_range.start(), expr_range.end())),
+            "named port connection must not produce a token spanning the whole connection"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Limit named port connection semantic tokens to the port name range instead of the whole connection
- Add a regression test for .instr_req_o (instr_req_o) style connections

## Verification
- cargo fmt --check
- cargo clippy -p ide --all-targets -- -D warnings
- cargo test -p ide semantic_tokens::tests
- cargo test -p ide inlay_hint::tests