### PR TITLE
chore(release): prepare 0.1.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vizsla"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 authors = ["roifewu <roifewu@gmail.com>"]
 repository = "https://github.com/pascal-lab/vizsla"

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -65,7 +65,14 @@ export default defineConfig({
         {
           label: '更新日志',
           translations: { en: 'Changelog' },
-          items: ['changelog', 'changelog/v0-1-4', 'changelog/v0-1-3', 'changelog/v0-1-2', 'changelog/v0-1-1'],
+          items: [
+            'changelog',
+            'changelog/v0-1-5',
+            'changelog/v0-1-4',
+            'changelog/v0-1-3',
+            'changelog/v0-1-2',
+            'changelog/v0-1-1',
+          ],
         },
       ],
     }),

--- a/docs/src/content/docs/changelog/index.mdx
+++ b/docs/src/content/docs/changelog/index.mdx
@@ -11,9 +11,9 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard
-    title="v0.1.4"
-    href="./v0-1-4/"
-    description="包含 Qihe 配置与 Windows 修复、诊断 profiling、LSP 性能优化、连接解析修复和语法高亮改进。"
+    title="v0.1.5"
+    href="./v0-1-5/"
+    description="包含诊断交付稳定性、项目配置与宏处理修复、Qihe legacy manifest 支持、端口提示目标和文档更新。"
   />
 </CardGrid>
 
@@ -23,3 +23,4 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 - [v0.1.2](./v0-1-2/)
 - [v0.1.3](./v0-1-3/)
 - [v0.1.4](./v0-1-4/)
+- [v0.1.5](./v0-1-5/)

