### PR TITLE
fix(ide): apply manifest predefines to navigation

### DIFF
--- a/crates/base-db/src/change.rs
+++ b/crates/base-db/src/change.rs
@@ -3,7 +3,7 @@ use triomphe::Arc;
 use vfs::ChangedFile;
 
 use crate::{
-    project::SharedProjectConfig,
+    project::{PreprocessConfig, SharedProjectConfig},
     source_db::SourceRootDb,
     source_root::{SourceRoot, SourceRootId},
 };
@@ -83,9 +83,33 @@ impl Change {
             db.set_file_text_with_durability(file_id, text, durability);
         }
 
+        update_file_preprocess_configs(db, files.as_ref());
+
         if files_changed {
             db.set_files_with_durability(files, Durability::HIGH);
         }
+    }
+}
+
+fn update_file_preprocess_configs(
+    db: &mut dyn SourceRootDb,
+    files: &rustc_hash::FxHashSet<vfs::FileId>,
+) {
+    let project_config = db.project_config();
+    for file_id in files.iter().copied() {
+        let source_root_id = db.source_root_id(file_id);
+        let source_root = db.source_root(source_root_id);
+        let profile_id = db.file_compilation_profile(file_id);
+        let preprocess = if source_root.is_ignored() {
+            PreprocessConfig::default()
+        } else {
+            project_config.preprocess_for_profile(profile_id)
+        };
+        db.set_file_preprocess_config_with_durability(
+            file_id,
+            Arc::new(preprocess),
+            durability(&source_root),
+        );
     }
 }
 

--- a/crates/base-db/src/source_db.rs
+++ b/crates/base-db/src/source_db.rs
@@ -11,7 +11,7 @@ use crate::{
     compilation_plan::{self, CompilationPlan},
     diagnostics_config::{DiagnosticSource, DiagnosticsConfig},
     preproc_index::{self, PreprocFileIndex},
-    project::{CompilationProfileId, ProjectConfig},
+    project::{CompilationProfileId, PreprocessConfig, ProjectConfig},
     source_root::{SourceRoot, SourceRootId},
 };
 
