### PR TITLE
Test WASM CI cache behavior

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,39 @@
+name: Setup pinned Rust
+description: Install the Rust toolchain pinned by rust-toolchain.toml.
+
+inputs:
+  components:
+    description: Comma-separated Rust components to install.
+    required: false
+    default: ""
+  targets:
+    description: Comma-separated Rust targets to install.
+    required: false
+    default: ""
+
+outputs:
+  toolchain:
+    description: Rust toolchain channel installed by this action.
+    value: ${{ steps.toolchain.outputs.toolchain }}
+
+runs:
+  using: composite
+  steps:
+    - name: Read pinned toolchain
+      id: toolchain
+      shell: bash
+      run: |
+        set -euo pipefail
+        toolchain="$(sed -n 's/^channel = "\(.*\)"/\1/p' "${GITHUB_WORKSPACE}/rust-toolchain.toml")"
+        if [ -z "${toolchain}" ]; then
+          echo "rust-toolchain.toml does not define a toolchain channel." >&2
+          exit 1
+        fi
+        echo "toolchain=${toolchain}" >> "${GITHUB_OUTPUT}"
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ steps.toolchain.outputs.toolchain }}
+        components: ${{ inputs.components }}
+        targets: ${{ inputs.targets }}

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -1,0 +1,26 @@
+name: Setup sccache
+description: Configure sccache for Rust and optional CMake builds.
+
+inputs:
+  cmake-launcher:
+    description: Also let crates that drive CMake use sccache as the C/C++ compiler launcher.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.10
+
+    - name: Configure sccache
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "SCCACHE_GHA_ENABLED=true" >> "${GITHUB_ENV}"
+        echo "SCCACHE_BASEDIRS=${GITHUB_WORKSPACE}" >> "${GITHUB_ENV}"
+        echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
+        echo "CARGO_INCREMENTAL=0" >> "${GITHUB_ENV}"
+        if [ "${{ inputs.cmake-launcher }}" = "true" ]; then
+          echo "VIDE_USE_SCCACHE_CMAKE=1" >> "${GITHUB_ENV}"
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
+        uses: ./.github/actions/setup-rust
         with:
           components: clippy, rustfmt
+      - name: Setup sccache
+        uses: ./.github/actions/setup-sccache
+        with:
+          cmake-launcher: "true"
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         continue-on-error: true
         with:
