### PR TITLE
feat(docs): Refresh homepage hero and sidebar behavior

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -12,13 +12,7 @@ export default defineConfig({
     starlight({
       title: {
         'zh-CN': 'VIDE',
-        en: 'Vide Docs',
-      },
-      logo: {
-        light: './src/assets/vide-logo-light.svg',
-        dark: './src/assets/vide-logo-dark.svg',
-        alt: 'Vide',
-        replacesTitle: true,
+        en: 'VIDE',
       },
       favicon: '/favicon.svg',
       description:

--- a/docs/src/assets/landing.css
+++ b/docs/src/assets/landing.css
@@ -1,16 +1,17 @@
 :root {
   --sl-font: Inter, var(--sl-font-system);
-  --vide-accent-hsl: 200, 100%, 50%;
+  --vide-accent-hsl: 215, 14%, 34%;
   --vide-accent: hsl(var(--vide-accent-hsl));
   --vide-overlay: hsla(var(--vide-accent-hsl), 0.18);
 }
 
 :root[data-theme='light'] {
-  --vide-accent-hsl: 202, 92%, 44%;
-  --vide-overlay: hsla(var(--vide-accent-hsl), 0.14);
+  --vide-accent-hsl: 215, 14%, 34%;
+  --vide-overlay: hsla(var(--vide-accent-hsl), 0.08);
 }
 
 :root[data-theme='dark'] {
+  --vide-accent-hsl: 0, 0%, 90%;
   --vide-primary-button-color: #111827;
 }
 

--- a/docs/src/assets/landing.css
+++ b/docs/src/assets/landing.css
@@ -2,7 +2,7 @@
   --sl-font: Inter, var(--sl-font-system);
   --vide-accent-hsl: 215, 14%, 34%;
   --vide-accent: hsl(var(--vide-accent-hsl));
-  --vide-overlay: hsla(var(--vide-accent-hsl), 0.18);
+  --vide-overlay: hsla(var(--vide-accent-hsl), 0.08);
 }
 
 :root[data-theme='light'] {
@@ -11,7 +11,7 @@
 }
 
 :root[data-theme='dark'] {
-  --vide-accent-hsl: 0, 0%, 90%;
+  --vide-accent-hsl: 0, 0%, 84%;
   --vide-primary-button-color: #111827;
 }
 

--- a/docs/src/components/HomepageFeatureSection.astro
+++ b/docs/src/components/HomepageFeatureSection.astro
@@ -7,14 +7,23 @@ interface Props {
 }
 
 const locale = normalizeHomepageLocale(Astro.props.locale);
-const heading =
-  locale === 'en'
-    ? `Make <span class="vide-feature__accent"><strong>hardware design</strong></span><br />feel as fluid as writing software`
-    : `让<span class="vide-feature__accent"><strong>硬件设计</strong></span><br />像编写软件一样<wbr /><span class="vide-feature__nowrap">丝滑顺手</span>`;
 ---
 
-<section class="vide-feature">
-  <h2 set:html={heading} />
+<section class="vide-feature" data-locale={locale}>
+  <h2>
+    {
+      locale === 'en' ? (
+        <>
+          Make <span class="vide-feature__accent"><strong>hardware design</strong></span><br />feel as fluid as
+          developing software
+        </>
+      ) : (
+        <>
+          让<span class="vide-feature__accent"><strong>硬件设计</strong></span><br />像开发软件一样<wbr /><span class="vide-feature__nowrap">丝滑顺手</span>
+        </>
+      )
+    }
+  </h2>
   <HomepageFeatureCarousel locale={locale} />
 </section>
 
@@ -30,6 +39,10 @@ const heading =
     font-size: clamp(2rem, 5vw, 3rem);
     letter-spacing: 0;
     line-height: 1.4;
+  }
+
+  .vide-feature[data-locale='en'] h2 {
+    max-width: 34ch;
   }
 
   .vide-feature__accent {

--- a/docs/src/components/HomepageHeroStyles.astro
+++ b/docs/src/components/HomepageHeroStyles.astro
@@ -10,9 +10,15 @@
     text-align: center;
     text-wrap: wrap;
     word-break: keep-all;
-    width: min(100%, 72rem);
-    max-width: 72rem;
+    width: min(100%, 88rem);
+    max-width: 88rem;
     font-size: clamp(2.2rem, 4.75vw, 4.15rem);
+  }
+
+  html:lang(en)[data-has-hero] .hero h1 {
+    width: min(100%, 92rem);
+    max-width: 92rem;
+    font-size: clamp(2.1rem, 4.35vw, 3.85rem);
   }
 
   [data-has-hero] .hero h1::before {
@@ -36,6 +42,10 @@
     font-size: clamp(1rem, 1.35vw, 1.2rem);
     line-height: 1.7;
     text-align: center;
+  }
+
+  html:lang(zh-CN)[data-has-hero] .hero .tagline {
+    font-size: clamp(1.18rem, 1.45vw, 1.38rem);
   }
 
   [data-has-hero] .hero .hero-tagline-accent {
@@ -89,8 +99,14 @@
     }
   }
 
-  [data-has-hero][data-has-sidebar] {
-    --sl-content-width: 67.5rem;
+  html[data-has-hero]:not([data-has-sidebar]),
+  html[data-has-hero][data-has-sidebar] {
+    --sl-content-width: 78rem;
+  }
+
+  html:lang(en)[data-has-hero]:not([data-has-sidebar]),
+  html:lang(en)[data-has-hero][data-has-sidebar] {
+    --sl-content-width: 84rem;
   }
 
   @media (min-width: 50rem) {

--- a/docs/src/components/HomepageHeroStyles.astro
+++ b/docs/src/components/HomepageHeroStyles.astro
@@ -1,25 +1,60 @@
 <style is:global>
+  [data-has-hero] .hero {
+    padding-block-start: clamp(1.25rem, 4vw, 3.75rem);
+  }
+
   [data-has-hero] .hero h1 {
-    display: grid;
-    gap: 2rem;
+    display: block;
     letter-spacing: 0;
     line-height: 1;
-  }
-
-  [data-has-hero] .hero h1 .hero-brand {
-    color: var(--vide-accent);
-    font-size: clamp(2.55rem, 4.3vw, 4rem);
-    font-weight: 900;
-  }
-
-  [data-has-hero] .hero h1 .hero-title-main {
-    font-size: clamp(2.5rem, 5.8vw, 5rem);
-    text-wrap: balance;
+    text-align: center;
+    text-wrap: wrap;
     word-break: keep-all;
+    width: min(100%, 72rem);
+    max-width: 72rem;
+    font-size: clamp(2.2rem, 4.75vw, 4.15rem);
   }
 
-  [data-has-hero] .hero h1 .hero-title-nowrap {
+  [data-has-hero] .hero h1::before {
+    content: "";
+    display: block;
+    width: min(15rem, 42vw);
+    aspect-ratio: 864 / 280;
+    margin-inline: auto;
+    margin-bottom: clamp(0.85rem, 2vw, 1.35rem);
+    background: url('../assets/vide-logo-reveal-light.svg') center / contain no-repeat;
+  }
+
+  :root[data-theme='dark'][data-has-hero] .hero h1::before,
+  :root[data-theme='dark'] [data-has-hero] .hero h1::before {
+    background-image: url('../assets/vide-logo-reveal-dark.svg');
+  }
+
+  [data-has-hero] .hero .tagline {
+    max-width: min(100%, 56rem);
+    color: var(--sl-color-gray-3);
+    font-size: clamp(1rem, 1.35vw, 1.2rem);
+    line-height: 1.7;
+    text-align: center;
+  }
+
+  [data-has-hero] .hero .hero-tagline-accent {
+    color: var(--vide-accent);
+    font-weight: 800;
+  }
+
+  [data-has-hero] .hero .hero-tagline-nowrap {
     white-space: nowrap;
+  }
+
+  [data-has-hero] .hero .stack,
+  [data-has-hero] .hero .copy {
+    align-items: center;
+    text-align: center;
+  }
+
+  [data-has-hero] .hero .actions {
+    justify-content: center;
   }
 
   [data-has-hero] .hero h1 .hero-title-sub {
@@ -27,5 +62,58 @@
     font-size: clamp(1rem, 1.45vw, 1.35rem);
     font-weight: 400;
     line-height: 1.35;
+  }
+
+  @media (max-width: 49.999rem) {
+    [data-has-hero] .hero,
+    [data-has-hero] .hero .stack,
+    [data-has-hero] .hero .copy {
+      min-width: 0;
+      width: 100%;
+      max-width: 100%;
+    }
+
+    [data-has-hero] .hero h1 {
+      font-size: clamp(1.85rem, 5.5vw, 2.1rem);
+      line-height: 1.08;
+      width: min(100%, calc(100vw - 2rem));
+      max-width: calc(100vw - 2rem);
+      white-space: normal;
+      word-break: normal;
+      overflow-wrap: anywhere;
+    }
+
+    [data-has-hero] .hero .actions {
+      flex-wrap: wrap;
+      max-width: calc(100vw - 2rem);
+    }
+  }
+
+  [data-has-hero][data-has-sidebar] {
+    --sl-content-width: 67.5rem;
+  }
+
+  @media (min-width: 50rem) {
+    [data-has-hero][data-has-sidebar] {
+      --sl-content-inline-start: 0rem;
+    }
+
+    [data-has-hero][data-has-sidebar] .sidebar-pane {
+      display: none;
+    }
+
+    [data-has-hero] .hero .stack,
+    [data-has-hero] .hero .copy {
+      align-items: center;
+      text-align: center;
+    }
+
+    [data-has-hero] .hero .actions {
+      justify-content: center;
+    }
+
+    [data-has-hero] .hero h1::before {
+      width: min(23rem, 50vw);
+    }
   }
 </style>

--- a/docs/src/content/docs/en/index.mdx
+++ b/docs/src/content/docs/en/index.mdx
@@ -6,8 +6,9 @@ editUrl: false
 lastUpdated: false
 hero:
   title: |
-    <span class="hero-brand">Vide</span>
-    <span class="hero-title-main">Modern SystemVerilog <wbr />development environment</span>
+    Modern SystemVerilog Coding IDE
+  tagline: |
+    <strong class="hero-tagline-accent">Vide</strong> is a coding IDE built for Verilog/SystemVerilog developers, <wbr /><span class="hero-tagline-nowrap">bringing modern software development environment features into the hardware world</span>.
   actions:
     - text: Quick Start
       link: ./user-guide/

--- a/docs/src/content/docs/en/index.mdx
+++ b/docs/src/content/docs/en/index.mdx
@@ -6,9 +6,9 @@ editUrl: false
 lastUpdated: false
 hero:
   title: |
-    Modern SystemVerilog Coding IDE
+    <strong class="hero-tagline-accent">VIDE</strong> : Modern SystemVerilog Coding IDE
   tagline: |
-    <strong class="hero-tagline-accent">Vide</strong> is a coding IDE built for Verilog/SystemVerilog developers, <wbr /><span class="hero-tagline-nowrap">bringing modern software development environment features into the hardware world</span>.
+    Bringing modern software development environment features into the hardware world.
   actions:
     - text: Quick Start
       link: ./user-guide/

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -6,8 +6,9 @@ editUrl: false
 lastUpdated: false
 hero:
   title: |
-    <span class="hero-brand">Vide</span>
-    <span class="hero-title-main">现代 SystemVerilog <wbr /><span class="hero-title-nowrap">开发环境</span></span>
+    <strong class="hero-tagline-accent">VIDE</strong> : 现代 SystemVerilog 编程 IDE
+  tagline: |
+    将现代软件开发环境的功能带入硬件世界</span>。
   actions:
     - text: 快速开始
       link: ./user-guide/

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -8,7 +8,7 @@ hero:
   title: |
     <strong class="hero-tagline-accent">VIDE</strong> : 现代 SystemVerilog 编程 IDE
   tagline: |
-    将现代软件开发环境的功能带入硬件世界</span>。
+    将现代软件开发环境的功能带入硬件世界。
   actions:
     - text: 快速开始
       link: ./user-guide/

--- a/docs/src/starlightRouteData.ts
+++ b/docs/src/starlightRouteData.ts
@@ -22,7 +22,7 @@ export function onRequest(
       ? route.id.slice(route.locale.length + 1)
       : route.id;
 
-  if (routeId === '' || routeId === 'index') {
+  if (routeId === '' || routeId === 'index' || routeId === route.locale) {
     route.hasSidebar = true;
     return next();
   }

--- a/docs/src/starlightRouteData.ts
+++ b/docs/src/starlightRouteData.ts
@@ -21,6 +21,12 @@ export function onRequest(
     route.locale && route.id.startsWith(`${route.locale}/`)
       ? route.id.slice(route.locale.length + 1)
       : route.id;
+
+  if (routeId === '' || routeId === 'index') {
+    route.hasSidebar = true;
+    return next();
+  }
+
   const section = getSection(routeId);
 
   if (!section) {


### PR DESCRIPTION
Update EN/zh hero copy and layout styling, replace the header logo usage with CSS-based reveal branding, and force homepage routes to keep the sidebar enabled.