### PR TITLE
fix(vscode): use qihe.bat by default on Windows

### DIFF
--- a/docs/src/content/docs/en/user-guide/features/qihe.mdx
+++ b/docs/src/content/docs/en/user-guide/features/qihe.mdx
@@ -116,7 +116,7 @@ The arguments come from:
 
 If `vide.qihe.compileArgs` already contains `--mode`, `--mode=...`, or `-m ...`, Vide does not add `--mode sv` again.
 
-Common defaults are:
+Common defaults are shown below. On Windows, if `vide.qihe.command` is not explicitly configured, Vide uses `qihe.bat`:
 
 ```json
 {

--- a/docs/src/content/docs/user-guide/features/qihe.mdx
+++ b/docs/src/content/docs/user-guide/features/qihe.mdx
@@ -114,7 +114,7 @@ qihe run <qihe-run-args> -i <tmp.qh> -c storage.root=<tmp-storage>
 
 如果 `vide.qihe.compileArgs` 已经包含 `--mode`、`--mode=...` 或 `-m ...`，Vide 不会再自动追加 `--mode sv`。
 
-常用默认值如下：
+常用默认值如下。在 Windows 上，如果没有显式配置 `vide.qihe.command`，Vide 会使用 `qihe.bat`：
 
 ```json
 {

--- a/editors/vscode/package.nls.json
+++ b/editors/vscode/package.nls.json
@@ -5,7 +5,7 @@
   "configuration.server.args.description": "Arguments passed before any additional arguments when a custom command is provided.",
   "configuration.server.cwd.description": "Working directory for the Vide language server process. Defaults to the first workspace folder.",
   "configuration.server.additionalArgs.description": "Additional arguments appended when launching the Vide language server.",
-  "configuration.qihe.command.description": "Command used to invoke Qihe. It must be available in the environment PATH seen by VS Code.",
+  "configuration.qihe.command.description": "Command used to invoke Qihe. When not explicitly configured, Vide uses qihe.bat on Windows and qihe elsewhere. The command must be available in the environment PATH seen by VS Code.",
   "configuration.qihe.autoConfigureArgsFromManifest.description": "Automatically add Qihe compile mode and forwarded slang options from the Vide project manifest. Disable this to provide those options manually through Qihe compile and run arguments.",
   "configuration.qihe.compileArgs.description": "Arguments inserted after `qihe compile`. Use this for compile mode selection or forwarded `slang` options such as `--mode sv -- -I include`.",
   "configuration.qihe.runArgs.description": "Arguments inserted after `qihe run` when the Qihe analysis button is used.",

--- a/editors/vscode/package.nls.zh-cn.json
+++ b/editors/vscode/package.nls.zh-cn.json
@@ -5,7 +5,7 @@
   "configuration.server.args.description": "使用自定义命令时，在其他参数之前传递的参数。",
   "configuration.server.cwd.description": "Vide 语言服务器进程的工作目录。默认使用第一个工作区文件夹。",
   "configuration.server.additionalArgs.description": "启动 Vide 语言服务器时追加的额外参数。",
-  "configuration.qihe.command.description": "用于调用 Qihe 的命令。它必须在 VS Code 可见的环境 PATH 中可用。",
+  "configuration.qihe.command.description": "用于调用 Qihe 的命令。未显式配置时，Vide 在 Windows 上使用 qihe.bat，在其他平台使用 qihe。该命令必须在 VS Code 可见的环境 PATH 中可用。",
   "configuration.qihe.autoConfigureArgsFromManifest.description": "根据 Vide 项目配置文件自动添加 Qihe 编译模式和转发给 slang 的选项。关闭后可通过 Qihe 编译和运行参数手动提供这些选项。",
   "configuration.qihe.compileArgs.description": "插入到 `qihe compile` 之后的参数。可用于选择编译模式，或转发 `slang` 选项，例如 `--mode sv -- -I include`。",
   "configuration.qihe.runArgs.description": "使用 Qihe 分析按钮时，插入到 `qihe run` 之后的参数。",

--- a/editors/vscode/src/initializationOptions.ts
+++ b/editors/vscode/src/initializationOptions.ts
@@ -2,23 +2,75 @@ import { USER_CONFIG_SETTINGS } from './generated/configuration';
 
 type ConfigurationReader = {
   get<T>(section: string): T | undefined;
+  inspect?<T>(section: string): ConfigurationInspection<T> | undefined;
+};
+
+type ConfigurationInspection<T> = {
+  defaultValue?: T;
+  globalValue?: T;
+  workspaceValue?: T;
+  workspaceFolderValue?: T;
+  defaultLanguageValue?: T;
+  globalLanguageValue?: T;
+  workspaceLanguageValue?: T;
+  workspaceFolderLanguageValue?: T;
 };
 
 function setting<T>(config: ConfigurationReader, section: string, fallback: T): T {
   return config.get<T>(section) ?? fallback;
 }
 
+function defaultQiheCommand(platform: NodeJS.Platform): string {
+  return platform === 'win32' ? 'qihe.bat' : 'qihe';
+}
+
+function hasConfiguredValue<T>(inspection: ConfigurationInspection<T> | undefined): boolean {
+  return (
+    inspection?.globalValue !== undefined ||
+    inspection?.workspaceValue !== undefined ||
+    inspection?.workspaceFolderValue !== undefined ||
+    inspection?.globalLanguageValue !== undefined ||
+    inspection?.workspaceLanguageValue !== undefined ||
+    inspection?.workspaceFolderLanguageValue !== undefined
+  );
+}
+
+function qiheCommandSetting(
+  config: ConfigurationReader,
+  section: string,
+  fallback: unknown,
+  platform: NodeJS.Platform,
+): string {
+  const command = setting(config, section, fallback);
+  if (typeof command !== 'string') {
+    return defaultQiheCommand(platform);
+  }
+
+  if (hasConfiguredValue(config.inspect?.<string>(section))) {
+    return command;
+  }
+
+  return command === fallback ? defaultQiheCommand(platform) : command;
+}
+
 export function serverInitializationOptions(
   config: ConfigurationReader,
+  platform: NodeJS.Platform = process.platform,
 ): Record<string, unknown> {
   const options: Record<string, unknown> = {};
 
   for (const configSetting of USER_CONFIG_SETTINGS) {
-    assignNestedValue(
-      options,
-      configSetting.path,
-      setting(config, configSetting.vscodeSection, configSetting.defaultValue),
-    );
+    const value =
+      configSetting.vscodeSection === 'qihe.command'
+        ? qiheCommandSetting(
+            config,
+            configSetting.vscodeSection,
+            configSetting.defaultValue,
+            platform,
+          )
+        : setting(config, configSetting.vscodeSection, configSetting.defaultValue);
+
+    assignNestedValue(options, configSetting.path, value);
   }
 
   return options;

--- a/editors/vscode/test/initializationOptions.test.ts
+++ b/editors/vscode/test/initializationOptions.test.ts
@@ -14,6 +14,14 @@ class TestConfiguration {
   }
 }
 
+class TestVscodeConfiguration extends TestConfiguration {
+  inspect<T>(section: string): { defaultValue?: T; globalValue?: T } | undefined {
+    return {
+      defaultValue: this.get<T>(section),
+    };
+  }
+}
+
 test('server initialization options include user configuration for startup', () => {
   const options = serverInitializationOptions(
     new TestConfiguration({
@@ -41,6 +49,22 @@ test('server initialization options include user configuration for startup', () 
   });
   assert.deepEqual(options.qihe, {
     command: 'custom-qihe',
+    autoConfigureArgsFromManifest: true,
+    compileArgs: [],
+    runArgs: ['-g', 'std'],
+  });
+});
+
+test('server initialization options treat the VS Code Qihe default as platform-owned', () => {
+  const options = serverInitializationOptions(
+    new TestVscodeConfiguration({
+      'qihe.command': 'qihe',
+    }),
+    'win32',
+  );
+
+  assert.deepEqual(options.qihe, {
+    command: 'qihe.bat',
     autoConfigureArgsFromManifest: true,
     compileArgs: [],
     runArgs: ['-g', 'std'],


### PR DESCRIPTION
Closes #96.

This change treats the VS Code-contributed `qihe` default as platform-owned, so Windows uses `qihe.bat` unless the user explicitly configures another command. It also updates the Qihe setting text and docs to document the Windows default.