-          shared-key: rust-${{ runner.os }}-nightly
+          shared-key: rust-${{ runner.os }}
+          key: workspace-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**', 'crates/**', 'xtask/**') }}
           cache-workspace-crates: true
           cache-on-failure: true
       - name: Format Check
@@ -57,18 +62,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
+        uses: ./.github/actions/setup-rust
         with:
           components: rustfmt
+      - name: Setup sccache
+        uses: ./.github/actions/setup-sccache
+        with:
+          cmake-launcher: "true"
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         continue-on-error: true
         with:
-          shared-key: rust-${{ runner.os }}-nightly
+          shared-key: rust-${{ runner.os }}
+          key: workspace-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**', 'crates/**', 'xtask/**') }}
           cache-workspace-crates: true
           cache-on-failure: true
       - name: Test
-        run: rustup run nightly cargo test --workspace
+        run: cargo test --workspace
 
   vscode-extension:
     name: VS Code Checks
@@ -112,14 +122,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
+        uses: ./.github/actions/setup-rust
         with:
           components: rustfmt
+      - name: Setup sccache
+        uses: ./.github/actions/setup-sccache
+        with:
+          cmake-launcher: "true"
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         continue-on-error: true
         with:
-          shared-key: rust-${{ runner.os }}-nightly
+          shared-key: rust-${{ runner.os }}
+          key: package-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**', 'crates/**', 'editors/vscode/scripts/**') }}
           cache-workspace-crates: true
           cache-on-failure: true
       - name: Setup Node
@@ -159,8 +174,10 @@ jobs:
         include:
           - target: alpine-x64
             image: ghcr.io/blackdex/rust-musl:x86_64-musl-nightly
+            rust-target: x86_64-unknown-linux-musl
           - target: alpine-arm64
             image: ghcr.io/blackdex/rust-musl:aarch64-musl-nightly
+            rust-target: aarch64-unknown-linux-musl
     defaults:
       run:
         working-directory: editors/vscode
@@ -171,16 +188,32 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends ca-certificates cmake git python3
 
-      - name: Install Rust components
-        working-directory: .
-        run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt
-
       - uses: actions/checkout@v4
 
       - name: Trust checkout directories
         working-directory: .
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Install Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          components: rustfmt
+          targets: ${{ matrix.rust-target }}
+
+      - name: Setup sccache
+        uses: ./.github/actions/setup-sccache
+        with:
+          cmake-launcher: "true"
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        continue-on-error: true
+        with:
+          shared-key: rust-${{ runner.os }}-${{ matrix.target }}
+          key: package-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**', 'crates/**', 'editors/vscode/scripts/**') }}
+          cache-workspace-crates: true
+          cache-on-failure: true
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,23 @@ name: CI
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - "docs/**"
+      - "playground/**"
+      - "crates/vide-lsp-wasm/**"
+      - ".github/actions/setup-emscripten/**"
+      - ".github/workflows/docs-preview.yml"
+      - ".github/workflows/deploy-docs.yml"
   pull_request:
     types: [opened, synchronize, reopened]
     branches: ["**"]
+    paths-ignore:
+      - "docs/**"
+      - "playground/**"
+      - "crates/vide-lsp-wasm/**"
+      - ".github/actions/setup-emscripten/**"
+      - ".github/workflows/docs-preview.yml"
+      - ".github/workflows/deploy-docs.yml"
   workflow_dispatch:
 
 concurrency:
@@ -18,8 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - name: Install Rust
         uses: dtolnay/rust-toolchain@nightly
         with:
@@ -28,6 +40,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         continue-on-error: true
         with:
+          shared-key: rust-${{ runner.os }}-nightly
           cache-workspace-crates: true
           cache-on-failure: true
       - name: Format Check
@@ -43,8 +56,6 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - name: Install Rust
         uses: dtolnay/rust-toolchain@nightly
         with:
@@ -53,6 +64,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         continue-on-error: true
         with:
+          shared-key: rust-${{ runner.os }}-nightly
           cache-workspace-crates: true
           cache-on-failure: true
       - name: Test
@@ -66,18 +78,6 @@ jobs:
         working-directory: editors/vscode
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
-        continue-on-error: true
-        with:
-          cache-workspace-crates: true
-          cache-on-failure: true
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -111,8 +111,6 @@ jobs:
         working-directory: editors/vscode
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - name: Install Rust
         uses: dtolnay/rust-toolchain@nightly
         with:
@@ -121,6 +119,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         continue-on-error: true
         with:
+          shared-key: rust-${{ runner.os }}-nightly
           cache-workspace-crates: true
           cache-on-failure: true
       - name: Setup Node
@@ -177,14 +176,11 @@ jobs:
         run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt
 
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Trust checkout directories
         working-directory: .
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git config --global --add safe.directory "$GITHUB_WORKSPACE/crates/slang"
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -253,20 +253,44 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Restore playground WASM cache
+        id: playground-wasm-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: playground/public/wasm
+          key: playground-wasm-${{ runner.os }}-${{ env.EMSDK_VERSION }}-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**', 'crates/**', 'playground/scripts/build-vide-wasm.mjs', 'playground/scripts/script-utils.mjs', '.github/actions/setup-emscripten/**', '.github/actions/setup-rust/**') }}
+
+      - name: Verify cached playground WASM
+        if: steps.playground-wasm-cache.outputs.cache-hit == 'true'
+        run: |
+          test -s playground/public/wasm/vide-lsp.js
+          test -s playground/public/wasm/vide-core.js
+          test -s playground/public/wasm/vide-core.wasm
+
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
+        if: steps.playground-wasm-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/setup-rust
         with:
           components: rustfmt
 
+      - name: Setup sccache
+        if: steps.playground-wasm-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/setup-sccache
+        with:
+          cmake-launcher: "true"
+
       - name: Rust Cache
+        if: steps.playground-wasm-cache.outputs.cache-hit != 'true'
         uses: Swatinem/rust-cache@v2
         continue-on-error: true
         with:
           shared-key: docs-wasm-${{ runner.os }}-${{ env.EMSDK_VERSION }}
+          key: wasm-src-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**', 'crates/**', 'playground/scripts/build-vide-wasm.mjs', 'playground/scripts/script-utils.mjs', '.github/actions/setup-emscripten/**', '.github/actions/setup-rust/**') }}
           cache-workspace-crates: true
           cache-on-failure: true
 
       - name: Install Emscripten SDK
+        if: steps.playground-wasm-cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-emscripten
         with:
           version: ${{ env.EMSDK_VERSION }}
@@ -285,10 +309,19 @@ jobs:
         working-directory: playground
 
       - name: Build playground WASM
+        if: steps.playground-wasm-cache.outputs.cache-hit != 'true'
         run: |
           source "${EMSDK}/emsdk_env.sh"
           npm run build:wasm
         working-directory: playground
+
+      - name: Save playground WASM cache
+        if: steps.playground-wasm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        continue-on-error: true
+        with:
+          path: playground/public/wasm
+          key: ${{ steps.playground-wasm-cache.outputs.cache-primary-key }}
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -252,8 +252,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -71,8 +71,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -6,8 +6,14 @@ on:
     paths:
       - "docs/**"
       - "playground/**"
-      - "crates/vide-lsp-wasm/**"
+      - "src/**"
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
       - ".github/actions/setup-emscripten/**"
+      - ".github/actions/setup-rust/**"
+      - ".github/actions/setup-sccache/**"
       - ".github/workflows/docs-preview.yml"
       - ".github/workflows/deploy-docs.yml"
   pull_request:
@@ -15,8 +21,14 @@ on:
     paths:
       - "docs/**"
       - "playground/**"
-      - "crates/vide-lsp-wasm/**"
+      - "src/**"
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
       - ".github/actions/setup-emscripten/**"
+      - ".github/actions/setup-rust/**"
+      - ".github/actions/setup-sccache/**"
       - ".github/workflows/docs-preview.yml"
       - ".github/workflows/deploy-docs.yml"
 
@@ -72,20 +84,44 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Restore playground WASM cache
+        id: playground-wasm-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: playground/public/wasm
+          key: playground-wasm-${{ runner.os }}-${{ env.EMSDK_VERSION }}-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**', 'crates/**', 'playground/scripts/build-vide-wasm.mjs', 'playground/scripts/script-utils.mjs', '.github/actions/setup-emscripten/**', '.github/actions/setup-rust/**') }}
+
+      - name: Verify cached playground WASM
+        if: steps.playground-wasm-cache.outputs.cache-hit == 'true'
+        run: |
+          test -s playground/public/wasm/vide-lsp.js
+          test -s playground/public/wasm/vide-core.js
+          test -s playground/public/wasm/vide-core.wasm
+
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
+        if: steps.playground-wasm-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/setup-rust
         with:
           components: rustfmt
 
+      - name: Setup sccache
+        if: steps.playground-wasm-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/setup-sccache
+        with:
+          cmake-launcher: "true"
+
       - name: Rust Cache
+        if: steps.playground-wasm-cache.outputs.cache-hit != 'true'
         uses: Swatinem/rust-cache@v2
         continue-on-error: true
         with:
           shared-key: docs-wasm-${{ runner.os }}-${{ env.EMSDK_VERSION }}
+          key: wasm-src-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**', 'crates/**', 'playground/scripts/build-vide-wasm.mjs', 'playground/scripts/script-utils.mjs', '.github/actions/setup-emscripten/**', '.github/actions/setup-rust/**') }}
           cache-workspace-crates: true
           cache-on-failure: true
 
       - name: Install Emscripten SDK
+        if: steps.playground-wasm-cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-emscripten
         with:
           version: ${{ env.EMSDK_VERSION }}
@@ -104,10 +140,19 @@ jobs:
         working-directory: playground
 
       - name: Build playground WASM
+        if: steps.playground-wasm-cache.outputs.cache-hit != 'true'
         run: |
           source "${EMSDK}/emsdk_env.sh"
           npm run build:wasm
         working-directory: playground
+
+      - name: Save playground WASM cache
+        if: steps.playground-wasm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        continue-on-error: true
+        with:
+          path: playground/public/wasm
+          key: ${{ steps.playground-wasm-cache.outputs.cache-primary-key }}
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@nightly
@@ -84,6 +82,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         continue-on-error: true
         with:
+          shared-key: rust-${{ runner.os }}-nightly
           cache-workspace-crates: true
           cache-on-failure: true
 
@@ -139,13 +138,10 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Trust checkout directories
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git config --global --add safe.directory "$GITHUB_WORKSPACE/crates/slang"
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,15 +74,21 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@nightly
+        uses: ./.github/actions/setup-rust
         with:
           components: rustfmt
+
+      - name: Setup sccache
+        uses: ./.github/actions/setup-sccache
+        with:
+          cmake-launcher: "true"
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         continue-on-error: true
         with:
-          shared-key: rust-${{ runner.os }}-nightly
+          shared-key: rust-${{ runner.os }}
+          key: package-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**', 'crates/**', 'editors/vscode/scripts/**') }}
           cache-workspace-crates: true
           cache-on-failure: true
 
@@ -125,16 +131,15 @@ jobs:
         include:
           - target: alpine-x64
             image: ghcr.io/blackdex/rust-musl:x86_64-musl-nightly
+            rust-target: x86_64-unknown-linux-musl
           - target: alpine-arm64
             image: ghcr.io/blackdex/rust-musl:aarch64-musl-nightly
+            rust-target: aarch64-unknown-linux-musl
     steps:
       - name: Install build dependencies
         run: |
           apt-get update
           apt-get install -y --no-install-recommends ca-certificates cmake git python3
-
-      - name: Install Rust components
-        run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -142,6 +147,26 @@ jobs:
       - name: Trust checkout directories
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          components: rustfmt
+          targets: ${{ matrix.rust-target }}
+
+      - name: Setup sccache
+        uses: ./.github/actions/setup-sccache
+        with:
+          cmake-launcher: "true"
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        continue-on-error: true
+        with:
+          shared-key: rust-${{ runner.os }}-${{ matrix.target }}
+          key: package-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**', 'crates/**', 'editors/vscode/scripts/**') }}
+          cache-workspace-crates: true
+          cache-on-failure: true
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "qihe"]
-	path = qihe
-	url = git@github.com:pascal-lab/qihe.git

--- a/crates/slang/bindings/rust/build.rs
+++ b/crates/slang/bindings/rust/build.rs
@@ -58,6 +58,13 @@ fn build_cpp_lib(cxxbridge_dir: &Path, debug: bool) -> PathBuf {
         }
     }
 
+    if let Some(sccache) = cmake_sccache_launcher() {
+        let launcher = sccache.to_string_lossy();
+        config
+            .define("CMAKE_C_COMPILER_LAUNCHER", launcher.as_ref())
+            .define("CMAKE_CXX_COMPILER_LAUNCHER", launcher.as_ref());
+    }
+
     if !emscripten && !debug && cfg!(target_env = "msvc") {
         // cmake-rs still sets config-specific MSVC flags for Visual Studio
         // generators to preserve /MD or /MT. That replaces CMake's built-in
@@ -71,6 +78,12 @@ fn build_cpp_lib(cxxbridge_dir: &Path, debug: bool) -> PathBuf {
     }
 
     config.build()
+}
+
+fn cmake_sccache_launcher() -> Option<PathBuf> {
+    env::var_os("VIDE_USE_SCCACHE_CMAKE")?;
+
+    env::var_os("SCCACHE_PATH").map(PathBuf::from).or_else(|| which::which("sccache").ok())
 }
 
 fn setup_linking(install_dir: &Path, debug: bool) {

--- a/playground/scripts/build-vide-wasm.mjs
+++ b/playground/scripts/build-vide-wasm.mjs
@@ -18,7 +18,7 @@ if (!buildEnv.EM_CONFIG && existsSync(emConfig)) {
   buildEnv.EM_CONFIG = emConfig;
 }
 
-run("rustup", ["target", "add", "--toolchain", "nightly", "wasm32-unknown-emscripten"], { env: buildEnv });
+run("rustup", ["target", "add", "wasm32-unknown-emscripten"], { env: buildEnv });
 run("ninja", ["--version"], { env: buildEnv });
 
 const linkArgs = [
@@ -43,7 +43,7 @@ Object.assign(buildEnv, {
 });
 
 const crateManifest = resolve(workspaceRoot, "crates", "vide-lsp-wasm", "Cargo.toml");
-run("rustup", ["run", "nightly", "cargo", "build", "--manifest-path", crateManifest, "--target", "wasm32-unknown-emscripten", "--release"], {
+run("cargo", ["build", "--manifest-path", crateManifest, "--target", "wasm32-unknown-emscripten", "--release"], {
   env: buildEnv,
 });
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,4 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2026-05-24"
+components = ["clippy", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
Temporary draft PR to exercise GitHub Actions caching for docs WASM builds.\n\nTest plan:\n- Let the first Build docs run populate the playground WASM cache.\n- Rerun the same Build docs workflow.\n- Confirm the rerun restores playground/public/wasm and skips Rust/Emscripten/WASM build steps.