### PR TITLE
fix(docs): make Pages base explicit

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,8 @@ jobs:
   build:
     name: Build Starlight
     runs-on: ubuntu-latest
+    env:
+      ASTRO_BASE: /vizsla
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,9 +1,11 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 
+const base = process.env.ASTRO_BASE ?? '/';
+
 export default defineConfig({
   site: 'https://pascal-lab.github.io',
-  base: '/vizsla',
+  base,
   integrations: [
     starlight({
       title: {


### PR DESCRIPTION
This change makes the Astro docs base path environment-driven instead of hard-coding the GitHub Pages subpath for every build. Local docs builds default to '/', while the Pages workflow explicitly sets ASTRO_BASE=/vizsla for the deployed site.