@@ -31,6 +31,9 @@ pub trait SourceDb: FileLoader + std::fmt::Debug {
 
     #[salsa::input]
     fn file_path(&self, file_id: FileId) -> Option<utils::paths::AbsPathBuf>;
+
+    #[salsa::input]
+    fn file_preprocess_config(&self, file_id: FileId) -> Arc<PreprocessConfig>;
 
     fn parse_src(&self, file_id: FileId) -> SyntaxTree;
     fn preproc_file_index(&self, file_id: FileId) -> Arc<PreprocFileIndex>;
@@ -93,8 +96,15 @@ fn parse_src(db: &dyn SourceDb, file_id: FileId) -> SyntaxTree {
 
     match db.file_kind(file_id) {
         SourceFileKind::SystemVerilog | SourceFileKind::IncludeHeader => {
-            // HIR source maps are local to the queried file; project-aware include
-            // expansion belongs to parse_src_for_compilation.
+            // HIR source maps are local to the queried file; project-aware
+            // include expansion belongs to parse_src_for_compilation.
+            let preprocess = db.file_preprocess_config(file_id);
+            let include_paths = preprocess.include_dir_strings();
+            let options = syntax::SyntaxTreeOptions {
+                predefines: preprocess.predefines.clone(),
+                include_paths,
+                ..syntax::SyntaxTreeOptions::without_include_expansion()
+            };
             let _span = tracing::info_span!(
                 "slang.syntax_tree.from_text",
                 ?file_id,
@@ -102,12 +112,7 @@ fn parse_src(db: &dyn SourceDb, file_id: FileId) -> SyntaxTree {
                 include_buffer_count = 0usize
             )
             .entered();
-            SyntaxTree::from_text_with_options(
-                &text,
-                "",
-                "",
-                &syntax::SyntaxTreeOptions::without_include_expansion(),
-            )
+            SyntaxTree::from_text_with_options(&text, "", "", &options)
         }
         SourceFileKind::LibraryMap => SyntaxTree::from_library_map_text(&text, "", ""),
         SourceFileKind::ProjectManifest => SyntaxTree::from_text("", "", ""),
@@ -115,7 +120,8 @@ fn parse_src(db: &dyn SourceDb, file_id: FileId) -> SyntaxTree {
 }
 
 fn preproc_file_index(db: &dyn SourceDb, file_id: FileId) -> Arc<PreprocFileIndex> {
-    preproc_file_index_with_predefines(db, file_id, Vec::new())
+    let predefines = db.file_preprocess_config(file_id).predefines.clone();
+    preproc_file_index_with_predefines(db, file_id, predefines)
 }
 
 fn preproc_file_index_with_predefines(

--- a/crates/ide/src/verilog_2005.rs
+++ b/crates/ide/src/verilog_2005.rs
@@ -4,7 +4,13 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use base_db::{change::Change, source_db::SourceDb, source_root::SourceRoot};
+use base_db::{
+    change::Change,
+    preproc_index::MacroIncludeTarget,
+    project::{CompilationProfile, CompilationProfileId, PreprocessConfig, ProjectConfig},
+    source_db::SourceDb,
+    source_root::{SourceRoot, SourceRootId},
+};
 use hir::semantics::Semantics;
 use ide_db::root_db::RootDb;
 use insta::assert_snapshot;
@@ -169,6 +175,53 @@ fn setup_marked_with_path(
     }
 
     let (host, file_id) = setup_with_path(&text, path);
+    (host, file_id, text, markers)
+}
+
+fn setup_marked_with_predefines(
+    text: &str,
+    predefines: Vec<String>,
+) -> (AnalysisHost, FileId, String, HashMap<String, TextSize>) {
+    let mut text = normalize_fixture_text(text);
+    let mut markers = HashMap::new();
+    let mut cursor = 0;
+    let prefix = "/*marker:";
+
+    while let Some(rel_start) = text[cursor..].find(prefix) {
+        let start = cursor + rel_start;
+        let name_start = start + prefix.len();
+        let Some(rel_end) = text[name_start..].find("*/") else {
+            panic!("unterminated marker in fixture");
+        };
+        let name_end = name_start + rel_end;
+        let name = text[name_start..name_end].to_string();
+        let end = name_end + 2;
+        text.replace_range(start..end, "");
+        markers.insert(name, TextSize::from(start as u32));
+        cursor = start;
+    }
+
+    let file_id = FileId(0);
+    let mut file_set = FileSet::default();
+    file_set.insert(file_id, VfsPath::new_virtual_path("/feature.v".to_owned()));
+
+    let mut change = Change::new();
+    change.set_roots(vec![SourceRoot::new_local(file_set)]);
+    change.set_project_config(Arc::new(ProjectConfig::new(
+        vec![Some(CompilationProfileId(0))],
+        vec![CompilationProfile {
+            source_roots: vec![SourceRootId(0)],
+            top_modules: Vec::new(),
+            preprocess: PreprocessConfig { predefines, include_dirs: Vec::new() },
+        }],
+    )));
+    change.add_changed_file(ChangedFile {
+        file_id,
+        change_kind: ChangeKind::Create(Arc::from(text.as_str()), LineEnding::Unix),
+    });
+
+    let mut host = AnalysisHost::default();
+    host.apply_change(change);
     (host, file_id, text, markers)
 }
 
@@ -453,6 +506,95 @@ endmodule
 
     let task_body = labels("task_body");
     assert!(task_body.iter().any(|label| label == "case"), "{task_body:?}");
+}
+
+#[test]
+fn manifest_predefines_select_ide_ifdef_branch_for_navigation() {
+    let text = r#"
+module manifest_define_ctx;
+`ifdef USE_IMPL
+  logic /*marker:active_def*/branch_sig;
+  assign /*marker:active_ref*/branch_sig = 1'b1;
+`else
+  logic /*marker:inactive_def*/branch_sig;
+  assign /*marker:inactive_ref*/branch_sig = 1'b0;
+`endif
+  assign /*marker:query_ref*/branch_sig = 1'b1;
+endmodule
+"#;
+    let (host, file_id, _clean_text, markers) =
+        setup_marked_with_predefines(text, vec!["USE_IMPL=1".to_owned()]);
+    let analysis = host.make_analysis();
+    let branch_sig_len = TextSize::from("branch_sig".len() as u32);
+    let active_def = TextRange::new(markers["active_def"], markers["active_def"] + branch_sig_len);
+    let inactive_def =
+        TextRange::new(markers["inactive_def"], markers["inactive_def"] + branch_sig_len);
+    let active_ref = TextRange::new(markers["active_ref"], markers["active_ref"] + branch_sig_len);
+    let inactive_ref =
+        TextRange::new(markers["inactive_ref"], markers["inactive_ref"] + branch_sig_len);
+    let query_ref = TextRange::new(markers["query_ref"], markers["query_ref"] + branch_sig_len);
+
+    let nav = analysis
+        .goto_definition(position(file_id, &markers, "query_ref"))
+        .unwrap()
+        .expect("branch_sig definition expected");
+    assert!(
+        nav.info.iter().any(|nav| nav.focus_range == Some(active_def)),
+        "goto should resolve to the manifest-defined active branch: {nav:?}"
+    );
+    assert!(
+        nav.info.iter().all(|nav| nav.focus_range != Some(inactive_def)),
+        "goto must not resolve to the inactive branch: {nav:?}"
+    );
+
+    let refs = analysis
+        .references(
+            position(file_id, &markers, "query_ref"),
+            ReferencesConfig::new(
+                ScopeVisibility::Private,
+                Some(SearchScope::single_file(file_id)),
+            ),
+        )
+        .unwrap()
+        .expect("branch_sig references expected");
+    let ranges = refs
+        .iter()
+        .flat_map(|refs| refs.refs.get(&file_id).into_iter().flatten())
+        .map(|(range, _)| *range)
+        .collect::<Vec<_>>();
+    assert!(ranges.contains(&active_ref), "active reference should be found: {ranges:?}");
+    assert!(ranges.contains(&query_ref), "query reference should be found: {ranges:?}");
+    assert!(
+        !ranges.contains(&inactive_ref),
+        "inactive reference should not be classified as the active definition: {ranges:?}"
+    );
+}
+
+#[test]
+fn manifest_predefines_feed_default_preproc_file_index() {
+    let text = r#"
+`ifdef USE_IMPL
+`include "active.svh"
+`else
+`include "inactive.svh"
+`endif
+module manifest_preproc_index_ctx;
+endmodule
+"#;
+    let (host, file_id, _clean_text, _markers) =
+        setup_marked_with_predefines(text, vec!["USE_IMPL=1".to_owned()]);
+
+    let index = host.raw_db().preproc_file_index(file_id);
+    let literal_include_paths = index
+        .includes
+        .iter()
+        .filter_map(|include| match &include.target {
+            MacroIncludeTarget::Literal { path, .. } => Some(path.as_str()),
+            MacroIncludeTarget::Token { .. } => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(literal_include_paths, vec!["active.svh"]);
 }
 
 #[test]


### PR DESCRIPTION
Manifest `defines` already fed compilation diagnostics and include discovery, but editor features that rely on the ordinary parse path still used an empty preprocessor configuration. This change stores the resolved preprocess config per file when project state is applied, then uses it for both IDE parsing and the default preprocessor index so `ifdef`-selected branches, goto definition, and reference search share the same manifest macro state. Validation: `cargo fmt --all -- --check`; `cargo check -p ide`; `cargo test -p ide manifest_predefines -- --nocapture`; `cargo test -p base-db preprocessor_index_honors_predefined_conditional_includes -- --nocapture`; `cargo test -p ide parsed_file_nodes_survive_parse_lru_eviction -- --nocapture`; `git diff --check`.