### PR TITLE
fix: load matching VideLab locale bundle

### DIFF
--- a/docs/src/components/VideLab.astro
+++ b/docs/src/components/VideLab.astro
@@ -145,9 +145,55 @@ const mountedFocusEditor = initialFocusEditor ?? focusEditor;
     document.head.append(link);
   }
 
-  async function ensureVideLab(assetBase) {
+  function localeBundleName(locale) {
+    const normalized = locale?.trim().toLowerCase();
+    return normalized === "zh-cn" ? "locale-zh-hans.es.js" : "";
+  }
+
+  function ensureMonacoLocale(assetBase, locale) {
+    const bundleName = localeBundleName(locale);
+    if (!bundleName) {
+      return Promise.resolve();
+    }
+
+    const src = `${assetBase}${bundleName}`;
+    const existing = document.querySelector(`script[data-vide-lab-locale="${bundleName}"]`);
+    if (existing) {
+      if (existing.dataset.loaded === "true") {
+        return Promise.resolve();
+      }
+      return new Promise((resolve, reject) => {
+        existing.addEventListener("load", resolve, { once: true });
+        existing.addEventListener("error", () => reject(new Error(`Could not load Monaco locale bundle '${bundleName}'.`)), {
+          once: true,
+        });
+      });
+    }
+
+    return new Promise((resolve, reject) => {
+      const script = document.createElement("script");
+      script.type = "module";
+      script.src = src;
+      script.dataset.videLabLocale = bundleName;
+      script.addEventListener(
+        "load",
+        () => {
+          script.dataset.loaded = "true";
+          resolve();
+        },
+        { once: true },
+      );
+      script.addEventListener("error", () => reject(new Error(`Could not load Monaco locale bundle '${bundleName}'.`)), {
+        once: true,
+      });
+      document.head.append(script);
+    });
+  }
+
+  async function ensureVideLab(assetBase, locale) {
     ensureVideLabStyles(assetBase);
     if (!customElements.get("vide-lab")) {
+      await ensureMonacoLocale(assetBase, locale);
       await import(`${assetBase}vide-lab.es.js`);
     }
     await customElements.whenDefined("vide-lab");
@@ -167,7 +213,7 @@ const mountedFocusEditor = initialFocusEditor ?? focusEditor;
 
     try {
       const assetBase = root.dataset.assetBase;
-      await ensureVideLab(assetBase);
+      await ensureVideLab(assetBase, root.dataset.locale);
 
       const lab = document.createElement("vide-lab");
       if (root.dataset.mode !== "app") {

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@codingame/monaco-vscode-api": "33.0.9",
         "@codingame/monaco-vscode-editor-api": "33.0.9",
+        "@codingame/monaco-vscode-language-pack-zh-hans": "33.0.9",
         "astro": "^6.3.7",
         "lit": "^3.3.3",
         "lucide": "^1.16.0",
@@ -326,6 +327,15 @@
       "version": "33.0.9",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-33.0.9.tgz",
       "integrity": "sha512-DkDzv6ijQU1udBhA4LB4OIMpPPoP3ktXCD7JWgwIwHifeIQzlgRMvzgKcMtWz/H4sSZYNHlBuJMgchmfLFTLig==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "33.0.9"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-language-pack-zh-hans": {
+      "version": "33.0.9",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-zh-hans/-/monaco-vscode-language-pack-zh-hans-33.0.9.tgz",
+      "integrity": "sha512-tcZfUpp7MXMA1or32kvJRa4hw+M/uyv0A13If3HmrjWJ+88eWlqw/SL+XNK/9wjrOK7OMEO/DaWDSi8zwMXvtQ==",
       "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "33.0.9"

--- a/playground/package.json
+++ b/playground/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@codingame/monaco-vscode-api": "33.0.9",
     "@codingame/monaco-vscode-editor-api": "33.0.9",
+    "@codingame/monaco-vscode-language-pack-zh-hans": "33.0.9",
     "astro": "^6.3.7",
     "lit": "^3.3.3",
     "lucide": "^1.16.0",

--- a/playground/scripts/copy-docs-assets.mjs
+++ b/playground/scripts/copy-docs-assets.mjs
@@ -7,7 +7,7 @@ const embedSource = resolve(repoRoot, "dist", "embed");
 const wasmSource = resolve(repoRoot, "public", "wasm");
 const wasmTarget = resolve(docsAssetRoot, "wasm");
 
-const requiredEmbedFiles = ["vide-lab.es.js", "vide-playground.css"];
+const requiredEmbedFiles = ["vide-lab.es.js", "locale-zh-hans.es.js", "vide-playground.css"];
 const requiredWasmFiles = ["vide-lsp.js", "vide-core.js", "vide-core.wasm"];
 
 function requireFiles(root, files, hint) {

--- a/playground/src/locale/zh-hans.ts
+++ b/playground/src/locale/zh-hans.ts
@@ -1,0 +1,1 @@
+import "@codingame/monaco-vscode-language-pack-zh-hans";

--- a/playground/vite.embed.config.ts
+++ b/playground/vite.embed.config.ts
@@ -1,35 +1,18 @@
 import { defineConfig } from "vite";
-import { copyFileSync, mkdirSync, readdirSync } from "node:fs";
-import { resolve } from "node:path";
-
-const monacoNlsLocales = new Set(["cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-br", "ru", "tr", "zh-cn", "zh-tw"]);
 
 export default defineConfig({
-  plugins: [
-    {
-      name: "copy-monaco-nls",
-      closeBundle() {
-        const monacoRoot = resolve("node_modules", "monaco-editor", "esm");
-        const outRoot = resolve("dist", "embed");
-        mkdirSync(outRoot, { recursive: true });
-        for (const fileName of readdirSync(monacoRoot)) {
-          const match = /^nls\.messages\.(.+)\.js$/.exec(fileName);
-          if (match && monacoNlsLocales.has(match[1])) {
-            copyFileSync(resolve(monacoRoot, fileName), resolve(outRoot, fileName));
-          }
-        }
-      },
-    },
-  ],
   build: {
     target: "es2022",
     outDir: "dist/embed",
     emptyOutDir: true,
     lib: {
-      entry: "src/components/vide-lab.ts",
+      entry: {
+        "vide-lab": "src/components/vide-lab.ts",
+        "locale-zh-hans": "src/locale/zh-hans.ts",
+      },
       name: "VideLab",
       formats: ["es"],
-      fileName: (format) => `vide-lab.${format}.js`,
+      fileName: (format, entryName) => `${entryName}.${format}.js`,
       cssFileName: "vide-playground",
     },
   },


### PR DESCRIPTION
## Summary
- Load the docs VideLab Chinese locale from the matching `@codingame/monaco-vscode-language-pack-zh-hans` package.
- Build a dedicated `locale-zh-hans.es.js` embed entry and require it in docs asset preparation.
- Stop loading Monaco's standalone `nls.messages.zh-cn.js`, whose numeric message table does not match the bundled VS Code API runtime.

## Validation
- Not run in this PR worktree at user request.