### PR TITLE
test: tolerate project status during shutdown

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -39,7 +39,7 @@ use crate::{
     },
     global_state::main_loop,
     i18n::{I18n, Locale},
-    lsp_ext::to_proto,
+    lsp_ext::{ext::ProjectStatusNotification, to_proto},
 };
 
 type TempDir = TestDir;
@@ -263,6 +263,8 @@ fn shutdown_test_server(
                 if notification.method == lsp_types::notification::Progress::METHOD => {}
             Message::Notification(notification)
                 if notification.method == lsp_types::notification::PublishDiagnostics::METHOD => {}
+            Message::Notification(notification)
+                if notification.method == ProjectStatusNotification::METHOD => {}
             other => panic!("unexpected message while shutting down test server: {other:?}"),
         }
     }


### PR DESCRIPTION
## Summary
- Allow the LSP shutdown test helper to drain `vide/projectStatus` notifications while waiting for the shutdown response.
- Keep server behavior unchanged; this only treats project-status updates like the existing progress and diagnostics notifications in the test harness.

## Validation
- `cargo fmt --check`
- `cargo test -p vide clearing_open_document_updates_analysis_state -- --nocapture`
- `cargo test -p vide --lib`