### PR TITLE
ci: make checks module-aware

### DIFF
--- a/.github/ci-modules.yml
+++ b/.github/ci-modules.yml
@@ -1,0 +1,39 @@
+server: &server
+  - "Cargo.toml"
+  - "Cargo.lock"
+  - "build.rs"
+  - "rust-toolchain.toml"
+  - "src/**"
+  - "crates/**"
+
+rust:
+  - *server
+  - "xtask/**"
+  - ".github/actions/setup-rust/**"
+  - ".github/actions/setup-sccache/**"
+  - ".github/ci-modules.yml"
+  - ".github/workflows/ci.yml"
+
+vscode:
+  - "editors/vscode/**"
+  - ".github/ci-modules.yml"
+  - ".github/workflows/ci.yml"
+
+package:
+  - *server
+  - "README.md"
+  - "editors/vscode/LICENSE"
+  - "editors/vscode/THIRD_PARTY_NOTICES.md"
+  - "editors/vscode/language-configuration.json"
+  - "editors/vscode/package.json"
+  - "editors/vscode/package-lock.json"
+  - "editors/vscode/package.nls*.json"
+  - "editors/vscode/l10n/**"
+  - "editors/vscode/media/**"
+  - "editors/vscode/scripts/**"
+  - "editors/vscode/src/**"
+  - "editors/vscode/syntaxes/**"
+  - ".github/actions/setup-rust/**"
+  - ".github/actions/setup-sccache/**"
+  - ".github/ci-modules.yml"
+  - ".github/workflows/ci.yml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,32 +3,41 @@ name: CI
 on:
   push:
     branches: [master]
-    paths-ignore:
-      - "docs/**"
-      - "playground/**"
-      - "crates/vide-lsp-wasm/**"
-      - ".github/actions/setup-emscripten/**"
-      - ".github/workflows/docs-preview.yml"
-      - ".github/workflows/deploy-docs.yml"
   pull_request:
     types: [opened, synchronize, reopened]
     branches: ["**"]
-    paths-ignore:
-      - "docs/**"
-      - "playground/**"
-      - "crates/vide-lsp-wasm/**"
-      - ".github/actions/setup-emscripten/**"
-      - ".github/workflows/docs-preview.yml"
-      - ".github/workflows/deploy-docs.yml"
   workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      vscode: ${{ steps.filter.outputs.vscode }}
