### PR TITLE
fix(ide): mark inactive macro branches as unused

### DIFF
--- a/crates/base-db/src/preproc_index.rs
+++ b/crates/base-db/src/preproc_index.rs
@@ -13,6 +13,7 @@ pub struct PreprocFileIndex {
     pub includes: Vec<MacroInclude>,
     pub conditionals: Vec<MacroConditional>,
     pub usages: Vec<MacroUsage>,
+    pub inactive_ranges: Vec<TextRange>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -118,6 +119,11 @@ fn range_to_text_range(range: std::ops::Range<usize>) -> Option<TextRange> {
 }
 
 fn collect_preprocessor_directive(index: &mut PreprocFileIndex, directive: PreprocessorDirective) {
+    index.inactive_ranges.extend(directive.disabled_ranges.iter().filter_map(|range| {
+        let range = range_to_text_range(range.clone())?;
+        (!range.is_empty()).then_some(range)
+    }));
+
     let kind = directive.kind;
     match kind {
         SyntaxKind::DEFINE_DIRECTIVE => {
@@ -418,6 +424,31 @@ endmodule
                 path: SmolStr::new("a.svh"),
                 raw: SmolStr::new("\"a.svh\"")
             }
+        );
+    }
+
+    #[test]
+    fn records_inactive_preprocessor_branch_ranges() {
+        let text = r#"`ifdef USE_A
+logic active;
+`else
+logic inactive;
+`endif
+"#;
+
+        let without_define = index_with_predefines(text, Vec::new());
+        let with_define = index_with_predefines(text, vec!["USE_A=1".to_owned()]);
+
+        let inactive_range = without_define.inactive_ranges[0];
+        assert_eq!(
+            &text[usize::from(inactive_range.start())..usize::from(inactive_range.end())],
+            "logic active;"
+        );
+
+        let inactive_range = with_define.inactive_ranges[0];
+        assert_eq!(
+            &text[usize::from(inactive_range.start())..usize::from(inactive_range.end())],
+            "logic inactive;"
         );
     }
 }

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -17,8 +17,11 @@ use crate::module_resolution::{ModuleResolution, ModuleResolutionAmbiguity, reso
 
 const AMBIGUOUS_MODULE_INSTANTIATION: VizslaDiagnosticDescriptor =
     VizslaDiagnosticDescriptor { code: 1, subsystem: 0, name: "ambiguous-module-instantiation" };
+const INACTIVE_PREPROCESSOR_BRANCH: VizslaDiagnosticDescriptor =
+    VizslaDiagnosticDescriptor { code: 2, subsystem: 0, name: "inactive-preprocessor-branch" };
 pub const DIAGNOSTIC_AMBIGUOUS_MODULE_STRICT: &str = "diagnostic.ambiguous_module.strict";
 pub const DIAGNOSTIC_AMBIGUOUS_MODULE_BEST_EFFORT: &str = "diagnostic.ambiguous_module.best_effort";
+pub const DIAGNOSTIC_INACTIVE_PREPROCESSOR_BRANCH: &str = "diagnostic.inactive_preprocessor_branch";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DiagnosticSource {
@@ -41,6 +44,12 @@ pub struct Diagnostic {
     pub message: String,
     pub message_key: Option<&'static str>,
     pub message_args: Vec<(&'static str, String)>,
+    pub tags: Vec<DiagnosticTag>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticTag {
+    Unnecessary,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -48,6 +57,12 @@ struct VizslaDiagnosticDescriptor {
     code: u16,
     subsystem: u16,
     name: &'static str,
+}
+
+#[derive(Debug, Clone, Default)]
+struct VizslaDiagnosticMetadata {
+    message_args: Vec<(&'static str, String)>,
+    tags: Vec<DiagnosticTag>,
 }
 
 impl VizslaDiagnosticDescriptor {
@@ -59,6 +74,44 @@ impl VizslaDiagnosticDescriptor {
         message: String,
         message_key: &'static str,
         message_args: Vec<(&'static str, String)>,
+    ) -> Diagnostic {
+        self.diagnostic_with_metadata(
+            file_id,
+            range,
+            severity,
+            message,
+            message_key,
+            VizslaDiagnosticMetadata { message_args, tags: Vec::new() },
+        )
+    }
+
+    fn diagnostic_with_tags(
+        self,
+        file_id: FileId,
+        range: TextRange,
+        severity: DiagnosticSeverity,
+        message: String,
+        message_key: &'static str,
+        tags: Vec<DiagnosticTag>,
+    ) -> Diagnostic {
+        self.diagnostic_with_metadata(
+            file_id,
+            range,
+            severity,
+            message,
+            message_key,
+            VizslaDiagnosticMetadata { message_args: Vec::new(), tags },
+        )
+    }
+
+    fn diagnostic_with_metadata(
+        self,
+        file_id: FileId,
+        range: TextRange,
+        severity: DiagnosticSeverity,
+        message: String,
+        message_key: &'static str,
+        metadata: VizslaDiagnosticMetadata,
     ) -> Diagnostic {
         Diagnostic {
             file_id,
@@ -72,7 +125,8 @@ impl VizslaDiagnosticDescriptor {
             severity,
             message,
             message_key: Some(message_key),
-            message_args,
+            message_args: metadata.message_args,
+            tags: metadata.tags,
         }
     }
 }
@@ -95,23 +149,37 @@ pub(crate) fn compilation_profile_diagnostics(
     db: &RootDb,
     profile_id: CompilationProfileId,
 ) -> Vec<Diagnostic> {
-    db.compilation_profile_diagnostics(profile_id)
+    let mut diagnostics = db
+        .compilation_profile_diagnostics(profile_id)
         .iter()
         .map(|diag| slang_diagnostic(diag.file_id, diag.source, &diag.diagnostic))
-        .collect()
+        .collect::<Vec<_>>();
+
+    diagnostics.extend(
+        compilation_profile_file_ids(db, profile_id)
+            .into_iter()
+            .flat_map(|file_id| inactive_preprocessor_branch_diagnostics(db, file_id)),
+    );
+    diagnostics
 }
 
 pub(crate) fn compilation_profile_syntax_diagnostics(
     db: &RootDb,
     profile_id: CompilationProfileId,
 ) -> Vec<Diagnostic> {
+    compilation_profile_file_ids(db, profile_id)
+        .into_iter()
+        .flat_map(|file_id| syntax_diagnostics(db, file_id))
+        .collect()
+}
+
+fn compilation_profile_file_ids(db: &RootDb, profile_id: CompilationProfileId) -> Vec<FileId> {
     let plan = db.compilation_plan_for_profile(Some(profile_id));
     let mut file_ids = plan.roots.clone();
     file_ids.extend(plan.include_only.iter().copied());
     file_ids.sort_unstable_by_key(|file_id| file_id.0);
     file_ids.dedup();
-
-    file_ids.into_iter().flat_map(|file_id| syntax_diagnostics(db, file_id)).collect()
+    file_ids
 }
 
 fn syntax_diagnostics(db: &RootDb, file_id: FileId) -> Vec<Diagnostic> {
@@ -141,6 +209,7 @@ fn slang_diagnostic(
         message: diag.message.clone(),
         message_key: None,
         message_args: Vec::new(),
+        tags: Vec::new(),
     }
 }
 
@@ -157,7 +226,7 @@ pub(crate) fn diagnostics(db: &RootDb, file_id: FileId) -> Vec<Diagnostic> {
     }
 
     let mut diagnostics = if slang_semantic_diagnostics_active(db, file_id) {
-        Vec::new()
+        inactive_preprocessor_branch_diagnostics(db, file_id)
     } else {
         syntax_diagnostics(db, file_id)
     };
@@ -184,6 +253,11 @@ pub(crate) fn source_root_diagnostics(db: &RootDb, file_id: FileId) -> Vec<Diagn
 
     if slang_semantic_diagnostics_active(db, file_id) {
         diagnostics.extend(compilation_diagnostics(db, file_id));
+        diagnostics.extend(
+            source_root
+                .iter()
+                .flat_map(|file_id| inactive_preprocessor_branch_diagnostics(db, file_id)),
+        );
     } else {
         for file_id in source_root.iter() {
             diagnostics.extend(syntax_diagnostics(db, file_id));
@@ -214,11 +288,21 @@ pub(crate) fn source_root_role(db: &RootDb, file_id: FileId) -> SourceRootRole {
 }
 
 fn vizsla_diagnostics(db: &RootDb, file_id: FileId) -> Vec<Diagnostic> {
-    if slang_semantic_diagnostics_active(db, file_id) {
+    if !vizsla_diagnostics_enabled(db) {
         return Vec::new();
     }
 
-    module_instantiation_resolution_diagnostics(db, file_id)
+    let mut diagnostics = inactive_preprocessor_branch_diagnostics(db, file_id);
+
+    if !slang_semantic_diagnostics_active(db, file_id) {
+        diagnostics.extend(module_instantiation_resolution_diagnostics(db, file_id));
+    }
+
+    diagnostics
+}
+
+fn vizsla_diagnostics_enabled(db: &RootDb) -> bool {
+    db.diagnostics_config().enabled
 }
 
 fn slang_semantic_diagnostics_active(db: &RootDb, file_id: FileId) -> bool {
@@ -273,6 +357,28 @@ fn module_instantiation_resolution_diagnostics(db: &RootDb, file_id: FileId) -> 
     diagnostics
 }
 
+fn inactive_preprocessor_branch_diagnostics(db: &RootDb, file_id: FileId) -> Vec<Diagnostic> {
+    if !vizsla_diagnostics_enabled(db) {
+        return Vec::new();
+    }
+
+    db.preproc_file_index(file_id)
+        .inactive_ranges
+        .iter()
+        .copied()
+        .map(|range| {
+            INACTIVE_PREPROCESSOR_BRANCH.diagnostic_with_tags(
+                file_id,
+                range,
+                DiagnosticSeverity::Note,
+                "code is inactive due to preprocessor conditionals".to_owned(),
+                DIAGNOSTIC_INACTIVE_PREPROCESSOR_BRANCH,
+                vec![DiagnosticTag::Unnecessary],
+            )
+        })
+        .collect()
+}
+
 fn ambiguous_module_instantiation_diagnostic(
     module_name: &str,
     candidate_count: usize,
@@ -324,8 +430,10 @@ fn to_text_range(diag: &SyntaxDiagnostic) -> TextRange {
 mod tests {
     use base_db::{
         change::Change,
+        diagnostics_config::DiagnosticsConfig,
         project::{CompilationProfile, CompilationProfileId, PreprocessConfig, ProjectConfig},
-        source_db::SourceRootDb,
+        salsa::Durability,
+        source_db::{SourceDb, SourceRootDb},
         source_root::{SourceRoot, SourceRootId, SourceRootRole},
     };
     use ide_db::root_db::RootDb;
@@ -334,11 +442,19 @@ mod tests {
     use vfs::{ChangeKind, ChangedFile, FileId, FileSet, VfsPath};
 
     use super::{
-        AMBIGUOUS_MODULE_INSTANTIATION, DiagnosticSource, diagnostics, source_root_diagnostics,
+        AMBIGUOUS_MODULE_INSTANTIATION, DIAGNOSTIC_INACTIVE_PREPROCESSOR_BRANCH, DiagnosticSource,
+        DiagnosticTag, INACTIVE_PREPROCESSOR_BRANCH, diagnostics, source_root_diagnostics,
     };
 
     fn db_with_files(files: &[(&str, &str)], configured: bool) -> RootDb {
         db_with_files_in_role(files, SourceRootRole::Local, configured)
+    }
+
+    fn disable_diagnostics(db: &mut RootDb) {
+        db.set_diagnostics_config_with_durability(
+            Arc::new(DiagnosticsConfig { enabled: false, ..DiagnosticsConfig::default() }),
+            Durability::HIGH,
+        );
     }
 
     fn db_with_files_in_role(
@@ -460,6 +576,40 @@ mod tests {
         assert!(
             diagnostics.iter().all(|diag| diag.source != DiagnosticSource::Vizsla),
             "vizsla ambiguity warning should not duplicate active slang semantic diagnostics: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn inactive_preprocessor_branch_reports_unnecessary_hint() {
+        let db = db_with_files(
+            &[("/top.sv", "`ifdef USE_IMPL\nlogic active;\n`else\nlogic inactive;\n`endif\n")],
+            false,
+        );
+
+        let diagnostics = diagnostics(&db, FileId(0));
+        let inactive = diagnostics
+            .iter()
+            .find(|diag| diag.name == INACTIVE_PREPROCESSOR_BRANCH.name)
+            .expect("expected inactive preprocessor branch diagnostic");
+
+        assert_eq!(inactive.severity, syntax::DiagnosticSeverity::Note);
+        assert_eq!(inactive.tags, vec![DiagnosticTag::Unnecessary]);
+        assert_eq!(inactive.message_key, Some(DIAGNOSTIC_INACTIVE_PREPROCESSOR_BRANCH));
+    }
+
+    #[test]
+    fn inactive_preprocessor_branch_respects_global_diagnostics_switch() {
+        let mut db = db_with_files(
+            &[("/top.sv", "`ifdef USE_IMPL\nlogic active;\n`else\nlogic inactive;\n`endif\n")],
+            false,
+        );
+        disable_diagnostics(&mut db);
+
+        let diagnostics = diagnostics(&db, FileId(0));
+
+        assert!(
+            diagnostics.is_empty(),
+            "global diagnostics switch must suppress Vizsla inactive diagnostics: {diagnostics:?}"
         );
     }
 

--- a/crates/slang/bindings/rust/ffi.rs
+++ b/crates/slang/bindings/rust/ffi.rs
@@ -83,6 +83,13 @@ mod slang_ffi {
     }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
+    struct RawTextRange {
+        range_start: usize,
+        range_end: usize,
+        has_range: bool,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
     struct RawPreprocessorMacroParam {
         name: RawPreprocessorToken,
         default_tokens: Vec<RawPreprocessorToken>,
@@ -104,6 +111,7 @@ mod slang_ffi {
         params: Vec<RawPreprocessorMacroParam>,
         body_tokens: Vec<RawPreprocessorToken>,
         expr_tokens: Vec<RawPreprocessorToken>,
+        disabled_ranges: Vec<RawTextRange>,
     }
 
     #[namespace = "slang"]

--- a/crates/slang/bindings/rust/ffi/wrapper.cc
+++ b/crates/slang/bindings/rust/ffi/wrapper.cc
@@ -124,6 +124,12 @@ void set_rust_range(size_t& start, size_t& end, bool& hasRange, slang::SourceRan
   hasRange = true;
 }
 
+::RawTextRange to_rust_text_range(slang::SourceRange range) {
+  ::RawTextRange result;
+  set_rust_range(result.range_start, result.range_end, result.has_range, range);
+  return result;
+}
+
 ::RawPreprocessorToken empty_preprocessor_token() {
   ::RawPreprocessorToken token;
   token.raw_text = rust::String();
@@ -144,6 +150,30 @@ void set_rust_range(size_t& start, size_t& end, bool& hasRange, slang::SourceRan
   result.value_text = rust::String(std::string(token.valueText()));
   set_rust_range(result.range_start, result.range_end, result.has_range, token.range());
   result.has_token = true;
+  return result;
+}
+
+template<typename TTokens>
+rust::Vec<::RawTextRange> to_rust_disabled_ranges(const TTokens& tokens) {
+  rust::Vec<::RawTextRange> result;
+  std::optional<::RawTextRange> merged;
+
+  for (auto token : tokens) {
+    auto range = to_rust_text_range(token.range());
+    if (!range.has_range)
+      continue;
+
+    if (!merged) {
+      merged = range;
+      continue;
+    }
+
+    merged->range_start = std::min(merged->range_start, range.range_start);
+    merged->range_end = std::max(merged->range_end, range.range_end);
+  }
+
+  if (merged && merged->range_start < merged->range_end)
+    result.emplace_back(*merged);
   return result;
 }
 
@@ -190,6 +220,7 @@ void collect_leaf_tokens(const slang::syntax::SyntaxNode& node,
   directive.params = rust::Vec<::RawPreprocessorMacroParam>();
   directive.body_tokens = rust::Vec<::RawPreprocessorToken>();
   directive.expr_tokens = rust::Vec<::RawPreprocessorToken>();
+  directive.disabled_ranges = rust::Vec<::RawTextRange>();
   set_rust_range(directive.range_start, directive.range_end, directive.has_range,
                  syntax.sourceRange());
 
@@ -222,6 +253,13 @@ void collect_leaf_tokens(const slang::syntax::SyntaxNode& node,
     case slang::syntax::SyntaxKind::ElsIfDirective: {
       const auto& branch = syntax.as<slang::syntax::ConditionalBranchDirectiveSyntax>();
       collect_leaf_tokens(*branch.expr, directive.expr_tokens);
+      directive.disabled_ranges = to_rust_disabled_ranges(branch.disabledTokens);
+      break;
+    }
+    case slang::syntax::SyntaxKind::ElseDirective:
+    case slang::syntax::SyntaxKind::EndIfDirective: {
+      const auto& branch = syntax.as<slang::syntax::UnconditionalBranchDirectiveSyntax>();
+      directive.disabled_ranges = to_rust_disabled_ranges(branch.disabledTokens);
       break;
     }
     case slang::syntax::SyntaxKind::MacroUsage: {

--- a/crates/slang/bindings/rust/ffi/wrapper.h
+++ b/crates/slang/bindings/rust/ffi/wrapper.h
@@ -37,6 +37,7 @@ struct RawSyntaxTreeBufferIds;
 struct RawExpectedSyntax;
 struct RawLexedTokenAtOffset;
 struct RawPreprocessorDirective;
+struct RawTextRange;
 
 namespace wrapper {
   using Diagnostic = ::slang::Diagnostic;

--- a/crates/slang/bindings/rust/lib.rs
+++ b/crates/slang/bindings/rust/lib.rs
@@ -254,6 +254,7 @@ pub struct PreprocessorDirective {
     pub params: Vec<PreprocessorMacroParam>,
     pub body_tokens: Vec<PreprocessorDirectiveToken>,
     pub expr_tokens: Vec<PreprocessorDirectiveToken>,
+    pub disabled_ranges: Vec<Range<usize>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -318,6 +319,11 @@ impl PreprocessorDirective {
                 .expr_tokens
                 .into_iter()
                 .filter_map(PreprocessorDirectiveToken::from_raw)
+                .collect(),
+            disabled_ranges: raw
+                .disabled_ranges
+                .into_iter()
+                .filter_map(|range| range.has_range.then_some(range.range_start..range.range_end))
                 .collect(),
         }
     }

--- a/src/global_state/handlers/request/code_action.rs
+++ b/src/global_state/handlers/request/code_action.rs
@@ -289,6 +289,7 @@ mod tests {
             message: "localized message".to_owned(),
             message_key: None,
             message_args: Vec::new(),
+            tags: Vec::new(),
         }
     }
 
@@ -359,6 +360,7 @@ mod tests {
             message: "mixing ordered and named port connections is not allowed".to_owned(),
             message_key: None,
             message_args: Vec::new(),
+            tags: Vec::new(),
         };
 
         assert_eq!(
@@ -382,6 +384,7 @@ mod tests {
             message: "localized message".to_owned(),
             message_key: None,
             message_args: Vec::new(),
+            tags: Vec::new(),
         };
 
         let diagnostics = code_action_diagnostics_from_ide(&[diag]);

--- a/src/global_state/snapshot.rs
+++ b/src/global_state/snapshot.rs
@@ -128,13 +128,7 @@ impl GlobalStateSnapshot {
             return Ok(Vec::new());
         }
 
-        let diagnostics = if self.config.diagnostics_config().semantic.enabled {
-            self.analysis.diagnostics(file_id)?
-        } else {
-            self.analysis.parse_diagnostics(file_id)?
-        };
-
-        Ok(diagnostics)
+        self.analysis.diagnostics(file_id)
     }
 
     pub(crate) fn lsp_diagnostics(

--- a/src/i18n/en.toml
+++ b/src/i18n/en.toml
@@ -29,6 +29,9 @@ unknown = "unknown executeCommand: {command}"
 invalid_value_one = "invalid config value:\n{errors}"
 invalid_value_many = "invalid config values:\n{errors}"
 
+[diagnostic]
+inactive_preprocessor_branch = "code is inactive due to preprocessor conditionals"
+
 [diagnostic.ambiguous_module]
 strict = "module instantiation '{module_name}' matches {candidate_count} module definitions; cannot determine which one to use"
 best_effort = "module instantiation '{module_name}' matches {candidate_count} module definitions; cannot determine which one to use"

--- a/src/i18n/zh-CN.toml
+++ b/src/i18n/zh-CN.toml
@@ -29,6 +29,9 @@ unknown = "未知 executeCommand：{command}"
 invalid_value_one = "配置项无效：\n{errors}"
 invalid_value_many = "配置项无效：\n{errors}"
 
+[diagnostic]
+inactive_preprocessor_branch = "代码因预处理条件未激活"
+
 [diagnostic.ambiguous_module]
 strict = "模块实例化 '{module_name}' 找到 {candidate_count} 个同名模块定义，无法确定应使用哪一个"
 best_effort = "模块实例化 '{module_name}' 找到 {candidate_count} 个同名模块定义，无法确定应使用哪一个"

--- a/src/lsp_ext/to_proto.rs
+++ b/src/lsp_ext/to_proto.rs
@@ -136,6 +136,7 @@ pub(crate) fn diagnostic(
 ) -> lsp_types::Diagnostic {
     let data = diagnostic_data(&diag);
     let message = diagnostic_message(i18n, &diag);
+    let tags = diagnostic_tags(&diag);
     lsp_types::Diagnostic {
         range: self::range(line_info, diag.range),
         severity: diagnostic_severity(diag.severity),
@@ -151,7 +152,7 @@ pub(crate) fn diagnostic(
         ),
         message,
         related_information: None,
-        tags: None,
+        tags,
         data: Some(data),
     }
 }
@@ -210,6 +211,18 @@ fn diagnostic_severity(severity: SlangDiagnosticSeverity) -> Option<lsp_types::D
         SlangDiagnosticSeverity::Warning => Some(LspSeverity::WARNING),
         SlangDiagnosticSeverity::Error | SlangDiagnosticSeverity::Fatal => Some(LspSeverity::ERROR),
     }
+}
+
+fn diagnostic_tags(diag: &ide_diagnostics::Diagnostic) -> Option<Vec<lsp_types::DiagnosticTag>> {
+    let tags = diag
+        .tags
+        .iter()
+        .map(|tag| match tag {
+            ide_diagnostics::DiagnosticTag::Unnecessary => lsp_types::DiagnosticTag::UNNECESSARY,
+        })
+        .collect::<Vec<_>>();
+
+    (!tags.is_empty()).then_some(tags)
 }
 
 fn symbol_kind(symbol_kind: SymbolKind) -> lsp_types::SymbolKind {
@@ -892,4 +905,49 @@ fn code_action_title_key(id: &str, label: &str) -> Option<&'static str> {
         },
         _ => return None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use ide::diagnostics::{
+        Diagnostic as IdeDiagnostic, DiagnosticSource as IdeDiagnosticSource, DiagnosticTag,
+    };
+    use syntax::DiagnosticSeverity;
+    use triomphe::Arc;
+    use utils::{
+        line_index::{LineIndex, TextRange, TextSize},
+        lines::{LineEnding, LineInfo, PositionEncoding},
+    };
+    use vfs::FileId;
+
+    use super::diagnostic;
+    use crate::i18n::{I18n, Locale};
+
+    #[test]
+    fn diagnostic_maps_unnecessary_tag() {
+        let line_info = LineInfo {
+            index: Arc::new(LineIndex::new("logic inactive;\n")),
+            ending: LineEnding::Unix,
+            encoding: PositionEncoding::Utf8,
+        };
+        let diag = IdeDiagnostic {
+            file_id: FileId(0),
+            code: 2,
+            subsystem: 0,
+            name: "inactive-preprocessor-branch".to_owned(),
+            option_name: None,
+            groups: Vec::new(),
+            source: IdeDiagnosticSource::Vizsla,
+            range: TextRange::new(TextSize::from(0), TextSize::from(14)),
+            severity: DiagnosticSeverity::Note,
+            message: "inactive".to_owned(),
+            message_key: None,
+            message_args: Vec::new(),
+            tags: vec![DiagnosticTag::Unnecessary],
+        };
+
+        let lsp_diag = diagnostic(I18n::new(Locale::En), &line_info, diag);
+
+        assert_eq!(lsp_diag.tags, Some(vec![lsp_types::DiagnosticTag::UNNECESSARY]));
+    }
 }


### PR DESCRIPTION
This change surfaces slang preprocessor disabled branch ranges as a base-db preprocessor index fact, reports them as Vizsla diagnostics tagged `Unnecessary`, and maps that tag to LSP `DiagnosticTag::UNNECESSARY` so VS Code fades inactive macro branches even when semantic analysis cannot see them. It also keeps the diagnostic under the existing diagnostics enable switch and routes syntax-only document diagnostics through the same IDE diagnostics path so document and workspace reports stay consistent. Validation: `cargo fmt --all -- --check`; `cargo clippy --workspace --all-targets -- -D warnings`; `rustup run nightly cargo test --workspace`.