--- a/docs/src/content/docs/changelog/v0-1-5.md
+++ b/docs/src/content/docs/changelog/v0-1-5.md
@@ -1,0 +1,31 @@
+---
+title: v0.1.5
+description: Vizsla v0.1.5 发布说明。
+---
+
+## 诊断与工作区稳定性
+
+- 诊断结果 ID 现在只会在真实诊断输入变化时更新，避免配置刷新但诊断内容未变时重复推送完整结果。（[#126](https://github.com/pascal-lab/vizsla/pull/126)）
+- 文件加载、路径别名和工作区就绪状态的处理更稳定。Vizsla 现在会忽略过期的文件加载批次，统一真实路径与别名路径的文件身份，并在工作区准备好之前暂停诊断请求，减少打开工程或文件变化时的陈旧诊断。（[#127](https://github.com/pascal-lab/vizsla/pull/127), [#129](https://github.com/pascal-lab/vizsla/pull/129), [#131](https://github.com/pascal-lab/vizsla/pull/131)）
+- workspace diagnostics 现在按诊断所有者组织，跨 source root、open URI alias 和 pull/publish diagnostics 场景的诊断投递更一致。（[#132](https://github.com/pascal-lab/vizsla/pull/132)）
+- VS Code 启动时会把初始配置传给语言服务器，结构性配置变化也会触发工作区重新加载，减少配置修改后仍沿用旧项目模型的问题。（[#120](https://github.com/pascal-lab/vizsla/pull/120), [#121](https://github.com/pascal-lab/vizsla/pull/121)）
+- 后台任务调度会优先处理延迟敏感的交互请求，降低大型工作区后台任务对编辑操作的影响。（[#125](https://github.com/pascal-lab/vizsla/pull/125)）
+
+## 编辑体验
+
+- 端口 inlay hints 现在可以指向对应端口定义，便于从实例化连接跳转到模块端口。（[#134](https://github.com/pascal-lab/vizsla/pull/134)）
+- 命名端口语义 token 的范围更准确，避免只高亮连接表达式或遗漏端口名。（[#130](https://github.com/pascal-lab/vizsla/pull/130)）
+- Verilog declaration list 的语法高亮更完整，改善 `.v` / `.vh` 文件中声明列表的颜色显示。（[#119](https://github.com/pascal-lab/vizsla/pull/119)）
+
+## 项目配置、Qihe 与宏
+
+- Qihe 项目分析现在会使用已解析的 legacy manifest，`vizsla_config.toml` 项目可以走与 `vizsla.toml` 一致的项目分析路径。（[#143](https://github.com/pascal-lab/vizsla/pull/143)）
+- manifest 中的预定义宏现在会进入共享的 IDE 解析和预处理状态，跳转定义、引用查找等普通 IDE 功能可以看到 manifest macro 配置。（[#142](https://github.com/pascal-lab/vizsla/pull/142)）
+- 因预处理条件未激活的代码现在会作为 VS Code unused hint 淡化显示。该提示保留诊断元数据，但在编辑器中以 hint 呈现，避免额外的信息级蓝色波浪线。（[#144](https://github.com/pascal-lab/vizsla/pull/144), [#145](https://github.com/pascal-lab/vizsla/pull/145)）
+
+## 文档、构建与发布
+
+- 文档新增 Vizsla Playground，并更新用户指南，使安装、配置、命令、状态栏和 Qihe 说明与当前扩展行为保持一致。（[#135](https://github.com/pascal-lab/vizsla/pull/135), [#141](https://github.com/pascal-lab/vizsla/pull/141)）
+- GitHub Pages 文档构建现在显式处理 base path，避免部署环境和本地构建的路径差异。（[#140](https://github.com/pascal-lab/vizsla/pull/140)）
+- 本地 release metadata 默认值和语言服务器版本对齐逻辑已整理，减少 release 构建与扩展版本不一致的风险。（[#122](https://github.com/pascal-lab/vizsla/pull/122), [#123](https://github.com/pascal-lab/vizsla/pull/123)）
+- 发布 Rust 语言服务器 `0.1.5` 与 VS Code 扩展 `0.1.5`。

--- a/docs/src/content/docs/en/changelog/index.mdx
+++ b/docs/src/content/docs/en/changelog/index.mdx
@@ -11,9 +11,9 @@ This section records user-visible changes for each official release. Add the cor
 
 <CardGrid>
   <LinkCard
-    title="v0.1.4"
-    href="./v0-1-4/"
-    description="Includes Qihe configuration and Windows fixes, diagnostics profiling, LSP performance improvements, connection-resolution fixes, and grammar updates."
+    title="v0.1.5"
+    href="./v0-1-5/"
+    description="Includes diagnostics delivery stability, project configuration and macro fixes, legacy manifest support for Qihe, port hint targets, and documentation updates."
   />
 </CardGrid>
 
@@ -23,3 +23,4 @@ This section records user-visible changes for each official release. Add the cor
 - [v0.1.2](./v0-1-2/)
 - [v0.1.3](./v0-1-3/)
 - [v0.1.4](./v0-1-4/)
+- [v0.1.5](./v0-1-5/)

--- a/docs/src/content/docs/en/changelog/v0-1-5.md
+++ b/docs/src/content/docs/en/changelog/v0-1-5.md
@@ -1,0 +1,31 @@
+---
+title: v0.1.5
+description: Vizsla v0.1.5 release notes.
+---
+
+## Diagnostics and Workspace Stability
+
+- Diagnostic result IDs now change only when the actual diagnostic inputs change, avoiding full result re-sends after configuration refreshes that do not affect diagnostics. ([#126](https://github.com/pascal-lab/vizsla/pull/126))
+- File loading, path aliases, and workspace readiness are more stable. Vizsla now ignores stale loaded-file batches, unifies real and alias path identities, and parks diagnostic requests until the workspace is ready, reducing stale diagnostics during project startup and file changes. ([#127](https://github.com/pascal-lab/vizsla/pull/127), [#129](https://github.com/pascal-lab/vizsla/pull/129), [#131](https://github.com/pascal-lab/vizsla/pull/131))
+- Workspace diagnostics are now organized by diagnostic owner, making delivery more consistent across source roots, open URI aliases, and pull/publish diagnostics modes. ([#132](https://github.com/pascal-lab/vizsla/pull/132))
+- VS Code now sends the initial configuration to the language server during startup, and structural configuration changes trigger a workspace reload so the project model does not keep stale settings. ([#120](https://github.com/pascal-lab/vizsla/pull/120), [#121](https://github.com/pascal-lab/vizsla/pull/121))
+- Background scheduling now prioritizes latency-sensitive interactive requests, reducing the impact of large workspace background work on editor actions. ([#125](https://github.com/pascal-lab/vizsla/pull/125))
+
+## Editing Experience
+
+- Port inlay hints can now target their corresponding port definitions, making it easier to navigate from instantiation connections back to module ports. ([#134](https://github.com/pascal-lab/vizsla/pull/134))
+- Named port semantic token ranges are more accurate, avoiding highlights that skip the port name or cover only the connection expression. ([#130](https://github.com/pascal-lab/vizsla/pull/130))
+- Verilog declaration-list highlighting is more complete for `.v` and `.vh` files. ([#119](https://github.com/pascal-lab/vizsla/pull/119))
+
+## Project Configuration, Qihe, and Macros
+
+- Qihe project analysis now uses resolved legacy manifests, so `vizsla_config.toml` projects can follow the same project-analysis path as `vizsla.toml` projects. ([#143](https://github.com/pascal-lab/vizsla/pull/143))
+- Manifest predefines now flow into the shared IDE parse and preprocess state, so goto definition, references, and other regular IDE features can see manifest macro configuration. ([#142](https://github.com/pascal-lab/vizsla/pull/142))
+- Code disabled by preprocessor conditionals is now faded as a VS Code unused hint. The hint keeps diagnostic metadata but is presented as a hint in the editor to avoid extra information-level blue squiggles. ([#144](https://github.com/pascal-lab/vizsla/pull/144), [#145](https://github.com/pascal-lab/vizsla/pull/145))
+
+## Documentation, Build, and Release
+
+- The docs now include Vizsla Playground and refreshed user-guide pages that match the current extension behavior for installation, configuration, commands, status UI, and Qihe usage. ([#135](https://github.com/pascal-lab/vizsla/pull/135), [#141](https://github.com/pascal-lab/vizsla/pull/141))
+- The GitHub Pages docs build now handles the base path explicitly, avoiding path differences between local builds and deployment. ([#140](https://github.com/pascal-lab/vizsla/pull/140))
+- Local release metadata defaults and language-server version alignment were cleaned up to reduce the risk of release builds diverging from the extension version. ([#122](https://github.com/pascal-lab/vizsla/pull/122), [#123](https://github.com/pascal-lab/vizsla/pull/123))
+- Released Rust language server `0.1.5` and VS Code extension `0.1.5`.

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vizsla-lsp",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vizsla-lsp",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vizsla-lsp",
   "displayName": "Vizsla",
   "description": "%extension.description%",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "publisher": "vizsla",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Prepare the 0.1.5 release by bumping the Rust language server and VS Code extension versions to 0.1.5, adding the v0.1.5 changelog pages in both Chinese and English, and wiring the new changelog entry into the docs navigation and index.

Validation already run locally: `cargo fmt --all -- --check`; `git diff --check`; `npm ci` in `editors/vscode` and `docs`; `npm test` in `editors/vscode`; `npm run build` in `docs`; `cargo clippy --workspace --all-targets -- -D warnings`.