### PR TITLE
fix(vfs): coordinate workspace readiness

### DIFF
--- a/crates/utils/src/excl_task.rs
+++ b/crates/utils/src/excl_task.rs
@@ -1,10 +1,16 @@
 // Exclusive task, make sure only one long-running operation is being executed
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct ExclTask<Output, Cause = String> {
     requested: Option<Cause>,
     in_process: bool,
     last_result: Option<Output>,
+}
+
+impl<Output, Cause> Default for ExclTask<Output, Cause> {
+    fn default() -> Self {
+        Self { requested: None, in_process: false, last_result: None }
+    }
 }
 
 impl<Output, Cause> ExclTask<Output, Cause> {

--- a/crates/vfs-notify/Cargo.toml
+++ b/crates/vfs-notify/Cargo.toml
@@ -15,3 +15,6 @@ tracing.workspace = true
 utils.workspace = true
 vfs.workspace = true
 walkdir = "2.4.0"
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/vfs-notify/src/lib.rs
+++ b/crates/vfs-notify/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{fs, sync::atomic::AtomicUsize};
+use std::{fs, mem, sync::atomic::AtomicUsize};
 
 use crossbeam_channel::{Receiver, Sender, select, unbounded};
 use itertools::Itertools;
@@ -67,6 +67,7 @@ struct NotifyActor {
     config_version: u32,
     watched_files: FxHashSet<AbsPathBuf>,
     watched_dirs: Vec<loader::Directories>,
+    loaded_paths: FxHashSet<AbsPathBuf>,
     // Drop order is significant.
     watcher: Option<(RecommendedWatcher, Receiver<NotifyEvent>)>,
 }
@@ -84,6 +85,7 @@ impl NotifyActor {
             config_version: 0,
             watched_files: FxHashSet::default(),
             watched_dirs: Vec::new(),
+            loaded_paths: FxHashSet::default(),
             watcher: None,
         }
     }
