### PR TITLE
fix: scope VideLab language clients

### DIFF
--- a/playground/src/lab/lsp-client.ts
+++ b/playground/src/lab/lsp-client.ts
@@ -93,10 +93,7 @@ export class VideBrowserClient {
 
   private clientOptions(): LanguageClientOptions {
     return {
-      documentSelector: [
-        { scheme: "file", language: "systemverilog" },
-        { scheme: "file", language: "verilog" },
-      ],
+      documentSelector: this.documentSelector(),
       workspaceFolder: {
         index: 0,
         name: "workspace",
@@ -124,6 +121,16 @@ export class VideBrowserClient {
         },
       },
     };
+  }
+
+  private documentSelector(): NonNullable<LanguageClientOptions["documentSelector"]> {
+    const rootPath = vscode.Uri.parse(this.rootUri).path.replace(/\/+$/, "");
+    const pattern = rootPath ? `${rootPath}/**` : undefined;
+
+    return [
+      { scheme: "file", language: "systemverilog", pattern },
+      { scheme: "file", language: "verilog", pattern },
+    ];
   }
 
   private handleMessage(message: WorkerResponse): void {


### PR DESCRIPTION
﻿## Summary

- Limit each browser language client to its own virtual VideLab workspace URI.
- Prevent multiple embedded labs on the same page from all responding to the same Verilog/SystemVerilog document.

## Why

The online experience page can load several VideLab editors at once. Each editor starts its own language client, but the previous document selector matched every `file://` Verilog/SystemVerilog document in the page. As more examples loaded, inlay hints could be duplicated and definition navigation could be handled by the wrong client.

## Validation

- `npm --prefix playground run build` passed in the source worktree before this PR was split out.
