### PR TITLE
chore: release v0.1.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vide"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 authors = ["roifewu <roifewu@gmail.com>", "hongjr03 <hongjr03@gmail.com>"]
 repository = "https://github.com/pascal-lab/vide"

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vide-ide",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vide-ide",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vide-ide",
   "displayName": "Vide - Verilog/SystemVerilog Coding IDE",
   "description": "%extension.description%",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "publisher": "pascal-lab",
   "license": "MIT",
   "icon": "media/icon.png",


### PR DESCRIPTION
## Summary
- Bump Rust crate version to 0.1.10
- Bump VS Code extension package version to 0.1.10

## Checks
- cargo check --locked
- npm --prefix editors/vscode run --silent check