+      package: ${{ steps.filter.outputs.package }}
+      server: ${{ steps.filter.outputs.server }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect changed paths
+        id: filter
+        if: github.event_name != 'workflow_dispatch'
+        uses: dorny/paths-filter@v4
+        with:
+          filters: .github/ci-modules.yml
+
   rust-lint:
     name: Rust Linting
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -45,7 +54,7 @@ jobs:
         continue-on-error: true
         with:
           shared-key: rust-${{ runner.os }}
-          key: workspace-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**', 'crates/**', 'xtask/**') }}
+          key: workspace-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'build.rs', 'rust-toolchain.toml', 'src/**', 'crates/**', 'xtask/**') }}
           cache-workspace-crates: true
           cache-on-failure: true
       - name: Format Check
@@ -55,6 +64,8 @@ jobs:
 
   rust-test:
     name: Rust Tests (${{ matrix.os }})
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -74,7 +85,7 @@ jobs:
         continue-on-error: true
         with:
           shared-key: rust-${{ runner.os }}
-          key: workspace-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**', 'crates/**', 'xtask/**') }}
+          key: workspace-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'build.rs', 'rust-toolchain.toml', 'src/**', 'crates/**', 'xtask/**') }}
           cache-workspace-crates: true
           cache-on-failure: true
       - name: Test
@@ -82,6 +93,8 @@ jobs:
 
   vscode-extension:
     name: VS Code Checks
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.vscode == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -101,7 +114,8 @@ jobs:
 
   dev-package:
     name: Dev Package (${{ matrix.target }})
-    if: github.event_name != 'pull_request'
+    needs: changes
+    if: github.event_name != 'pull_request' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.package == 'true')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -119,22 +133,33 @@ jobs:
     defaults:
       run:
         working-directory: editors/vscode
+    env:
+      SERVER_BIN: ${{ startsWith(matrix.target, 'win32-') && 'vide.exe' || 'vide' }}
     steps:
       - uses: actions/checkout@v4
+      - name: Restore bundled server cache
+        id: bundled-server-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: editors/vscode/server/${{ matrix.target }}/${{ env.SERVER_BIN }}
+          key: bundled-server-${{ matrix.target }}-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'build.rs', 'rust-toolchain.toml', 'src/**', 'crates/**') }}
       - name: Install Rust
+        if: steps.bundled-server-cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-rust
         with:
           components: rustfmt
       - name: Setup sccache
+        if: steps.bundled-server-cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-sccache
         with:
           cmake-launcher: "true"
       - name: Rust Cache
+        if: steps.bundled-server-cache.outputs.cache-hit != 'true'
         uses: Swatinem/rust-cache@v2
         continue-on-error: true
         with:
           shared-key: rust-${{ runner.os }}
-          key: package-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**', 'crates/**', 'editors/vscode/scripts/**') }}
+          key: package-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'build.rs', 'rust-toolchain.toml', 'src/**', 'crates/**') }}
           cache-workspace-crates: true
           cache-on-failure: true
       - name: Setup Node
@@ -150,11 +175,19 @@ jobs:
         shell: bash
         run: |
           commit_hash="$(git rev-parse --short "$GITHUB_SHA")"
-          echo "VIDE_COMMIT_HASH=${commit_hash}" >> "$GITHUB_ENV"
           echo "commit_hash=${commit_hash}" >> "$GITHUB_OUTPUT"
-          echo "VIDE_BUILD_DATE=$(date -u +'%Y%m%dT%H%M%SZ')" >> "$GITHUB_ENV"
+          echo "VIDE_EXTENSION_BUILD_KIND=nightly" >> "$GITHUB_ENV"
+          echo "VIDE_EXTENSION_COMMIT_HASH=${commit_hash}" >> "$GITHUB_ENV"
+          echo "VIDE_EXTENSION_BUILD_DATE=$(date -u +'%Y%m%dT%H%M%SZ')" >> "$GITHUB_ENV"
       - name: Package extension
-        run: npm run package:debug -- ${{ matrix.target }}
+        run: npm run package:debug -- ${{ matrix.target }} ${{ steps.bundled-server-cache.outputs.cache-hit == 'true' && '--server=prebuilt' || '--server=build' }}
+      - name: Save bundled server cache
+        if: steps.bundled-server-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        continue-on-error: true
+        with:
+          path: editors/vscode/server/${{ matrix.target }}/${{ env.SERVER_BIN }}
+          key: ${{ steps.bundled-server-cache.outputs.cache-primary-key }}
       - name: Upload dev VSIX
         uses: actions/upload-artifact@v4
         with:
@@ -165,7 +198,8 @@ jobs:
 
   dev-alpine-package:
     name: Dev Package (${{ matrix.target }})
-    if: github.event_name != 'pull_request'
+    needs: changes
+    if: github.event_name != 'pull_request' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.package == 'true')
     runs-on: ubuntu-22.04
     container: ${{ matrix.image }}
     strategy:
@@ -181,6 +215,8 @@ jobs:
     defaults:
       run:
         working-directory: editors/vscode
+    env:
+      SERVER_BIN: ${{ startsWith(matrix.target, 'win32-') && 'vide.exe' || 'vide' }}
     steps:
       - name: Install build dependencies
         working-directory: .
@@ -195,23 +231,33 @@ jobs:
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      - name: Restore bundled server cache
+        id: bundled-server-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: editors/vscode/server/${{ matrix.target }}/${{ env.SERVER_BIN }}
+          key: bundled-server-${{ matrix.target }}-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'build.rs', 'rust-toolchain.toml', 'src/**', 'crates/**') }}
+
       - name: Install Rust
+        if: steps.bundled-server-cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-rust
         with:
           components: rustfmt
           targets: ${{ matrix.rust-target }}
 
       - name: Setup sccache
+        if: steps.bundled-server-cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-sccache
         with:
           cmake-launcher: "true"
 
       - name: Rust Cache
+        if: steps.bundled-server-cache.outputs.cache-hit != 'true'
         uses: Swatinem/rust-cache@v2
         continue-on-error: true
         with:
           shared-key: rust-${{ runner.os }}-${{ matrix.target }}
-          key: package-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**', 'crates/**', 'editors/vscode/scripts/**') }}
+          key: package-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'build.rs', 'rust-toolchain.toml', 'src/**', 'crates/**') }}
           cache-workspace-crates: true
           cache-on-failure: true
 
@@ -231,12 +277,21 @@ jobs:
         working-directory: .
         run: |
           commit_hash="$(git rev-parse --short "$GITHUB_SHA")"
-          echo "VIDE_COMMIT_HASH=${commit_hash}" >> "$GITHUB_ENV"
           echo "commit_hash=${commit_hash}" >> "$GITHUB_OUTPUT"
-          echo "VIDE_BUILD_DATE=$(date -u +'%Y%m%dT%H%M%SZ')" >> "$GITHUB_ENV"
+          echo "VIDE_EXTENSION_BUILD_KIND=nightly" >> "$GITHUB_ENV"
+          echo "VIDE_EXTENSION_COMMIT_HASH=${commit_hash}" >> "$GITHUB_ENV"
+          echo "VIDE_EXTENSION_BUILD_DATE=$(date -u +'%Y%m%dT%H%M%SZ')" >> "$GITHUB_ENV"
 
       - name: Package extension
-        run: npm run package:debug -- ${{ matrix.target }}
+        run: npm run package:debug -- ${{ matrix.target }} ${{ steps.bundled-server-cache.outputs.cache-hit == 'true' && '--server=prebuilt' || '--server=build' }}
+
+      - name: Save bundled server cache
+        if: steps.bundled-server-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        continue-on-error: true
+        with:
+          path: editors/vscode/server/${{ matrix.target }}/${{ env.SERVER_BIN }}
+          key: ${{ steps.bundled-server-cache.outputs.cache-primary-key }}
 
       - name: Upload dev VSIX
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -333,7 +333,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: playground/public/wasm
-          key: playground-wasm-${{ runner.os }}-${{ env.EMSDK_VERSION }}-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**', 'crates/**', 'playground/scripts/build-vide-wasm.mjs', 'playground/scripts/script-utils.mjs', '.github/actions/setup-emscripten/**', '.github/actions/setup-rust/**') }}
+          key: playground-wasm-${{ runner.os }}-${{ env.EMSDK_VERSION }}-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'build.rs', 'rust-toolchain.toml', 'src/**', 'crates/**', 'playground/scripts/build-vide-wasm.mjs', 'playground/scripts/script-utils.mjs', '.github/actions/setup-emscripten/**', '.github/actions/setup-rust/**') }}
 
       - name: Verify cached playground WASM
         if: steps.playground-wasm-cache.outputs.cache-hit == 'true'
@@ -360,7 +360,7 @@ jobs:
         continue-on-error: true
         with:
           shared-key: docs-wasm-${{ runner.os }}-${{ env.EMSDK_VERSION }}
-          key: wasm-src-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**', 'crates/**', 'playground/scripts/build-vide-wasm.mjs', 'playground/scripts/script-utils.mjs', '.github/actions/setup-emscripten/**', '.github/actions/setup-rust/**') }}
+          key: wasm-src-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'build.rs', 'rust-toolchain.toml', 'src/**', 'crates/**', 'playground/scripts/build-vide-wasm.mjs', 'playground/scripts/script-utils.mjs', '.github/actions/setup-emscripten/**', '.github/actions/setup-rust/**') }}
           cache-workspace-crates: true
           cache-on-failure: true
 

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -6,12 +6,16 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
     paths:
+      # Documentation pages and the browser playground shell.
       - "docs/**"
       - "playground/**"
+      # WASM playground server inputs. The WASM crate links the root server
+      # browser entry point, so request/IDE changes can affect PR previews.
       - "src/**"
       - "crates/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "build.rs"
       - "rust-toolchain.toml"
       - ".github/actions/setup-emscripten/**"
       - ".github/actions/setup-rust/**"
@@ -77,7 +81,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: playground/public/wasm
-          key: playground-wasm-${{ runner.os }}-${{ env.EMSDK_VERSION }}-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**', 'crates/**', 'playground/scripts/build-vide-wasm.mjs', 'playground/scripts/script-utils.mjs', '.github/actions/setup-emscripten/**', '.github/actions/setup-rust/**') }}
+          key: playground-wasm-${{ runner.os }}-${{ env.EMSDK_VERSION }}-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'build.rs', 'rust-toolchain.toml', 'src/**', 'crates/**', 'playground/scripts/build-vide-wasm.mjs', 'playground/scripts/script-utils.mjs', '.github/actions/setup-emscripten/**', '.github/actions/setup-rust/**') }}
 
       - name: Verify cached playground WASM
         if: steps.playground-wasm-cache.outputs.cache-hit == 'true'
@@ -104,7 +108,7 @@ jobs:
         continue-on-error: true
         with:
           shared-key: docs-wasm-${{ runner.os }}-${{ env.EMSDK_VERSION }}
-          key: wasm-src-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**', 'crates/**', 'playground/scripts/build-vide-wasm.mjs', 'playground/scripts/script-utils.mjs', '.github/actions/setup-emscripten/**', '.github/actions/setup-rust/**') }}
+          key: wasm-src-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'build.rs', 'rust-toolchain.toml', 'src/**', 'crates/**', 'playground/scripts/build-vide-wasm.mjs', 'playground/scripts/script-utils.mjs', '.github/actions/setup-emscripten/**', '.github/actions/setup-rust/**') }}
           cache-workspace-crates: true
           cache-on-failure: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
         continue-on-error: true
         with:
           shared-key: rust-${{ runner.os }}
-          key: package-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**', 'crates/**', 'editors/vscode/scripts/**') }}
+          key: package-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'build.rs', 'rust-toolchain.toml', 'src/**', 'crates/**') }}
           cache-workspace-crates: true
           cache-on-failure: true
 
@@ -110,8 +110,13 @@ jobs:
       - name: Set build metadata
         shell: bash
         run: |
-          echo "VIDE_COMMIT_HASH=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
-          echo "VIDE_BUILD_DATE=$(date -u +'%Y%m%dT%H%M%SZ')" >> "$GITHUB_ENV"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            echo "VIDE_EXTENSION_BUILD_KIND=beta" >> "$GITHUB_ENV"
+            echo "VIDE_EXTENSION_COMMIT_HASH=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
+            echo "VIDE_EXTENSION_BUILD_DATE=$(date -u +'%Y%m%dT%H%M%SZ')" >> "$GITHUB_ENV"
+          else
+            echo "VIDE_EXTENSION_BUILD_KIND=stable" >> "$GITHUB_ENV"
+          fi
 
       - name: Build VSIX
         working-directory: editors/vscode
@@ -168,7 +173,7 @@ jobs:
         continue-on-error: true
         with:
           shared-key: rust-${{ runner.os }}-${{ matrix.target }}
-          key: package-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**', 'crates/**', 'editors/vscode/scripts/**') }}
+          key: package-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'build.rs', 'rust-toolchain.toml', 'src/**', 'crates/**') }}
           cache-workspace-crates: true
           cache-on-failure: true
 
@@ -186,8 +191,13 @@ jobs:
       - name: Set build metadata
         shell: bash
         run: |
-          echo "VIDE_COMMIT_HASH=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
-          echo "VIDE_BUILD_DATE=$(date -u +'%Y%m%dT%H%M%SZ')" >> "$GITHUB_ENV"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            echo "VIDE_EXTENSION_BUILD_KIND=beta" >> "$GITHUB_ENV"
+            echo "VIDE_EXTENSION_COMMIT_HASH=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
+            echo "VIDE_EXTENSION_BUILD_DATE=$(date -u +'%Y%m%dT%H%M%SZ')" >> "$GITHUB_ENV"
+          else
+            echo "VIDE_EXTENSION_BUILD_KIND=stable" >> "$GITHUB_ENV"
+          fi
 
       - name: Build VSIX
         working-directory: editors/vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,3 @@ winapi.workspace = true
 
 [dev-dependencies]
 utils = { workspace = true, features = ["test-support"] }
-
-[build-dependencies]
-time = { version = "0.3.47", features = ["formatting", "macros"] }

--- a/build.rs
+++ b/build.rs
@@ -1,63 +1,13 @@
-use std::{env, process::Command};
-
-use time::{OffsetDateTime, macros::format_description};
+use std::env;
 
 fn main() {
-    println!("cargo:rerun-if-env-changed=VIDE_COMMIT_HASH");
-    println!("cargo:rerun-if-env-changed=VIDE_BUILD_DATE");
-    watch_git_metadata();
+    println!("cargo:rerun-if-env-changed=VIDE_BUILD_METADATA");
 
-    let release = env::var("PROFILE").as_deref() == Ok("release");
-    let commit_hash = build_env("VIDE_COMMIT_HASH", release, git_commit_hash);
-    let build_date = build_env("VIDE_BUILD_DATE", release, utc_build_date);
-
-    println!("cargo:rustc-env=VIDE_COMMIT_HASH={commit_hash}");
-    println!("cargo:rustc-env=VIDE_BUILD_DATE={build_date}");
-}
-
-fn build_env(name: &str, release: bool, fallback: impl FnOnce() -> String) -> String {
-    match env::var(name) {
-        Ok(value) if !value.trim().is_empty() => value,
-        _ if release => fallback(),
-        _ => "dev".to_string(),
-    }
-}
-
-fn git_commit_hash() -> String {
-    git_output(["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "unknown".to_string())
-}
-
-fn watch_git_metadata() {
-    for path in [git_path("HEAD"), git_current_branch_path()].into_iter().flatten() {
-        println!("cargo:rerun-if-changed={path}");
-    }
-}
-
-fn git_current_branch_path() -> Option<String> {
-    let branch = git_output(["symbolic-ref", "--quiet", "HEAD"])?;
-    git_path(&branch)
-}
-
-fn git_path(path: impl AsRef<str>) -> Option<String> {
-    git_output(["rev-parse", "--git-path", path.as_ref()])
-}
-
-fn git_output<const N: usize>(args: [&str; N]) -> Option<String> {
-    Command::new("git")
-        .args(args)
-        .output()
+    let metadata = env::var("VIDE_BUILD_METADATA")
         .ok()
-        .filter(|output| output.status.success())
-        .and_then(|output| String::from_utf8(output.stdout).ok())
-        .map(|output| output.trim().to_string())
-        .filter(|output| !output.is_empty())
-}
-
-fn utc_build_date() -> String {
-    format_build_date(OffsetDateTime::now_utc())
-}
-
-fn format_build_date(date: OffsetDateTime) -> String {
-    let format = format_description!("[year][month][day]T[hour][minute][second]Z");
-    date.format(format).expect("UTC build date format should be valid")
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+        .map(|value| format!("+{value}"))
+        .unwrap_or_default();
+    println!("cargo:rustc-env=VIDE_BUILD_METADATA={metadata}");
 }

--- a/docs/src/content/docs/advanced-guide/build-from-source.md
+++ b/docs/src/content/docs/advanced-guide/build-from-source.md
@@ -35,9 +35,14 @@ cargo build
 cargo build --release
 ```
 
-发布构建会把构建元数据写入 `vide --version` 输出。本地构建如果没有设置
-`VIDE_COMMIT_HASH` 和 `VIDE_BUILD_DATE`，会自动使用当前 Git 短提交和 UTC
-构建时间；CI 或发布脚本仍然可以通过这两个环境变量覆盖默认值。
+`vide --version` 默认只包含包版本和构建 profile，不会自动读取当前 Git
+提交。需要给 beta、nightly 或内部构建加额外标记时，可以显式设置
+`VIDE_BUILD_METADATA`：
+
+```powershell
+$env:VIDE_BUILD_METADATA = "abc1234.20260529T120000Z"
+cargo build --release
+```
 
 验证版本：
 

--- a/docs/src/content/docs/en/advanced-guide/build-from-source.md
+++ b/docs/src/content/docs/en/advanced-guide/build-from-source.md
@@ -38,10 +38,15 @@ Release build:
 cargo build --release
 ```
 
-Release builds embed build metadata in the `vide --version` output. Local
-builds automatically use the current short Git commit and UTC build time when
-`VIDE_COMMIT_HASH` and `VIDE_BUILD_DATE` are not set; CI or release scripts
-can still override the defaults with those environment variables.
+By default, `vide --version` only includes the package version and build
+profile; it does not read the current Git commit automatically. For beta,
+nightly, or internal builds that need an extra marker, set
+`VIDE_BUILD_METADATA` explicitly:
+
+```powershell
+$env:VIDE_BUILD_METADATA = "abc1234.20260529T120000Z"
+cargo build --release
+```
 
 Verify the version:
 

--- a/docs/src/content/docs/en/user-guide/commands-status-logs.mdx
+++ b/docs/src/content/docs/en/user-guide/commands-status-logs.mdx
@@ -15,7 +15,7 @@ The VS Code extension contributes these commands. Use the Command Palette title 
 | --- | --- | --- |
 | `vide.showOutput` | `Vide: Show Language Server Output` | Opens the `Vide Language Server` output channel. |
 | `vide.restartServer` | `Vide: Restart Language Server` | Stops and restarts the current language server. |
-| `vide.showServerVersion` | `Vide: Show Server Version` | Runs the current server command with the current cwd and environment, combines `vide.server.args` with `--version`, and does not append `vide.server.additionalArgs`. |
+| `vide.showServerVersion` | `Vide: Show Server Version` | Shows the current extension version, then runs the current server command with the current cwd and environment, combines `vide.server.args` with `--version`, and does not append `vide.server.additionalArgs`. |
 | `vide.reloadWorkspace` | `Vide: Reload Project Configuration` | Rereads project configuration files and refreshes project information without restarting the server. |
 | `vide.showStatus` | `Vide: Show Status` | Opens the Vide status menu. |
 | `vide.runQiheAnalysis` | `Vide: Run Qihe Analysis` | Runs Qihe analysis for the current local Verilog/SystemVerilog file. |

--- a/docs/src/content/docs/user-guide/commands-status-logs.mdx
+++ b/docs/src/content/docs/user-guide/commands-status-logs.mdx
@@ -15,7 +15,7 @@ VS Code 扩展贡献这些命令。使用时看“命令面板标题”即可；
 | --- | --- | --- |
 | `vide.showOutput` | `Vide：显示语言服务器输出` | 打开 `Vide Language Server` 输出通道。 |
 | `vide.restartServer` | `Vide：重启语言服务器` | 停止并重新启动当前语言服务器。 |
-| `vide.showServerVersion` | `Vide：显示服务器版本` | 使用当前启动命令、工作目录和环境，把 `vide.server.args` 与 `--version` 组合起来执行版本查询；不会附加 `vide.server.additionalArgs`。 |
+| `vide.showServerVersion` | `Vide：显示服务器版本` | 显示当前扩展版本，并使用当前启动命令、工作目录和环境，把 `vide.server.args` 与 `--version` 组合起来查询服务器版本；不会附加 `vide.server.additionalArgs`。 |
 | `vide.reloadWorkspace` | `Vide：重新加载项目配置` | 不重启语言服务器，重新读取项目配置并刷新工程信息。 |
 | `vide.showStatus` | `Vide：显示状态` | 打开 Vide 状态菜单。 |
 | `vide.runQiheAnalysis` | `Vide：运行 Qihe 分析` | 对当前本地 Verilog/SystemVerilog 文件运行 Qihe 分析。 |

--- a/editors/vscode/.gitignore
+++ b/editors/vscode/.gitignore
@@ -3,6 +3,7 @@ dist/
 out/
 *.vsix
 README.md
+build-info.json
 .vscode-test/
 *.log
 .DS_Store

--- a/editors/vscode/l10n/bundle.l10n.zh-cn.json
+++ b/editors/vscode/l10n/bundle.l10n.zh-cn.json
@@ -35,7 +35,7 @@
   "Vide Language Server": "Vide 语言服务器",
   "Failed to start Vide Language Server: {0}": "无法启动 Vide 语言服务器：{0}",
   "No version output": "没有版本输出",
-  "Vide server: {0}": "Vide 服务器：{0}",
+  "Vide extension: {0}; server: {1}": "Vide 扩展：{0}；服务器：{1}",
   "Failed to query Vide server version: {0}": "无法查询 Vide 服务器版本：{0}",
   "Show Output": "显示输出",
   "Show Qihe Output": "显示 Qihe 输出",

--- a/editors/vscode/scripts/package.ts
+++ b/editors/vscode/scripts/package.ts
@@ -14,6 +14,7 @@ const repoRoot = path.resolve(vscodeDir, '..', '..');
 const binName = 'vide';
 
 type BuildProfile = 'debug' | 'release';
+type ServerMode = 'build' | 'prebuilt';
 
 const cargoTargets: Partial<Record<PlatformFolder, string>> = {
   'alpine-arm64': 'aarch64-unknown-linux-musl',
@@ -117,24 +118,35 @@ function cargoOutputDir(profile: BuildProfile, cargoTarget?: string): string {
   return path.join(...pathParts);
 }
 
+function ensureServerExecutable(serverPath: string, target: PlatformFolder): void {
+  if (!target.startsWith('win32-')) {
+    fs.chmodSync(serverPath, 0o755);
+  }
+}
+
 function ensureTargetServerBinary(
   target: PlatformFolder,
   binFile: string,
   profile: BuildProfile,
+  serverMode: ServerMode,
 ): string {
   const serverOutDir = path.join(vscodeDir, 'server', target);
+  const serverPath = path.join(serverOutDir, binFile);
+  if (serverMode === 'prebuilt') {
+    if (fs.existsSync(serverPath)) {
+      ensureServerExecutable(serverPath, target);
+      return serverPath;
+    }
+    throw new Error(`missing prebuilt server binary: ${serverPath}`);
+  }
+
   const hostTarget = hostPlatformFolder();
   const cargoTarget = cargoTargets[target];
   if (target !== hostTarget && !cargoTarget) {
-    const serverPath = path.join(serverOutDir, binFile);
-    if (!fs.existsSync(serverPath)) {
-      throw new Error(
-        `missing bundled server binary: ${serverPath}\n` +
-          'tip: run packaging on a matching native runner or copy the target binary first.',
-      );
-    }
-
-    return serverPath;
+    throw new Error(
+      `missing bundled server binary: ${serverPath}\n` +
+        'tip: run packaging on a matching native runner or copy the target binary first.',
+    );
   }
 
   if (cargoTarget) {
@@ -147,9 +159,7 @@ function ensureTargetServerBinary(
   const destPath = path.join(serverOutDir, binFile);
   fs.mkdirSync(serverOutDir, { recursive: true });
   fs.copyFileSync(sourcePath, destPath);
-  if (!target.startsWith('win32-')) {
-    fs.chmodSync(destPath, 0o755);
-  }
+  ensureServerExecutable(destPath, target);
 
   return destPath;
 }
@@ -177,18 +187,62 @@ function syncReadmeFromRepoRoot(): void {
   fs.copyFileSync(path.join(repoRoot, 'README.md'), path.join(vscodeDir, 'README.md'));
 }
 
-function parseArgs(): { target: PlatformFolder; profile: BuildProfile } {
+function readExtensionVersion(): string {
+  const packageJson = JSON.parse(fs.readFileSync(path.join(vscodeDir, 'package.json'), 'utf8')) as {
+    version?: unknown;
+  };
+  if (typeof packageJson.version !== 'string' || packageJson.version.length === 0) {
+    throw new Error('VS Code extension package.json must define a version.');
+  }
+  return packageJson.version;
+}
+
+function optionalEnv(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+}
+
+function writeBuildInfo(target: PlatformFolder, profile: BuildProfile): void {
+  const buildInfo = {
+    version: readExtensionVersion(),
+    target,
+    profile,
+    kind: optionalEnv('VIDE_EXTENSION_BUILD_KIND') ?? 'local',
+    commitHash: optionalEnv('VIDE_EXTENSION_COMMIT_HASH'),
+    buildDate: optionalEnv('VIDE_EXTENSION_BUILD_DATE'),
+  };
+  fs.writeFileSync(
+    path.join(vscodeDir, 'build-info.json'),
+    `${JSON.stringify(buildInfo, null, 2)}\n`,
+  );
+}
+
+function parseServerMode(value: string): ServerMode {
+  if (value === 'build' || value === 'prebuilt') {
+    return value;
+  }
+  throw new Error(`unsupported server mode: ${value}`);
+}
+
+function parseArgs(): { target: PlatformFolder; profile: BuildProfile; serverMode: ServerMode } {
   const args = process.argv.slice(2);
-  const profile = args[0] === '--debug' ? 'debug' : 'release';
-  if (profile === 'debug') {
-    args.shift();
+  let profile: BuildProfile = 'release';
+  let serverMode: ServerMode = 'build';
+  let target: string | undefined;
+
+  for (const arg of args) {
+    if (arg === '--debug') {
+      profile = 'debug';
+    } else if (arg.startsWith('--server=')) {
+      serverMode = parseServerMode(arg.slice('--server='.length));
+    } else if (!target) {
+      target = arg;
+    } else {
+      throw new Error(`unexpected package argument: ${arg}`);
+    }
   }
 
-  const target = args[0] ?? hostPlatformFolder();
-  if (args.length > 1) {
-    throw new Error(`unexpected package arguments: ${args.join(' ')}`);
-  }
-
+  target ??= hostPlatformFolder();
   if (!isPlatformFolder(target)) {
     throw new Error(
       `unsupported target platform: ${target}\n` +
@@ -196,14 +250,19 @@ function parseArgs(): { target: PlatformFolder; profile: BuildProfile } {
     );
   }
 
-  return { target, profile };
+  return { target, profile, serverMode };
 }
 
-function packageExtension(target: PlatformFolder, profile: BuildProfile): string {
+function packageExtension(
+  target: PlatformFolder,
+  profile: BuildProfile,
+  serverMode: ServerMode,
+): string {
   syncReadmeFromRepoRoot();
+  writeBuildInfo(target, profile);
 
   const binFile = binaryFileForTarget(target);
-  const targetServerPath = ensureTargetServerBinary(target, binFile, profile);
+  const targetServerPath = ensureTargetServerBinary(target, binFile, profile, serverMode);
   cleanRuntimeServerFiles();
   const runtimeServerPath = stageRuntimeServer(targetServerPath, target, binFile);
 
@@ -227,8 +286,8 @@ function packageExtension(target: PlatformFolder, profile: BuildProfile): string
 }
 
 function main(): void {
-  const { target, profile } = parseArgs();
-  const vsixPath = packageExtension(target, profile);
+  const { target, profile, serverMode } = parseArgs();
+  const vsixPath = packageExtension(target, profile, serverMode);
   console.log(vsixPath);
 }
 

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -52,6 +52,12 @@ const languageServerOutputChannelName = 'Vide Language Server';
 const qiheOutputChannelName = 'Vide Qihe';
 const versionTimeoutMs = 5000;
 
+interface ExtensionBuildInfo {
+  kind?: string;
+  commitHash?: string;
+  buildDate?: string;
+}
+
 const activeQiheTokens = new Set<string>();
 const qiheProgressNotifications = new Map<string, { resolve: () => void }>();
 let qiheStatusHideTimer: NodeJS.Timeout | undefined;
@@ -86,6 +92,30 @@ function showOutput(): void {
 
 function showQiheOutput(): void {
   requireQiheOutputChannel().show(true);
+}
+
+function extensionVersion(context: vscode.ExtensionContext): string {
+  const packageJson = context.extension.packageJSON as { version?: unknown };
+  return typeof packageJson.version === 'string' && packageJson.version.length > 0
+    ? packageJson.version
+    : 'unknown';
+}
+
+function extensionBuildInfo(context: vscode.ExtensionContext): ExtensionBuildInfo | undefined {
+  const buildInfoPath = path.join(context.extensionPath, 'build-info.json');
+  if (!fs.existsSync(buildInfoPath)) {
+    return undefined;
+  }
+  return JSON.parse(fs.readFileSync(buildInfoPath, 'utf8')) as ExtensionBuildInfo;
+}
+
+function extensionBuildLabel(context: vscode.ExtensionContext): string {
+  const version = extensionVersion(context);
+  const buildInfo = extensionBuildInfo(context);
+  const details = [buildInfo?.kind, buildInfo?.commitHash, buildInfo?.buildDate].filter(
+    (part): part is string => typeof part === 'string' && part.length > 0,
+  );
+  return details.length > 0 ? `${version} (${details.join(', ')})` : version;
 }
 
 async function showLanguageServerErrorMessage(message: string): Promise<void> {
@@ -692,7 +722,13 @@ async function showServerVersion(context: vscode.ExtensionContext): Promise<void
     const output = `${stdout}${stderr}`.trim() || vscode.l10n.t('No version output');
     const firstLine = output.split(/\r?\n/, 1)[0] ?? output;
     log(`[INFO] Server version output:\n${output}`);
-    vscode.window.showInformationMessage(vscode.l10n.t('Vide server: {0}', firstLine));
+    vscode.window.showInformationMessage(
+      vscode.l10n.t(
+        'Vide extension: {0}; server: {1}',
+        extensionBuildLabel(context),
+        firstLine,
+      ),
+    );
   } catch (error) {
     const message = vscode.l10n.t(
       'Failed to query Vide server version: {0}',
@@ -811,6 +847,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   updateServerStatus('stopped');
 
   log('[INFO] Vide extension activating...');
+  log(`[INFO] Extension version: ${extensionBuildLabel(context)}`);
   log(`[INFO] Extension path: ${context.extensionPath}`);
   log(`[INFO] Platform: ${process.platform}-${process.arch}`);
   log(`[INFO] VS Code version: ${vscode.version}`);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,13 +28,8 @@ mod lsp_ext;
 pub const DEFAULT_PROCESS_NAME: &str = env!("CARGO_PKG_NAME");
 const DEBUG: bool = cfg!(debug_assertions);
 const BUILD_PROFILE: &str = if DEBUG { "DEBUG" } else { "RELEASE" };
-pub const VERSION: &str = formatcp!(
-    "{}_{}+{}.{}",
-    env!("CARGO_PKG_VERSION"),
-    BUILD_PROFILE,
-    env!("VIDE_COMMIT_HASH"),
-    env!("VIDE_BUILD_DATE")
-);
+pub const VERSION: &str =
+    formatcp!("{}_{}{}", env!("CARGO_PKG_VERSION"), BUILD_PROFILE, env!("VIDE_BUILD_METADATA"));
 
 #[derive(Clone, Debug, Parser)]
 #[clap(name = DEFAULT_PROCESS_NAME, version = VERSION)]


### PR DESCRIPTION
## Summary
- Add a shared CI module map and use it to skip Rust, VS Code, and packaging jobs when their inputs did not change.
- Decouple Rust server version metadata from Git commit/date so server binaries can be reused by source-input hash.
- Let VSIX packaging reuse cached server binaries on cache hits and store beta/nightly build metadata in the extension package.
- Keep PR docs previews scoped to docs, playground, and WASM server inputs.

## Validation
- `cargo fmt --all -- --check`
- `cargo check -q`
- `cargo test -q -p vide --lib`
- `npm --prefix editors/vscode test`
- `npm --prefix editors/vscode run package:debug -- win32-x64 --server=build`
- `npm --prefix editors/vscode run package:debug -- win32-x64 --server=prebuilt`
- `npm --prefix docs run build`
- Parsed `.github/ci-modules.yml` and updated workflow YAML files with `js-yaml`