### PR TITLE
ci: publish VS Code extension to Open VSX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -485,3 +485,40 @@ jobs:
             done
             exit 1
           fi
+
+  publish-openvsx:
+    name: Publish Open VSX ${{ matrix.target }}
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: publish
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - linux-x64
+          - linux-arm64
+          - win32-x64
+          - darwin-arm64
+          - alpine-x64
+          - alpine-arm64
+          - web
+    steps:
+      - name: Download VSIX artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Require Open VSX token
+        env:
+          OPEN_VSX_TOKEN: ${{ secrets.OPEN_VSX_TOKEN }}
+        run: |
+          if [ -z "${OPEN_VSX_TOKEN:-}" ]; then
+            echo "OPEN_VSX_TOKEN secret is not set; cannot publish to Open VSX." >&2
+            exit 1
+          fi
+
+      - name: Publish VSIX package to Open VSX
+        uses: HaaLeo/publish-vscode-extension@v2
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          extensionFile: artifacts/vide-vscode-stable-${{ matrix.target }}/vide-vscode-${{ matrix.target }}.vsix


### PR DESCRIPTION
## Summary
- add an Open VSX publish job for stable tag releases
- publish the existing platform VSIX artifacts with HaaLeo/publish-vscode-extension@v2
- require OPEN_VSX_TOKEN before upload

## Validation
- actionlint .github/workflows/release.yml