@@ -123,7 +125,9 @@ impl NotifyActor {
 
                         let config_version = config.version;
                         self.config_version = config_version;
-                        let n_total = config.to_load.len();
+                        let has_reconcile_step = !self.loaded_paths.is_empty();
+                        let n_entries = config.to_load.len();
+                        let n_total = n_entries + usize::from(has_reconcile_step);
                         if n_total > 0 {
                             self.send(loader::Message::Progress {
                                 n_total,
@@ -134,9 +138,11 @@ impl NotifyActor {
 
                         self.watched_files.clear();
                         self.watched_dirs.clear();
+                        let previous_loaded_paths = mem::take(&mut self.loaded_paths);
 
                         let (entry_tx, entry_rx) = unbounded();
                         let (watch_tx, watch_rx) = unbounded();
+                        let (loaded_tx, loaded_rx) = unbounded();
                         let processed = AtomicUsize::new(0);
 
                         config.to_load.into_par_iter().enumerate().for_each(|(i, entry)| {
@@ -145,6 +151,18 @@ impl NotifyActor {
                                 tracing::debug!("watched entry dropped because receiver is closed");
                             }
                             let files = Self::load_entry(&watch_tx, entry, do_watch);
+                            let reported_paths =
+                                files.iter().map(|(path, _)| path.clone()).collect_vec();
+                            let loaded_paths = files
+                                .iter()
+                                .filter(|(_, result)| !matches!(result, LoadResult::LoadError))
+                                .map(|(path, _)| path.clone())
+                                .collect_vec();
+                            if loaded_tx.send((reported_paths, loaded_paths)).is_err() {
+                                tracing::debug!(
+                                    "loaded path batch dropped because receiver is closed"
+                                );
+                            }
                             self.send(loader::Message::Loaded { files, config_version });
                             self.send(loader::Message::Progress {
                                 n_total,
@@ -153,6 +171,14 @@ impl NotifyActor {
                                 config_version,
                             });
                         });
+
+                        drop(loaded_tx);
+                        let mut reported_paths = FxHashSet::default();
+                        let mut loaded_paths = FxHashSet::default();
+                        for (reported, loaded) in loaded_rx {
+                            reported_paths.extend(reported);
+                            loaded_paths.extend(loaded);
+                        }
 
                         drop(watch_tx);
                         for path in watch_rx {
@@ -166,10 +192,34 @@ impl NotifyActor {
                                 loader::Entry::Directories(dir) => self.watched_dirs.push(dir),
                             }
                         }
+
+                        let unloaded = previous_loaded_paths
+                            .difference(&reported_paths)
+                            .cloned()
+                            .map(|path| (path, LoadResult::LoadError))
+                            .collect_vec();
+                        self.loaded_paths = loaded_paths;
+                        if !unloaded.is_empty() {
+                            self.send(loader::Message::Loaded { files: unloaded, config_version });
+                        }
+                        if has_reconcile_step {
+                            self.send(loader::Message::Progress {
+                                n_total,
+                                n_done: n_total,
+                                config_version,
+                            });
+                        } else if n_total == 0 {
+                            self.send(loader::Message::Progress {
+                                n_total,
+                                n_done: 0,
+                                config_version,
+                            });
+                        }
                     }
                     ServerMsg::Invalidate(path) => {
                         let contents = read(path.as_path());
                         let files = vec![(path, contents)];
+                        self.record_loaded_files(&files);
                         self.send(loader::Message::Loaded {
                             files,
                             config_version: self.config_version,
@@ -181,43 +231,8 @@ impl NotifyActor {
                         continue;
                     };
 
-                    if !(event.kind.is_create() || event.kind.is_modify() || event.kind.is_remove())
-                    {
-                        continue;
-                    }
-
-                    let files = event
-                        .paths
-                        .into_iter()
-                        .filter_map(|path| AbsPathBuf::try_from(path).ok())
-                        .filter_map(|path| {
-                            let metadata = fs::metadata(&path).ok();
-                            let file_type = metadata.as_ref().map(|meta| meta.file_type());
-                            let is_file = file_type.as_ref().is_some_and(|it| it.is_file());
-                            let is_dir = file_type.as_ref().is_some_and(|it| it.is_dir());
-
-                            if is_dir && self.watched_dirs.iter().any(|dir| dir.contains_dir(&path))
-                            {
-                                self.watch(&path);
-                                return None;
-                            }
-
-                            if metadata.is_some() && !is_file {
-                                return None;
-                            }
-
-                            if !(self.watched_files.contains(&path)
-                                || self.watched_dirs.iter().any(|dir| dir.contains_file(&path)))
-                            {
-                                return None;
-                            }
-
-                            let contents = read(&path);
-
-                            Some((path, contents))
-                        })
-                        .collect();
-
+                    let files = self.process_notify_event(event);
+                    self.record_loaded_files(&files);
                     self.send(loader::Message::Loaded {
                         files,
                         config_version: self.config_version,
@@ -225,6 +240,80 @@ impl NotifyActor {
                 }
             }
         }
+    }
+
+    fn process_notify_event(&mut self, event: notify::Event) -> Vec<(AbsPathBuf, LoadResult)> {
+        if !(event.kind.is_create() || event.kind.is_modify() || event.kind.is_remove()) {
+            return Vec::new();
+        }
+
+        let mut files = Vec::new();
+        for path in event.paths.into_iter().filter_map(|path| AbsPathBuf::try_from(path).ok()) {
+            if event.kind.is_remove() {
+                let unloaded = self.unload_removed_path(&path);
+                if !unloaded.is_empty() {
+                    files.extend(unloaded);
+                    continue;
+                }
+            }
+
+            let metadata = fs::metadata(&path).ok();
+            let file_type = metadata.as_ref().map(|meta| meta.file_type());
+            let is_file = file_type.as_ref().is_some_and(|it| it.is_file());
+            let is_dir = file_type.as_ref().is_some_and(|it| it.is_dir());
+
+            if is_dir && self.is_watched_dir(&path) {
+                files.extend(self.load_created_directory(&path));
+                continue;
+            }
+
+            if metadata.is_some() && !is_file {
+                continue;
+            }
+
+            if !self.is_watched_file(&path) {
+                continue;
+            }
+
+            files.push((path.clone(), read(&path)));
+        }
+
+        files
+    }
+
+    fn is_watched_dir(&self, path: &AbsPathBuf) -> bool {
+        self.watched_dirs.iter().any(|dir| dir.contains_dir(path))
+    }
+
+    fn is_watched_file(&self, path: &AbsPathBuf) -> bool {
+        self.watched_files.contains(path)
+            || self.watched_dirs.iter().any(|dir| dir.contains_file(path))
+    }
+
+    fn load_created_directory(&mut self, path: &AbsPathBuf) -> Vec<(AbsPathBuf, LoadResult)> {
+        let dirs =
+            self.watched_dirs.iter().filter(|dir| dir.contains_dir(path)).cloned().collect_vec();
+        let mut files = Vec::new();
+
+        for dir in dirs {
+            let (watch_tx, watch_rx) = unbounded();
+            files.extend(Self::load_directory_subtree(&watch_tx, &dir, path, true));
+            drop(watch_tx);
+            for path in watch_rx {
+                self.watch(&path);
+            }
+        }
+
+        files
+    }
+
+    fn unload_removed_path(&self, path: &AbsPathBuf) -> Vec<(AbsPathBuf, LoadResult)> {
+        self.loaded_paths
+            .iter()
+            .filter(|loaded_path| loaded_path.starts_with(path))
+            .cloned()
+            .map(|path| (path, LoadResult::LoadError))
+            .collect_vec()
     }
 
     fn load_entry(
@@ -247,52 +336,70 @@ impl NotifyActor {
                 let mut res = Vec::new();
 
                 for root in dirs.include_roots() {
-                    let walkdir =
-                        WalkDir::new(root).follow_links(true).into_iter().filter_entry(|entry| {
-                            if !entry.file_type().is_dir() {
-                                return true;
-                            }
-                            let Ok(path) = AbsPathBuf::try_from(entry.path().to_path_buf()) else {
-                                return false;
-                            };
-                            root == &path || dirs.contains_dir(&path)
-                        });
-
-                    let files = walkdir.filter_map(|it| it.ok()).filter_map(|entry| {
-                        let is_dir = entry.file_type().is_dir();
-                        let is_file = entry.file_type().is_file();
-                        let abs_path = AbsPathBuf::try_from(entry.into_path()).ok()?;
-
-                        if is_dir && watch && watch_tx.send(abs_path.to_owned()).is_err() {
-                            tracing::debug!(
-                                "watched directory path dropped because receiver is closed"
-                            );
-                        }
-
-                        if !is_file {
-                            return None;
-                        }
-
-                        if !dirs.contains_file(&abs_path) {
-                            return None;
-                        }
-
-                        Some(abs_path)
-                    });
-
-                    res.extend(files.map(|file| {
-                        let contents = read(file.as_path());
-                        (file, contents)
-                    }));
+                    res.extend(Self::load_directory_subtree(watch_tx, &dirs, root, watch));
                 }
                 res
             }
         }
     }
 
+    fn load_directory_subtree(
+        watch_tx: &Sender<AbsPathBuf>,
+        dirs: &loader::Directories,
+        root: &AbsPathBuf,
+        watch: bool,
+    ) -> Vec<(AbsPathBuf, LoadResult)> {
+        let walkdir = WalkDir::new(root).follow_links(true).into_iter().filter_entry(|entry| {
+            if !entry.file_type().is_dir() {
+                return true;
+            }
+            let Ok(path) = AbsPathBuf::try_from(entry.path().to_path_buf()) else {
+                return false;
+            };
+            root == &path || dirs.contains_dir(&path)
+        });
+
+        let files = walkdir.filter_map(|it| it.ok()).filter_map(|entry| {
+            let is_dir = entry.file_type().is_dir();
+            let is_file = entry.file_type().is_file();
+            let abs_path = AbsPathBuf::try_from(entry.into_path()).ok()?;
+
+            if is_dir && watch && watch_tx.send(abs_path.to_owned()).is_err() {
+                tracing::debug!("watched directory path dropped because receiver is closed");
+            }
+
+            if !is_file {
+                return None;
+            }
+
+            if !dirs.contains_file(&abs_path) {
+                return None;
+            }
+
+            Some(abs_path)
+        });
+
+        files
+            .map(|file| {
+                let contents = read(file.as_path());
+                (file, contents)
+            })
+            .collect_vec()
+    }
+
     fn watch(&mut self, path: &AbsPathBuf) {
         if let Some((watcher, _)) = &mut self.watcher {
             log_notify_error(watcher.watch(path.as_ref(), RecursiveMode::NonRecursive));
+        }
+    }
+
+    fn record_loaded_files(&mut self, files: &[(AbsPathBuf, LoadResult)]) {
+        for (path, result) in files {
+            if matches!(result, LoadResult::LoadError) {
+                self.loaded_paths.remove(path);
+            } else {
+                self.loaded_paths.insert(path.clone());
+            }
         }
     }
 
@@ -317,4 +424,294 @@ fn read(path: &AbsPath) -> LoadResult {
 
 fn log_notify_error<T>(res: notify::Result<T>) -> Option<T> {
     res.map_err(|err| tracing::warn!("notify error: {}", err)).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use notify::{
+        Event as NotifyEvent, EventKind,
+        event::{CreateKind, RemoveKind},
+    };
+    use utils::paths::AbsPathBuf;
+    use vfs::{
+        PathMatcher,
+        loader::{self, Handle as _},
+    };
+
+    use super::*;
+
+    struct TestDir {
+        _dir: tempfile::TempDir,
+        path: AbsPathBuf,
+    }
+
+    impl TestDir {
+        fn new(name: &str) -> Self {
+            let dir =
+                tempfile::Builder::new().prefix(&format!("vizsla-{name}-")).tempdir().unwrap();
+            let path = AbsPathBuf::assert_utf8(dir.path().to_path_buf());
+            Self { _dir: dir, path }
+        }
+
+        fn join(&self, path: &str) -> AbsPathBuf {
+            self.path.join(path)
+        }
+    }
+
+    fn collect_until_progress_done(
+        receiver: &Receiver<loader::Message>,
+        version: u32,
+    ) -> Vec<Vec<(AbsPathBuf, LoadResult)>> {
+        let mut loaded_batches = Vec::new();
+        loop {
+            match receiver.recv_timeout(Duration::from_secs(1)).unwrap() {
+                loader::Message::Loaded { files, config_version } if config_version == version => {
+                    loaded_batches.push(files);
+                }
+                loader::Message::Progress { n_total, n_done, config_version }
+                    if config_version == version && n_done == n_total =>
+                {
+                    return loaded_batches;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn recv_version_message(receiver: &Receiver<loader::Message>, version: u32) -> loader::Message {
+        loop {
+            let message = receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+            match &message {
+                loader::Message::Loaded { config_version, .. }
+                | loader::Message::Progress { config_version, .. }
+                    if *config_version == version =>
+                {
+                    return message;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn spawn_loader() -> (NotifyHandle, Receiver<loader::Message>) {
+        let (sender, receiver) = unbounded();
+        (<NotifyHandle as loader::Handle>::spawn(sender), receiver)
+    }
+
+    fn assert_loaded(batches: &[Vec<(AbsPathBuf, LoadResult)>], expected_path: &AbsPathBuf) {
+        assert!(
+            batches.iter().flatten().any(|(path, result)| {
+                path == expected_path && matches!(result, LoadResult::Loaded(_, _))
+            }),
+            "expected loaded path {expected_path}, got {batches:?}"
+        );
+    }
+
+    fn path_buf(path: &AbsPathBuf) -> std::path::PathBuf {
+        let path: &std::path::Path = path.as_ref();
+        path.to_path_buf()
+    }
+
+    fn watched_sv_dir(root: AbsPathBuf) -> loader::Directories {
+        loader::Directories {
+            extensions: vec!["sv".to_owned()],
+            include: vec![PathMatcher::all_under_roots(vec![root])],
+            exclude: Vec::new(),
+            exclude_globs: None,
+        }
+    }
+
+    fn actor() -> NotifyActor {
+        let (sender, _receiver) = unbounded();
+        NotifyActor::new(sender)
+    }
+
+    #[test]
+    fn empty_config_emits_ready_ack_progress() {
+        let (mut handle, receiver) = spawn_loader();
+
+        handle.set_config(loader::Config { version: 1, to_load: Vec::new(), to_watch: Vec::new() });
+
+        assert!(matches!(
+            recv_version_message(&receiver, 1),
+            loader::Message::Progress { n_done: 0, n_total: 0, .. }
+        ));
+    }
+
+    #[test]
+    fn removed_config_file_is_unloaded() {
+        let dir = TestDir::new("vfs-notify-unload-file");
+        let file = dir.join("top.sv");
+        std::fs::write(&file, "module top; endmodule\n").unwrap();
+        let (mut handle, receiver) = spawn_loader();
+
+        handle.set_config(loader::Config {
+            version: 1,
+            to_load: vec![loader::Entry::Files(vec![file.clone()])],
+            to_watch: Vec::new(),
+        });
+        let loaded = collect_until_progress_done(&receiver, 1);
+        assert_loaded(&loaded, &file);
+
+        handle.set_config(loader::Config { version: 2, to_load: Vec::new(), to_watch: Vec::new() });
+
+        assert!(matches!(
+            recv_version_message(&receiver, 2),
+            loader::Message::Progress { n_done: 0, n_total: 1, .. }
+        ));
+        let loader::Message::Loaded { files: unloaded, .. } = recv_version_message(&receiver, 2)
+        else {
+            panic!("expected unload batch before final progress");
+        };
+        assert_eq!(unloaded, vec![(file, LoadResult::LoadError)]);
+        assert!(matches!(
+            recv_version_message(&receiver, 2),
+            loader::Message::Progress { n_done: 1, n_total: 1, .. }
+        ));
+    }
+
+    #[test]
+    fn configured_missing_file_is_not_reconciled_twice() {
+        let dir = TestDir::new("vfs-notify-missing-config-file");
+        let file = dir.join("top.sv");
+        std::fs::write(&file, "module top; endmodule\n").unwrap();
+        let (mut handle, receiver) = spawn_loader();
+
+        handle.set_config(loader::Config {
+            version: 1,
+            to_load: vec![loader::Entry::Files(vec![file.clone()])],
+            to_watch: Vec::new(),
+        });
+        let loaded = collect_until_progress_done(&receiver, 1);
+        assert_loaded(&loaded, &file);
+
+        std::fs::remove_file(&file).unwrap();
+        handle.set_config(loader::Config {
+            version: 2,
+            to_load: vec![loader::Entry::Files(vec![file.clone()])],
+            to_watch: Vec::new(),
+        });
+
+        let mut unload_count = 0;
+        loop {
+            match recv_version_message(&receiver, 2) {
+                loader::Message::Loaded { files, .. } => {
+                    unload_count += files
+                        .iter()
+                        .filter(|(path, result)| {
+                            path == &file && matches!(result, LoadResult::LoadError)
+                        })
+                        .count();
+                }
+                loader::Message::Progress { n_done, n_total, .. } if n_done == n_total => break,
+                _ => {}
+            }
+        }
+
+        assert_eq!(unload_count, 1);
+    }
+
+    #[test]
+    fn removed_config_directory_is_unloaded() {
+        let dir = TestDir::new("vfs-notify-unload-directory");
+        let source_dir = dir.join("rtl");
+        std::fs::create_dir_all(&source_dir).unwrap();
+        let file = source_dir.join("top.sv");
+        std::fs::write(&file, "module top; endmodule\n").unwrap();
+        let (mut handle, receiver) = spawn_loader();
+
+        handle.set_config(loader::Config {
+            version: 1,
+            to_load: vec![loader::Entry::Directories(loader::Directories {
+                extensions: vec!["sv".to_owned()],
+                include: vec![PathMatcher::all_under_roots(vec![source_dir])],
+                exclude: Vec::new(),
+                exclude_globs: None,
+            })],
+            to_watch: Vec::new(),
+        });
+        let loaded = collect_until_progress_done(&receiver, 1);
+        assert_loaded(&loaded, &file);
+
+        handle.set_config(loader::Config { version: 2, to_load: Vec::new(), to_watch: Vec::new() });
+
+        assert!(matches!(
+            recv_version_message(&receiver, 2),
+            loader::Message::Progress { n_done: 0, n_total: 1, .. }
+        ));
+        let loader::Message::Loaded { files: unloaded, .. } = recv_version_message(&receiver, 2)
+        else {
+            panic!("expected unload batch before final progress");
+        };
+        assert_eq!(unloaded, vec![(file, LoadResult::LoadError)]);
+        assert!(matches!(
+            recv_version_message(&receiver, 2),
+            loader::Message::Progress { n_done: 1, n_total: 1, .. }
+        ));
+    }
+
+    #[test]
+    fn created_watched_directory_is_loaded_immediately() {
+        let dir = TestDir::new("vfs-notify-created-directory-load");
+        let root = dir.join("workspace");
+        let created_dir = root.join("generated");
+        let nested_dir = created_dir.join("nested");
+        std::fs::create_dir_all(&nested_dir).unwrap();
+        let top = created_dir.join("top.sv");
+        let child = nested_dir.join("child.sv");
+        let ignored = created_dir.join("notes.txt");
+        std::fs::write(&top, "module top; endmodule\n").unwrap();
+        std::fs::write(&child, "module child; endmodule\n").unwrap();
+        std::fs::write(&ignored, "not systemverilog").unwrap();
+        let mut actor = actor();
+        actor.watched_dirs.push(watched_sv_dir(root));
+
+        let files = actor.process_notify_event(
+            NotifyEvent::new(EventKind::Create(CreateKind::Folder))
+                .add_path(path_buf(&created_dir)),
+        );
+        actor.record_loaded_files(&files);
+
+        assert!(
+            files.iter().any(|(path, result)| {
+                path == &top && matches!(result, LoadResult::Loaded(_, _))
+            })
+        );
+        assert!(files.iter().any(|(path, result)| {
+            path == &child && matches!(result, LoadResult::Loaded(_, _))
+        }));
+        assert!(!files.iter().any(|(path, _)| path == &ignored));
+        assert!(actor.loaded_paths.contains(&top));
+        assert!(actor.loaded_paths.contains(&child));
+    }
+
+    #[test]
+    fn removed_watched_directory_unloads_loaded_descendants() {
+        let dir = TestDir::new("vfs-notify-removed-directory-unload");
+        let root = dir.join("workspace");
+        let removed_dir = root.join("removed");
+        let top = removed_dir.join("top.sv");
+        let child = removed_dir.join("nested/child.sv");
+        let sibling = root.join("sibling.sv");
+        let mut actor = actor();
+        actor.watched_dirs.push(watched_sv_dir(root));
+        actor.loaded_paths.extend([top.clone(), child.clone(), sibling.clone()]);
+
+        let mut files = actor.process_notify_event(
+            NotifyEvent::new(EventKind::Remove(RemoveKind::Folder))
+                .add_path(path_buf(&removed_dir)),
+        );
+        files.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
+        actor.record_loaded_files(&files);
+
+        let mut expected =
+            vec![(child.clone(), LoadResult::LoadError), (top.clone(), LoadResult::LoadError)];
+        expected.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
+        assert_eq!(files, expected);
+        assert!(!actor.loaded_paths.contains(&top));
+        assert!(!actor.loaded_paths.contains(&child));
+        assert!(actor.loaded_paths.contains(&sibling));
+    }
 }

--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -9,6 +9,7 @@ pub mod reload;
 pub mod respond;
 pub(crate) mod snapshot;
 mod trace;
+mod workspace_state;
 
 use std::time::Instant;
 
@@ -33,11 +34,17 @@ use utils::{
 };
 use vfs::{self, FileId, Vfs};
 
+#[cfg(test)]
+pub(crate) use self::workspace_state::VfsProgress;
+pub(crate) use self::workspace_state::{
+    WorkspaceFetchCause, WorkspaceFetchCompletion, WorkspaceGeneration,
+};
 use self::{
     main_loop::{DiagnosticPublishFreshness, DiagnosticPublishKey, Task},
     mem_docs::MemDocs,
     snapshot::GlobalStateSnapshot,
     trace::LspTrace,
+    workspace_state::WorkspaceVfsReadiness,
 };
 use crate::config::{Config, ConfigError};
 
@@ -83,19 +90,6 @@ pub(crate) struct Handle<H, C> {
     pub(crate) receiver: C,
 }
 
-#[derive(Default)]
-pub(crate) struct VfsProgress {
-    pub(crate) config_version: u32,
-    pub(crate) n_done: usize,
-    pub(crate) n_total: usize,
-}
-
-impl VfsProgress {
-    fn in_progress(&self) -> bool {
-        self.n_done < self.n_total
-    }
-}
-
 pub(crate) type ReqHandler = fn(&mut GlobalState, lsp_server::Response);
 pub(crate) const DEFAULT_REQ_HANDLER: ReqHandler = |_, _| {};
 
@@ -119,6 +113,7 @@ pub(crate) struct GlobalState {
 
     pub(crate) semantic_tokens_cache: Arc<Mutex<FxHashMap<Url, lsp_types::SemanticTokens>>>,
     pub(crate) published_diagnostics: FxHashMap<DiagnosticPublishKey, Vec<lsp_types::Diagnostic>>,
+    pub(crate) pending_diagnostic_requests: Vec<Request>,
     // didOpen/didClose can change the URI set for a file without changing its
     // text. Keep those target changes explicit so push diagnostics converge at
     // the normal change-processing boundary.
@@ -132,12 +127,12 @@ pub(crate) struct GlobalState {
 
     pub(crate) vfs_loader: Handle<Box<dyn vfs::loader::Handle>, Receiver<vfs::loader::Message>>,
     pub(crate) vfs: Arc<RwLock<(Vfs, IntMap<FileId, LineEnding>)>>,
-    pub(crate) vfs_config_version: u32,
-    pub(crate) vfs_progress: VfsProgress,
+    pub(crate) workspace_vfs: WorkspaceVfsReadiness,
 
     // workspaces
     pub(crate) workspaces: Arc<Vec<Workspace>>,
-    pub(crate) fetch_workspaces_task: ExclTask<(Arc<Vec<Workspace>>, Vec<anyhow::Error>)>,
+    pub(crate) fetch_workspaces_task:
+        ExclTask<(Arc<Vec<Workspace>>, Vec<anyhow::Error>), WorkspaceFetchCause>,
     pub(crate) registered_client_file_watcher_globs: Option<Vec<String>>,
 }
 
@@ -182,6 +177,7 @@ impl GlobalState {
 
             semantic_tokens_cache: Arc::new(Default::default()),
             published_diagnostics: FxHashMap::default(),
+            pending_diagnostic_requests: Vec::new(),
             pending_document_diagnostic_targets: FxHashSet::default(),
             diagnostics_revision: 0,
             diagnostic_target_revision: 0,
@@ -191,8 +187,7 @@ impl GlobalState {
 
             vfs_loader,
             vfs: Arc::new(RwLock::new((Vfs::default(), IntMap::default()))),
-            vfs_config_version: 0,
-            vfs_progress: VfsProgress::default(),
+            workspace_vfs: WorkspaceVfsReadiness::default(),
 
             workspaces: Arc::from(vec![]),
             fetch_workspaces_task: ExclTask::default(),
@@ -215,7 +210,11 @@ impl GlobalState {
     }
 
     pub(crate) fn diagnostic_publish_freshness(&self) -> DiagnosticPublishFreshness {
-        DiagnosticPublishFreshness::new(self.diagnostics_revision, self.diagnostic_target_revision)
+        DiagnosticPublishFreshness::new(
+            self.diagnostics_revision,
+            self.diagnostic_target_revision,
+            self.workspace_vfs.diagnostic_readiness_revision(),
+        )
     }
 }
 

--- a/src/global_state/main_loop.rs
+++ b/src/global_state/main_loop.rs
@@ -3,17 +3,17 @@ use std::time::{Duration, Instant};
 use always_assert::always;
 use crossbeam_channel::{Receiver, select};
 use lsp_server::{Connection, Message, Notification, Request, Response};
-use lsp_types::{TraceValue, notification::Notification as _};
+use lsp_types::{TraceValue, notification::Notification as _, request::Request as _};
 use project_model::project_manifest;
 use rustc_hash::FxHashSet;
 use triomphe::Arc;
-use utils::thread::ThreadIntent;
 use vfs::{FileId, VfsPath, loader as vfs_loader};
 
 use super::{
-    GlobalState, VfsProgress,
+    GlobalState, WorkspaceFetchCompletion,
     dispatcher::{NotifDispatcher, ReqDispatcher},
     handlers,
+    process_changes::DiagnosticInvalidation,
     qihe::{QiheRunId, QiheUpdate},
     reload::FetchWorkspaceProgress,
     respond::Progress,
@@ -66,18 +66,24 @@ impl Event {
 mod tests {
     use std::time::Duration;
 
-    use lsp_server::Connection;
+    use lsp_server::{Connection, Message};
     use lsp_types::{
-        Diagnostic, DiagnosticSeverity, Position, PublishDiagnosticsParams, Range,
-        notification::Notification as _,
+        ClientCapabilities, Diagnostic, DiagnosticSeverity, Position, ProgressParams,
+        ProgressParamsValue, PublishDiagnosticsParams, Range, WindowClientCapabilities,
+        WorkDoneProgress, notification::Notification as _, request::Request as _,
     };
+    use project_model::{ProjectModel, project_manifest::ProjectManifest};
+    use triomphe::Arc;
     use utils::{lines::LineEnding, paths::AbsPathBuf, test_support::TestDir};
     use vfs::loader::LoadResult;
 
     use super::*;
     use crate::{Opt, config::user_config::UserConfig, i18n::I18n, lsp_ext::to_proto};
 
-    fn test_state(root_path: AbsPathBuf) -> GlobalState {
+    fn test_state_with_caps(
+        root_path: AbsPathBuf,
+        client_caps: ClientCapabilities,
+    ) -> (GlobalState, Connection) {
         let config = Config::new(
             Opt {
                 process_name: "vizsla-test".to_string(),
@@ -86,15 +92,26 @@ mod tests {
                 profile_trace: None,
             },
             root_path.clone(),
-            lsp_types::ClientCapabilities::default(),
+            client_caps,
             vec![root_path],
             I18n::default(),
             UserConfig::default(),
             Vec::new(),
         );
 
-        let (server, _client) = Connection::memory();
-        GlobalState::new(server.sender, config, lsp_types::TraceValue::Off)
+        let (server, client) = Connection::memory();
+        (GlobalState::new(server.sender, config, lsp_types::TraceValue::Off), client)
+    }
+
+    fn test_state(root_path: AbsPathBuf) -> GlobalState {
+        test_state_with_caps(root_path, ClientCapabilities::default()).0
+    }
+
+    fn workspace_model(root_path: AbsPathBuf) -> Vec<project_model::Workspace> {
+        let (model, errors) =
+            ProjectModel::load(vec![ProjectManifest::UnconfiguredRoot(root_path)]);
+        assert!(errors.is_empty(), "{errors:#?}");
+        model.workspaces
     }
 
     fn recv_publish(client: &Connection) -> PublishDiagnosticsParams {
@@ -104,6 +121,20 @@ mod tests {
         };
         assert_eq!(notification.method, lsp_types::notification::PublishDiagnostics::METHOD);
         serde_json::from_value(notification.params).unwrap()
+    }
+
+    fn recv_work_done_progress(client: &Connection) -> WorkDoneProgress {
+        for _ in 0..8 {
+            let message = client.receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+            if let Message::Notification(notification) = message
+                && notification.method == lsp_types::notification::Progress::METHOD
+            {
+                let params: ProgressParams = serde_json::from_value(notification.params).unwrap();
+                let ProgressParamsValue::WorkDone(progress) = params.value;
+                return progress;
+            }
+        }
+        panic!("expected work-done progress notification");
     }
 
     fn publish_batch(tasks: Vec<PublishDiagnosticsTask>) -> PublishDiagnosticsBatch {
@@ -278,7 +309,7 @@ mod tests {
         state.publish_diagnostics_tasks(
             PublishDiagnosticsBatch::from_tasks(
                 vec![PublishDiagnosticsTask::for_test(file_id, uri, None, vec![diagnostic])],
-                DiagnosticPublishFreshness::new(1, 0),
+                DiagnosticPublishFreshness::new(1, 0, 0),
             ),
             false,
         );
@@ -293,7 +324,8 @@ mod tests {
         let root_path = root.path().to_path_buf();
         let file_path = root_path.join("stale.sv");
         let mut state = test_state(root_path);
-        state.vfs_config_version = 2;
+        state.workspace_vfs.begin_vfs_load(1);
+        state.workspace_vfs.begin_vfs_load(1);
 
         state.process_vfs_msg(vfs_loader::Message::Loaded {
             files: vec![(
@@ -307,6 +339,249 @@ mod tests {
         let mut vfs = state.vfs.write();
         assert!(vfs.0.file_id(&vfs_path).is_none());
         assert!(vfs.0.take_changes().is_empty());
+    }
+
+    #[test]
+    fn empty_vfs_load_waits_for_loader_ack() {
+        let root = TestDir::new("empty-vfs-load-waits-for-ack");
+        let root_path = root.path().to_path_buf();
+        let (mut state, client) = test_state_with_caps(
+            root_path,
+            ClientCapabilities {
+                window: Some(WindowClientCapabilities {
+                    work_done_progress: Some(true),
+                    ..WindowClientCapabilities::default()
+                }),
+                ..ClientCapabilities::default()
+            },
+        );
+
+        let config_version = state.workspace_vfs.begin_vfs_load(0);
+        assert!(!state.workspace_vfs.is_ready());
+
+        state.process_vfs_msg(vfs_loader::Message::Progress {
+            n_total: 0,
+            n_done: 0,
+            config_version,
+        });
+
+        assert!(state.workspace_vfs.is_ready());
+        assert!(client.receiver.recv_timeout(Duration::from_millis(50)).is_err());
+    }
+
+    #[test]
+    fn diagnostic_requests_are_parked_until_workspace_ready() {
+        let root = TestDir::new("diagnostic-request-readiness-queue");
+        let root_path = root.path().to_path_buf();
+        let mut state = test_state(root_path);
+        let config_version = state.workspace_vfs.begin_vfs_load(1);
+        let request_id = lsp_server::RequestId::from(7);
+        let req = Request::new(
+            request_id.clone(),
+            lsp_types::request::WorkspaceDiagnosticRequest::METHOD.to_owned(),
+            lsp_types::WorkspaceDiagnosticParams {
+                identifier: None,
+                previous_result_ids: Vec::new(),
+                work_done_progress_params: lsp_types::WorkDoneProgressParams::default(),
+                partial_result_params: Default::default(),
+            },
+        );
+
+        state.register_request(Instant::now(), &req);
+        state.handle_request(req);
+
+        assert_eq!(state.pending_diagnostic_requests.len(), 1);
+        assert!(state.task_pool.receiver.recv_timeout(Duration::from_millis(50)).is_err());
+
+        state
+            .handle_event(Event::Vfs(vfs_loader::Message::Progress {
+                n_total: 1,
+                n_done: 1,
+                config_version,
+            }))
+            .unwrap();
+
+        assert!(state.pending_diagnostic_requests.is_empty());
+        let task = state.task_pool.receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+        let Task::Response(response) = task else {
+            panic!("expected parked diagnostic request to resume as response task, got {task:?}");
+        };
+        assert_eq!(response.id, request_id);
+    }
+
+    #[test]
+    fn stale_progress_does_not_update_readiness_or_report() {
+        let root = TestDir::new("stale-vfs-progress");
+        let root_path = root.path().to_path_buf();
+        let (mut state, client) = test_state_with_caps(
+            root_path,
+            ClientCapabilities {
+                window: Some(WindowClientCapabilities {
+                    work_done_progress: Some(true),
+                    ..WindowClientCapabilities::default()
+                }),
+                ..ClientCapabilities::default()
+            },
+        );
+        let stale_config = state.workspace_vfs.begin_vfs_load(4);
+        let current_config = state.workspace_vfs.begin_vfs_load(4);
+
+        state.process_vfs_msg(vfs_loader::Message::Progress {
+            n_total: 4,
+            n_done: 4,
+            config_version: stale_config,
+        });
+
+        assert_eq!(
+            state.workspace_vfs.current_vfs_progress(),
+            crate::global_state::VfsProgress {
+                config_version: current_config,
+                n_done: 0,
+                n_total: 4,
+            }
+        );
+        assert!(!state.workspace_vfs.is_ready());
+        assert!(client.receiver.recv_timeout(Duration::from_millis(50)).is_err());
+
+        state.process_vfs_msg(vfs_loader::Message::Progress {
+            n_total: 4,
+            n_done: 2,
+            config_version: current_config,
+        });
+
+        assert_eq!(
+            state.workspace_vfs.current_vfs_progress(),
+            crate::global_state::VfsProgress {
+                config_version: current_config,
+                n_done: 2,
+                n_total: 4,
+            }
+        );
+        let Message::Notification(notification) =
+            client.receiver.recv_timeout(Duration::from_secs(1)).unwrap()
+        else {
+            panic!("expected progress notification");
+        };
+        assert_eq!(notification.method, lsp_types::notification::Progress::METHOD);
+        let params: ProgressParams = serde_json::from_value(notification.params).unwrap();
+        let ProgressParamsValue::WorkDone(WorkDoneProgress::Report(report)) = params.value else {
+            panic!("expected VFS progress report");
+        };
+        assert_eq!(report.message.as_deref(), Some("2/4"));
+        assert_eq!(report.percentage, Some(50));
+    }
+
+    #[test]
+    fn out_of_order_vfs_progress_does_not_regress_readiness_or_report() {
+        let root = TestDir::new("out-of-order-vfs-progress");
+        let root_path = root.path().to_path_buf();
+        let (mut state, client) = test_state_with_caps(
+            root_path,
+            ClientCapabilities {
+                window: Some(WindowClientCapabilities {
+                    work_done_progress: Some(true),
+                    ..WindowClientCapabilities::default()
+                }),
+                ..ClientCapabilities::default()
+            },
+        );
+        let config_version = state.workspace_vfs.begin_vfs_load(2);
+
+        state.process_vfs_msg(vfs_loader::Message::Progress {
+            n_total: 2,
+            n_done: 2,
+            config_version,
+        });
+
+        assert!(state.workspace_vfs.is_ready());
+        assert_eq!(
+            state.workspace_vfs.current_vfs_progress(),
+            crate::global_state::VfsProgress { config_version, n_done: 2, n_total: 2 }
+        );
+        assert!(matches!(recv_work_done_progress(&client), WorkDoneProgress::End(_)));
+
+        state.process_vfs_msg(vfs_loader::Message::Progress {
+            n_total: 2,
+            n_done: 1,
+            config_version,
+        });
+
+        assert!(state.workspace_vfs.is_ready());
+        assert_eq!(
+            state.workspace_vfs.current_vfs_progress(),
+            crate::global_state::VfsProgress { config_version, n_done: 2, n_total: 2 }
+        );
+        assert!(client.receiver.recv_timeout(Duration::from_millis(50)).is_err());
+    }
+
+    #[test]
+    fn superseded_workspace_fetch_does_not_commit_stale_workspaces() {
+        let root = TestDir::new("superseded-workspace-fetch");
+        let root_path = root.path().to_path_buf();
+        let existing_root = root.join("existing");
+        let stale_root = root.join("stale");
+        std::fs::create_dir_all(&existing_root).unwrap();
+        std::fs::create_dir_all(&stale_root).unwrap();
+        let (mut state, _client) = test_state_with_caps(root_path, ClientCapabilities::default());
+        let existing_workspaces = Arc::new(workspace_model(existing_root));
+        state.workspaces = Arc::clone(&existing_workspaces);
+
+        state.request_workspace_reload("first reload");
+        let first = state.fetch_workspaces_task.should_start().unwrap();
+        state.workspace_vfs.start_workspace_fetch(first.generation);
+        state.request_workspace_reload("second reload");
+
+        state.process_task(Task::FetchWorkspace(FetchWorkspaceProgress::End {
+            generation: first.generation,
+            workspaces: workspace_model(stale_root),
+            errors: Vec::new(),
+        }));
+
+        assert!(Arc::ptr_eq(&state.workspaces, &existing_workspaces));
+        assert_eq!(state.workspace_vfs.current_vfs_config_version(), 0);
+        let second = state.fetch_workspaces_task.should_start().unwrap();
+        assert_eq!(second.cause, "second reload");
+        assert_ne!(second.generation, first.generation);
+    }
+
+    #[test]
+    fn superseded_workspace_fetch_ends_reported_progress() {
+        let root = TestDir::new("superseded-workspace-fetch-progress");
+        let root_path = root.path().to_path_buf();
+        let stale_root = root.join("stale");
+        std::fs::create_dir_all(&stale_root).unwrap();
+        let (mut state, client) = test_state_with_caps(
+            root_path,
+            ClientCapabilities {
+                window: Some(WindowClientCapabilities {
+                    work_done_progress: Some(true),
+                    ..WindowClientCapabilities::default()
+                }),
+                ..ClientCapabilities::default()
+            },
+        );
+
+        state.request_workspace_reload("first reload");
+        let first = state.fetch_workspaces_task.should_start().unwrap();
+        state.workspace_vfs.start_workspace_fetch(first.generation);
+        state.process_task(Task::FetchWorkspace(FetchWorkspaceProgress::Begin {
+            generation: first.generation,
+            cause: first.cause.clone(),
+        }));
+        assert!(matches!(recv_work_done_progress(&client), WorkDoneProgress::Begin(_)));
+
+        state.request_workspace_reload("second reload");
+        state.process_task(Task::FetchWorkspace(FetchWorkspaceProgress::End {
+            generation: first.generation,
+            workspaces: workspace_model(stale_root),
+            errors: Vec::new(),
+        }));
+
+        assert!(matches!(recv_work_done_progress(&client), WorkDoneProgress::End(_)));
+        assert_eq!(state.workspace_vfs.current_vfs_config_version(), 0);
+        let second = state.fetch_workspaces_task.should_start().unwrap();
+        assert_eq!(second.cause, "second reload");
+        assert_ne!(second.generation, first.generation);
     }
 }
 
@@ -336,11 +611,16 @@ pub(crate) struct PublishDiagnosticsBatch {
 pub(crate) struct DiagnosticPublishFreshness {
     diagnostics_revision: u64,
     target_revision: u64,
+    readiness_revision: u64,
 }
 
 impl DiagnosticPublishFreshness {
-    pub(crate) fn new(diagnostics_revision: u64, target_revision: u64) -> Self {
-        Self { diagnostics_revision, target_revision }
+    pub(crate) fn new(
+        diagnostics_revision: u64,
+        target_revision: u64,
+        readiness_revision: u64,
+    ) -> Self {
+        Self { diagnostics_revision, target_revision, readiness_revision }
     }
 }
 
@@ -471,8 +751,10 @@ impl Task {
         match self {
             Task::Response(_) => "task.response",
             Task::Retry(_) => "task.retry",
-            Task::FetchWorkspace(FetchWorkspaceProgress::Begin(_)) => "task.fetch_workspace.begin",
-            Task::FetchWorkspace(FetchWorkspaceProgress::End(_, _)) => "task.fetch_workspace.end",
+            Task::FetchWorkspace(FetchWorkspaceProgress::Begin { .. }) => {
+                "task.fetch_workspace.begin"
+            }
+            Task::FetchWorkspace(FetchWorkspaceProgress::End { .. }) => "task.fetch_workspace.end",
             Task::Diagnostics(_) => "task.diagnostics",
             Task::Qihe(task) => task.kind(),
         }
@@ -484,10 +766,10 @@ impl Task {
                 format!("task response id={:?} error={}", res.id, res.error.is_some())
             }
             Task::Retry(req) => format!("task retry method={} id={:?}", req.method, req.id),
-            Task::FetchWorkspace(FetchWorkspaceProgress::Begin(cause)) => {
+            Task::FetchWorkspace(FetchWorkspaceProgress::Begin { cause, .. }) => {
                 format!("task fetch workspace begin cause={cause}")
             }
-            Task::FetchWorkspace(FetchWorkspaceProgress::End(workspaces, errors)) => {
+            Task::FetchWorkspace(FetchWorkspaceProgress::End { workspaces, errors, .. }) => {
                 format!(
                     "task fetch workspace end workspaces={} errors={}",
                     workspaces.len(),
@@ -637,12 +919,12 @@ impl GlobalState {
         };
         tracing::debug!(event.summary = %event_summary, "handle_event start");
 
-        let was_stuck = self.is_stuck();
+        let was_workspace_ready = self.is_workspace_ready();
         let event_span = tracing::info_span!(
             "main_loop.handle_event",
             event.kind = event_kind,
             event.summary = %event_summary,
-            was_stuck
+            was_workspace_ready
         );
         let _event_span = event_span.enter();
 
@@ -662,9 +944,13 @@ impl GlobalState {
         let event_handling_duration = loop_start.elapsed();
 
         let state_changed = self.process_changes();
+        if self.workspace_vfs.take_deferred_diagnostics_if_ready() {
+            self.invalidate_diagnostics(DiagnosticInvalidation::WorkspaceChanged);
+            self.drain_pending_diagnostic_requests();
+        }
 
-        if self.is_stuck() {
-            let client_refresh = !was_stuck || state_changed;
+        if self.is_workspace_ready() {
+            let client_refresh = !was_workspace_ready || state_changed;
 
             if client_refresh && self.config.cli_code_lens_refresh_support() {
                 self.send_request::<lsp_types::request::CodeLensRefresh>((), DEFAULT_REQ_HANDLER);
@@ -681,7 +967,7 @@ impl GlobalState {
         self.start_requested_workspace_fetch();
 
         let loop_duration = loop_start.elapsed();
-        if loop_duration > Duration::from_millis(100) && was_stuck {
+        if loop_duration > Duration::from_millis(100) && was_workspace_ready {
             tracing::warn!(
                 event.summary = %event_summary,
                 event.debug_len = event_dbg_msg.len(),
@@ -702,13 +988,9 @@ impl GlobalState {
     }
 
     fn handle_request(&mut self, req: Request) {
-        if matches!(
-            req.method.as_str(),
-            lsp_types::request::DocumentDiagnosticRequest::METHOD
-                | lsp_types::request::WorkspaceDiagnosticRequest::METHOD
-        ) && !self.is_stuck()
-        {
-            self.task_pool.handle.spawn_and_send(ThreadIntent::Worker, move || Task::Retry(req));
+        if Self::is_pull_diagnostic_request(&req) && !self.is_workspace_ready() {
+            self.workspace_vfs.defer_diagnostics_until_ready();
+            self.pending_diagnostic_requests.push(req);
             return;
         }
 
@@ -792,6 +1074,23 @@ impl GlobalState {
         handler(self, res)
     }
 
+    fn is_pull_diagnostic_request(req: &Request) -> bool {
+        matches!(
+            req.method.as_str(),
+            lsp_types::request::DocumentDiagnosticRequest::METHOD
+                | lsp_types::request::WorkspaceDiagnosticRequest::METHOD
+        )
+    }
+
+    fn drain_pending_diagnostic_requests(&mut self) {
+        let pending_requests = std::mem::take(&mut self.pending_diagnostic_requests);
+        for req in pending_requests {
+            if !self.is_completed(&req) {
+                self.handle_request(req);
+            }
+        }
+    }
+
     fn handle_task(&mut self, task: Task) {
         self.process_task(task);
 
@@ -821,27 +1120,60 @@ impl GlobalState {
                 }
             }
             Task::FetchWorkspace(process) => {
-                let state = match process {
-                    FetchWorkspaceProgress::Begin(cause) => {
+                let Some(state) = (match process {
+                    FetchWorkspaceProgress::Begin { generation, cause } => {
+                        if !self.workspace_vfs.accept_workspace_fetch_begin(generation) {
+                            tracing::debug!(?generation, "stale workspace fetch begin ignored");
+                            return;
+                        }
                         self.send_loading_project_status(cause);
-                        Progress::Begin
+                        Some(Progress::Begin)
                     }
-                    FetchWorkspaceProgress::End(workspaces, errors) => {
+                    FetchWorkspaceProgress::End { generation, workspaces, errors } => {
                         let workspace_count = workspaces.len();
                         let error_messages =
                             errors.iter().map(|err| format!("{err:#}")).collect::<Vec<_>>();
+                        let completion = self
+                            .workspace_vfs
+                            .finish_workspace_fetch(generation, !errors.is_empty());
 
-                        self.fetch_workspaces_task.complete(Some((Arc::new(workspaces), errors)));
+                        match completion {
+                            WorkspaceFetchCompletion::Stale { progress_started } => {
+                                self.fetch_workspaces_task.complete(None);
+                                tracing::debug!(
+                                    ?generation,
+                                    "stale workspace fetch result ignored"
+                                );
+                                progress_started.then_some(Progress::End)
+                            }
+                            WorkspaceFetchCompletion::CurrentFailure => {
+                                self.fetch_workspaces_task
+                                    .complete(Some((Arc::new(workspaces), errors)));
+                                if let Err(e) = self.fetch_workspace_error_stringify() {
+                                    tracing::error!("Fetch workspace error: \n{e}");
+                                }
+                                self.send_project_status_for_result(
+                                    workspace_count,
+                                    &error_messages,
+                                );
+                                Some(Progress::End)
+                            }
+                            WorkspaceFetchCompletion::CurrentSuccess => {
+                                self.fetch_workspaces_task
+                                    .complete(Some((Arc::new(workspaces), errors)));
 
-                        if let Err(e) = self.fetch_workspace_error_stringify() {
-                            tracing::error!("Fetch workspace error: \n{e}");
+                                self.switch_workspaces("fetched new workspaces".into(), generation);
+                                self.send_project_status_for_result(
+                                    workspace_count,
+                                    &error_messages,
+                                );
+
+                                Some(Progress::End)
+                            }
                         }
-
-                        self.switch_workspaces("fetched new workspaces".into());
-                        self.send_project_status_for_result(workspace_count, &error_messages);
-
-                        Progress::End
                     }
+                }) else {
+                    return;
                 };
 
                 self.report_progress(
@@ -869,33 +1201,46 @@ impl GlobalState {
     fn process_vfs_msg(&mut self, msg: vfs_loader::Message) {
         match msg {
             vfs_loader::Message::Progress { n_total, n_done, config_version } => {
-                always!(config_version <= self.vfs_config_version);
+                always!(config_version <= self.workspace_vfs.current_vfs_config_version());
 
-                self.vfs_progress = VfsProgress { config_version, n_done, n_total };
+                let Some(progress) =
+                    self.workspace_vfs.accept_vfs_progress(config_version, n_done, n_total)
+                else {
+                    tracing::debug!(
+                        config_version,
+                        current_config_version = self.workspace_vfs.current_vfs_config_version(),
+                        "stale VFS progress ignored"
+                    );
+                    return;
+                };
 
-                let state = if n_done == 0 {
+                if progress.n_total == 0 {
+                    return;
+                }
+
+                let state = if progress.n_done == 0 {
                     Progress::Begin
-                } else if n_done < n_total {
+                } else if progress.n_done < progress.n_total {
                     Progress::Report
                 } else {
-                    assert_eq!(n_done, n_total);
+                    assert_eq!(progress.n_done, progress.n_total);
                     Progress::End
                 };
 
                 self.report_progress(
                     self.config.i18n.text(keys::PROGRESS_ROOTS_SCANNING),
                     state,
-                    Some(format!("{n_done}/{n_total}")),
-                    Some(Progress::fraction(n_done, n_total)),
+                    Some(format!("{}/{}", progress.n_done, progress.n_total)),
+                    Some(Progress::fraction(progress.n_done, progress.n_total)),
                     None,
                 );
             }
             vfs_loader::Message::Loaded { files, config_version } => {
-                always!(config_version <= self.vfs_config_version);
-                if config_version < self.vfs_config_version {
+                always!(config_version <= self.workspace_vfs.current_vfs_config_version());
+                if !self.workspace_vfs.accepts_vfs_loaded(config_version) {
                     tracing::debug!(
                         config_version,
-                        current_config_version = self.vfs_config_version,
+                        current_config_version = self.workspace_vfs.current_vfs_config_version(),
                         files = files.len(),
                         "stale VFS loaded batch ignored"
                     );
@@ -930,6 +1275,12 @@ impl GlobalState {
 
         if self.config.cli_pull_diagnostics_support() && !force_push {
             tracing::info!("skipping push diagnostics for pull-capable client");
+            return;
+        }
+
+        if !self.workspace_vfs.is_ready() {
+            self.workspace_vfs.defer_diagnostics_until_ready();
+            tracing::debug!("diagnostics publish deferred until workspace/VFS is ready");
             return;
         }
 

--- a/src/global_state/process_changes.rs
+++ b/src/global_state/process_changes.rs
@@ -133,6 +133,15 @@ impl GlobalState {
     }
 
     pub(crate) fn invalidate_diagnostics(&mut self, invalidation: DiagnosticInvalidation) {
+        if !self.workspace_vfs.is_ready() {
+            self.workspace_vfs.defer_diagnostics_until_ready();
+            tracing::debug!(
+                ?invalidation,
+                "diagnostics invalidation deferred until workspace/VFS is ready"
+            );
+            return;
+        }
+
         if self.config.cli_pull_diagnostics_support()
             && self.config.cli_workspace_diagnostic_refresh_support()
             && match &invalidation {
@@ -305,6 +314,15 @@ impl GlobalState {
 
     pub(crate) fn request_diagnostics(&mut self, files: Vec<FileId>) {
         if files.is_empty() {
+            return;
+        }
+
+        if !self.workspace_vfs.is_ready() {
+            self.workspace_vfs.defer_diagnostics_until_ready();
+            tracing::debug!(
+                file_count = files.len(),
+                "diagnostics request deferred until workspace/VFS is ready"
+            );
             return;
         }
 

--- a/src/global_state/reload.rs
+++ b/src/global_state/reload.rs
@@ -10,7 +10,10 @@ use utils::{
 use super::main_loop::Task;
 use crate::{
     config::{Config, FilesWatcher},
-    global_state::{DEFAULT_REQ_HANDLER, GlobalState, process_changes::DiagnosticInvalidation},
+    global_state::{
+        DEFAULT_REQ_HANDLER, GlobalState, WorkspaceFetchCause, WorkspaceGeneration,
+        process_changes::DiagnosticInvalidation,
+    },
 };
 
 const CLIENT_FILE_WATCHER_REGISTRATION_ID: &str = "workspace/didChangeWatchedFiles";
@@ -18,9 +21,9 @@ const CLIENT_FILE_WATCHER_METHOD: &str = "workspace/didChangeWatchedFiles";
 
 #[derive(Debug)]
 pub(crate) enum FetchWorkspaceProgress {
-    Begin(String),
+    Begin { generation: WorkspaceGeneration, cause: String },
     // workspaces
-    End(Vec<Workspace>, Vec<anyhow::Error>),
+    End { generation: WorkspaceGeneration, workspaces: Vec<Workspace>, errors: Vec<anyhow::Error> },
 }
 
 impl From<FetchWorkspaceProgress> for Task {
@@ -30,20 +33,24 @@ impl From<FetchWorkspaceProgress> for Task {
 }
 
 impl GlobalState {
-    pub(crate) fn is_stuck(&self) -> bool {
-        !(self.fetch_workspaces_task.in_process()
-            || self.vfs_progress.config_version < self.vfs_config_version
-            || self.vfs_progress.in_progress())
+    pub(crate) fn is_workspace_ready(&self) -> bool {
+        self.workspace_vfs.is_ready()
     }
 
-    pub(crate) fn fetch_workspaces(&mut self, cause: String) {
-        tracing::info!(%cause, "will fetch workspaces");
+    pub(crate) fn fetch_workspaces(&mut self, request: WorkspaceFetchCause) {
+        self.workspace_vfs.start_workspace_fetch(request.generation);
+        tracing::info!(cause = %request.cause, generation = ?request.generation, "will fetch workspaces");
 
         self.task_pool.handle.spawn_and_send_cps(ThreadIntent::Worker, {
             let manifests = self.config.project_manifests.clone();
+            let generation = request.generation;
+            let cause = request.cause;
 
             move |sender| {
-                if sender.send(FetchWorkspaceProgress::Begin(cause.clone()).into()).is_err() {
+                if sender
+                    .send(FetchWorkspaceProgress::Begin { generation, cause: cause.clone() }.into())
+                    .is_err()
+                {
                     tracing::debug!("workspace fetch start dropped because main loop is gone");
                     return;
                 }
@@ -58,7 +65,14 @@ impl GlobalState {
                 }
 
                 if sender
-                    .send(FetchWorkspaceProgress::End(all_workspaces, error_sink).into())
+                    .send(
+                        FetchWorkspaceProgress::End {
+                            generation,
+                            workspaces: all_workspaces,
+                            errors: error_sink,
+                        }
+                        .into(),
+                    )
                     .is_err()
                 {
                     tracing::debug!("workspace fetch result dropped because main loop is gone");
@@ -68,7 +82,8 @@ impl GlobalState {
     }
 
     pub(crate) fn request_workspace_reload(&mut self, cause: impl Into<String>) {
-        self.fetch_workspaces_task.request(cause.into());
+        let request = self.workspace_vfs.request_workspace_reload(cause.into());
+        self.fetch_workspaces_task.request(request);
     }
 
     pub(crate) fn request_workspace_auto_reload(&mut self, cause: impl Into<String>) {
@@ -78,8 +93,8 @@ impl GlobalState {
     }
 
     pub(crate) fn start_requested_workspace_fetch(&mut self) {
-        if let Some(cause) = self.fetch_workspaces_task.should_start() {
-            self.fetch_workspaces(cause);
+        if let Some(request) = self.fetch_workspaces_task.should_start() {
+            self.fetch_workspaces(request);
         }
     }
 
@@ -94,8 +109,8 @@ impl GlobalState {
         }
     }
 
-    pub(crate) fn switch_workspaces(&mut self, cause: String) {
-        tracing::info!(%cause, "start switching workspaces");
+    pub(crate) fn switch_workspaces(&mut self, cause: String, generation: WorkspaceGeneration) {
+        tracing::info!(%cause, ?generation, "start switching workspaces");
 
         let Some((workspaces, errors)) = self.fetch_workspaces_task.last_op_result() else {
             return;
@@ -132,22 +147,14 @@ impl GlobalState {
             FilesWatcher::Server => to_watch,
         };
 
-        self.vfs_config_version += 1;
-        let vfs_config_version = self.vfs_config_version;
         let to_load_len = to_load.len();
+        let vfs_config_version = self.workspace_vfs.begin_vfs_load(to_load_len);
 
         self.vfs_loader.handle.set_config(vfs::loader::Config {
             to_load,
             to_watch,
             version: vfs_config_version,
         });
-        if to_load_len == 0 {
-            self.vfs_progress = crate::global_state::VfsProgress {
-                config_version: vfs_config_version,
-                n_done: 0,
-                n_total: 0,
-            };
-        }
 
         self.source_root_config = source_root_config;
 
@@ -537,13 +544,17 @@ mod tests {
         let existing_workspaces = Arc::clone(&state.workspaces);
 
         state.request_workspace_reload("test reload");
-        assert_eq!(state.fetch_workspaces_task.should_start().as_deref(), Some("test reload"));
+        let request = state.fetch_workspaces_task.should_start().unwrap();
+        assert_eq!(request.cause, "test reload");
+        state.workspace_vfs.start_workspace_fetch(request.generation);
+        assert_eq!(
+            state.workspace_vfs.finish_workspace_fetch(request.generation, true),
+            crate::global_state::WorkspaceFetchCompletion::CurrentFailure
+        );
         state.fetch_workspaces_task.complete(Some((
             Arc::new(Vec::new()),
             vec![anyhow::anyhow!("failed to reload workspace")],
         )));
-
-        state.switch_workspaces("failed reload".into());
 
         assert!(Arc::ptr_eq(&state.workspaces, &existing_workspaces));
     }
@@ -564,13 +575,17 @@ mod tests {
         assert!(state.workspaces.is_empty());
 
         state.request_workspace_reload("test reload");
-        assert_eq!(state.fetch_workspaces_task.should_start().as_deref(), Some("test reload"));
+        let request = state.fetch_workspaces_task.should_start().unwrap();
+        assert_eq!(request.cause, "test reload");
+        state.workspace_vfs.start_workspace_fetch(request.generation);
+        assert_eq!(
+            state.workspace_vfs.finish_workspace_fetch(request.generation, true),
+            crate::global_state::WorkspaceFetchCompletion::CurrentFailure
+        );
         state.fetch_workspaces_task.complete(Some((
             Arc::new(model.workspaces),
             vec![anyhow::anyhow!("failed to load dependency")],
         )));
-
-        state.switch_workspaces("partial reload".into());
 
         assert!(Arc::ptr_eq(&state.workspaces, &initial_workspaces));
         assert!(state.workspaces.is_empty());

--- a/src/global_state/workspace_state.rs
+++ b/src/global_state/workspace_state.rs
@@ -1,0 +1,182 @@
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct WorkspaceGeneration(u64);
+
+impl WorkspaceGeneration {
+    fn next(self) -> Self {
+        Self(self.0 + 1)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct WorkspaceFetchCause {
+    pub(crate) generation: WorkspaceGeneration,
+    pub(crate) cause: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum WorkspaceFetchCompletion {
+    CurrentSuccess,
+    CurrentFailure,
+    Stale { progress_started: bool },
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct VfsProgress {
+    pub(crate) config_version: u32,
+    pub(crate) n_done: usize,
+    pub(crate) n_total: usize,
+}
+
+impl VfsProgress {
+    pub(crate) fn in_progress(&self) -> bool {
+        self.n_done < self.n_total
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct WorkspaceVfsReadiness {
+    requested_workspace_generation: WorkspaceGeneration,
+    active_fetch_generation: Option<WorkspaceGeneration>,
+    fetch_progress_generation: Option<WorkspaceGeneration>,
+    committed_workspace_generation: WorkspaceGeneration,
+    vfs_config_version: u32,
+    vfs_progress: VfsProgress,
+    vfs_ready: bool,
+    diagnostic_readiness_revision: u64,
+    diagnostics_deferred_until_ready: bool,
+}
+
+impl Default for WorkspaceVfsReadiness {
+    fn default() -> Self {
+        Self {
+            requested_workspace_generation: WorkspaceGeneration::default(),
+            active_fetch_generation: None,
+            fetch_progress_generation: None,
+            committed_workspace_generation: WorkspaceGeneration::default(),
+            vfs_config_version: 0,
+            vfs_progress: VfsProgress::default(),
+            vfs_ready: true,
+            diagnostic_readiness_revision: 0,
+            diagnostics_deferred_until_ready: false,
+        }
+    }
+}
+
+impl WorkspaceVfsReadiness {
+    pub(crate) fn request_workspace_reload(&mut self, cause: String) -> WorkspaceFetchCause {
+        self.requested_workspace_generation = self.requested_workspace_generation.next();
+        self.diagnostic_readiness_revision += 1;
+        WorkspaceFetchCause { generation: self.requested_workspace_generation, cause }
+    }
+
+    pub(crate) fn start_workspace_fetch(&mut self, generation: WorkspaceGeneration) {
+        self.active_fetch_generation = Some(generation);
+    }
+
+    pub(crate) fn accept_workspace_fetch_begin(&mut self, generation: WorkspaceGeneration) -> bool {
+        let accepted = self.active_fetch_generation == Some(generation)
+            && self.requested_workspace_generation == generation;
+        if accepted {
+            self.fetch_progress_generation = Some(generation);
+        }
+        accepted
+    }
+
+    pub(crate) fn finish_workspace_fetch(
+        &mut self,
+        generation: WorkspaceGeneration,
+        has_errors: bool,
+    ) -> WorkspaceFetchCompletion {
+        if self.active_fetch_generation != Some(generation) {
+            return WorkspaceFetchCompletion::Stale {
+                progress_started: self.finish_fetch_progress(generation),
+            };
+        }
+
+        self.active_fetch_generation = None;
+        if self.requested_workspace_generation != generation {
+            return WorkspaceFetchCompletion::Stale {
+                progress_started: self.finish_fetch_progress(generation),
+            };
+        }
+
+        self.finish_fetch_progress(generation);
+        if has_errors {
+            self.requested_workspace_generation = self.committed_workspace_generation;
+            return WorkspaceFetchCompletion::CurrentFailure;
+        }
+
+        self.committed_workspace_generation = generation;
+        WorkspaceFetchCompletion::CurrentSuccess
+    }
+
+    fn finish_fetch_progress(&mut self, generation: WorkspaceGeneration) -> bool {
+        if self.fetch_progress_generation == Some(generation) {
+            self.fetch_progress_generation = None;
+            return true;
+        }
+        false
+    }
+
+    pub(crate) fn begin_vfs_load(&mut self, n_total: usize) -> u32 {
+        self.vfs_config_version += 1;
+        self.vfs_progress =
+            VfsProgress { config_version: self.vfs_config_version, n_done: 0, n_total };
+        self.vfs_ready = false;
+        self.vfs_config_version
+    }
+
+    pub(crate) fn accept_vfs_progress(
+        &mut self,
+        config_version: u32,
+        n_done: usize,
+        n_total: usize,
+    ) -> Option<VfsProgress> {
+        if config_version != self.vfs_config_version {
+            return None;
+        }
+        if n_done < self.vfs_progress.n_done {
+            return None;
+        }
+
+        self.vfs_progress = VfsProgress { config_version, n_done, n_total };
+        self.vfs_ready = !self.vfs_progress.in_progress();
+        Some(self.vfs_progress)
+    }
+
+    pub(crate) fn accepts_vfs_loaded(&self, config_version: u32) -> bool {
+        config_version == self.vfs_config_version
+    }
+
+    pub(crate) fn current_vfs_config_version(&self) -> u32 {
+        self.vfs_config_version
+    }
+
+    #[cfg(test)]
+    pub(crate) fn current_vfs_progress(&self) -> VfsProgress {
+        self.vfs_progress
+    }
+
+    pub(crate) fn is_ready(&self) -> bool {
+        self.active_fetch_generation.is_none()
+            && self.requested_workspace_generation == self.committed_workspace_generation
+            && self.vfs_progress.config_version == self.vfs_config_version
+            && self.vfs_ready
+    }
+
+    pub(crate) fn defer_diagnostics_until_ready(&mut self) {
+        self.diagnostics_deferred_until_ready = true;
+    }
+
+    pub(crate) fn take_deferred_diagnostics_if_ready(&mut self) -> bool {
+        if !self.is_ready() {
+            return false;
+        }
+
+        std::mem::take(&mut self.diagnostics_deferred_until_ready)
+    }
+
+    pub(crate) fn diagnostic_readiness_revision(&self) -> u64 {
+        self.diagnostic_readiness_revision
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2072,10 +2072,12 @@ fn restored_project_manifest_clears_diagnostics_for_excluded_files() {
 
     let first_report = request_workspace_diagnostic_report(&client, 1, Vec::new());
     let mut saw_ignored_diagnostic = false;
+    let mut ignored_result_id = None;
     for item in first_report.items {
         if let lsp_types::WorkspaceDocumentDiagnosticReport::Full(full) = item
             && full.uri == ignored_uri
         {
+            ignored_result_id = full.full_document_diagnostic_report.result_id.clone();
             saw_ignored_diagnostic = full
                 .full_document_diagnostic_report
                 .items
@@ -2084,6 +2086,8 @@ fn restored_project_manifest_clears_diagnostics_for_excluded_files() {
         }
     }
     assert!(saw_ignored_diagnostic, "root-scanning config should diagnose ignored.sv");
+    let ignored_result_id =
+        ignored_result_id.expect("ignored.sv should have a workspace diagnostic result id");
 
     fs::write(
         &manifest_path,
@@ -2109,7 +2113,10 @@ fn restored_project_manifest_clears_diagnostics_for_excluded_files() {
             WorkspaceDiagnosticRequest::METHOD.to_string(),
             WorkspaceDiagnosticParams {
                 identifier: None,
-                previous_result_ids: Vec::new(),
+                previous_result_ids: vec![lsp_types::PreviousResultId {
+                    uri: ignored_uri.clone(),
+                    value: ignored_result_id,
+                }],
                 work_done_progress_params: WorkDoneProgressParams::default(),
                 partial_result_params: Default::default(),
             },


### PR DESCRIPTION
This change centralizes workspace/VFS readiness tracking so stale workspace fetches, VFS progress, and loaded batches cannot update the active server state after a newer reload starts. It also defers diagnostics until the current workspace and VFS generation is ready, parks pull diagnostic requests during not-ready windows, and resumes them on readiness transitions instead of polling through retry tasks.

The notify loader now reconciles unloaded paths, acknowledges empty configs, and handles created/removed watched directories.
