### PR TITLE
feat(diagnostics): turn on warnings about width

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -309,7 +309,12 @@
           "items": {
             "type": "string"
           },
-          "default": [],
+          "default": [
+            "width-expand",
+            "width-trunc",
+            "port-width-expand",
+            "port-width-trunc"
+          ],
           "markdownDescription": "%configuration.diagnostics.slang.warnings.markdownDescription%"
         },
         "vide.diagnostics.slang.rules": {

--- a/editors/vscode/src/generated/configuration.ts
+++ b/editors/vscode/src/generated/configuration.ts
@@ -243,7 +243,7 @@ export const USER_CONFIG_SETTINGS = [
 		docsGroup: "Diagnostics",
 		descriptionKey: "configuration.diagnostics.slang.warnings.markdownDescription",
 		markdownDescriptionKey: "configuration.diagnostics.slang.warnings.markdownDescription",
-		defaultValue: [],
+		defaultValue: ["width-expand","width-trunc","port-width-expand","port-width-trunc"],
 	},
 	{
 		path: ["diagnostics","slang","rules"],

--- a/editors/vscode/test/initializationOptions.test.ts
+++ b/editors/vscode/test/initializationOptions.test.ts
@@ -43,7 +43,7 @@ test('server initialization options include user configuration for startup', () 
     parse: { enable: true },
     semantic: { enable: false },
     slang: {
-      warnings: [],
+      warnings: ['width-expand', 'width-trunc', 'port-width-expand', 'port-width-trunc'],
       rules: [{ selector: 'source:parse', severity: 'ignore' }],
     },
   });
@@ -90,7 +90,7 @@ test('diagnostics profiling initialization options reuse startup options with se
     parse: { enable: true },
     semantic: { enable: false },
     slang: {
-      warnings: [],
+      warnings: ['width-expand', 'width-trunc', 'port-width-expand', 'port-width-trunc'],
       rules: [],
     },
   });

--- a/schemas/v1/user-config.schema.json
+++ b/schemas/v1/user-config.schema.json
@@ -114,7 +114,12 @@
           "enable": true
         },
         "slang": {
-          "warnings": [],
+          "warnings": [
+            "width-expand",
+            "width-trunc",
+            "port-width-expand",
+            "port-width-trunc"
+          ],
           "rules": []
         }
       }
@@ -527,7 +532,12 @@
         "slang": {
           "$ref": "#/$defs/SlangDiagnosticsUserConfig",
           "default": {
-            "warnings": [],
+            "warnings": [
+              "width-expand",
+              "width-trunc",
+              "port-width-expand",
+              "port-width-trunc"
+            ],
             "rules": []
           }
         }
@@ -560,7 +570,12 @@
           "items": {
             "type": "string"
           },
-          "default": []
+          "default": [
+            "width-expand",
+            "width-trunc",
+            "port-width-expand",
+            "port-width-trunc"
+          ]
         },
         "rules": {
           "description": "Per-diagnostic severity overrides.",

--- a/src/config/user_config.rs
+++ b/src/config/user_config.rs
@@ -25,6 +25,8 @@ use super::Config;
 
 const DEFAULT_QIHE_COMMAND: &str = "qihe";
 const DEFAULT_QIHE_RUN_ARGS: &[&str] = &["-g", "std"];
+const DEFAULT_SLANG_WIDTH_WARNINGS: &[&str] =
+    &["width-expand", "width-trunc", "port-width-expand", "port-width-trunc"];
 const USER_CONFIG_SCHEMA_FIELD: &str = "$schema";
 #[cfg(feature = "user-config-schema")]
 const USER_CONFIG_SCHEMA_URL: &str =
@@ -484,7 +486,7 @@ impl Default for DiagnosticsPhaseUserConfig {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "user-config-schema", derive(schemars::JsonSchema))]
 #[serde(default, deny_unknown_fields)]
 #[cfg_attr(feature = "user-config-schema", schemars(deny_unknown_fields))]
@@ -493,7 +495,7 @@ pub(crate) struct SlangDiagnosticsUserConfig {
         feature = "user-config-schema",
         schemars(
             description = "Additional slang warning groups or aliases to enable.",
-            default = "empty_string_vec"
+            default = "default_slang_width_warnings"
         )
     )]
     pub(crate) warnings: Vec<String>,
@@ -502,6 +504,16 @@ pub(crate) struct SlangDiagnosticsUserConfig {
         schemars(description = "Per-diagnostic severity overrides.")
     )]
     pub(crate) rules: Vec<DiagnosticRuleUserConfig>,
+}
+
+impl Default for SlangDiagnosticsUserConfig {
+    fn default() -> Self {
+        Self { warnings: default_slang_width_warnings(), rules: Vec::new() }
+    }
+}
+
+fn default_slang_width_warnings() -> Vec<String> {
+    DEFAULT_SLANG_WIDTH_WARNINGS.iter().map(|warning| (*warning).to_owned()).collect()
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -1097,7 +1109,7 @@ const USER_CONFIG_SETTINGS: &[ConfigSettingMeta] = &[
         ),
         enum_descriptions: &[],
         exposed_in_vscode: true,
-        default: ConfigSettingDefault::StringArray(&[]),
+        default: ConfigSettingDefault::StringArray(DEFAULT_SLANG_WIDTH_WARNINGS),
         schema: ConfigSettingSchema::StringArray,
     },
     ConfigSettingMeta {
@@ -1563,6 +1575,10 @@ fn check_default() {
     let mut errors = vec![];
     let user_cfg = UserConfig::from_json(json, &mut errors);
     assert_eq!(user_cfg, UserConfig::default());
+    assert_eq!(
+        user_cfg.diagnostics_config().slang.warnings,
+        ["width-expand", "width-trunc", "port-width-expand", "port-width-trunc"]
+    );
 }
 
 #[test]
@@ -1590,6 +1606,22 @@ fn parses_nested_diagnostics_config() {
     assert!(!config.semantic.enabled);
     assert_eq!(config.slang.warnings, ["default", "no-unused"]);
     assert_eq!(config.slang.rules.len(), 2);
+}
+
+#[test]
+fn explicit_empty_slang_warnings_override_defaults() {
+    let json = serde_json::json!({
+        "diagnostics": {
+            "slang": {
+                "warnings": []
+            }
+        }
+    });
+    let mut errors = vec![];
+    let user_cfg = UserConfig::from_json(json, &mut errors);
+    assert!(errors.is_empty(), "{errors:?}");
+
+    assert!(user_cfg.diagnostics_config().slang.warnings.is_empty());
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -750,6 +750,10 @@ fn code_action_titles(actions: &[CodeActionOrCommand]) -> Vec<String> {
         .collect()
 }
 
+fn diagnostic_option(diagnostic: &lsp_types::Diagnostic) -> Option<&str> {
+    diagnostic.data.as_ref()?.get("option")?.as_str()
+}
+
 #[test]
 fn clearing_open_document_updates_analysis_state() {
     let text = "module stale_after_clear;\nendmodule\n";
@@ -794,6 +798,63 @@ fn clearing_open_document_updates_analysis_state() {
     };
 
     assert_eq!(symbol_count, 0, "cleared documents must not expose stale symbols");
+
+    shutdown_test_server(&client, server_thread);
+}
+
+#[test]
+fn default_diagnostics_warn_on_port_width_mismatch() {
+    let text = "\
+module width_child(input logic [3:0] a);
+endmodule
+
+module top;
+  logic [7:0] wide;
+  width_child u(.a(wide));
+endmodule
+";
+    let (_temp_dir, client, server_thread, uri) = setup_configured_diagnostics_test(
+        ClientCapabilities::default(),
+        UserConfig::default(),
+        text,
+    );
+
+    let (_result_id, diagnostics) = request_document_diagnostics(&client, uri, 190);
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic_option(diagnostic) == Some("port-width-trunc")),
+        "expected default port width warning, got {diagnostics:?}"
+    );
+
+    shutdown_test_server(&client, server_thread);
+}
+
+#[test]
+fn explicit_empty_slang_warnings_suppress_port_width_mismatch_warning() {
+    let text = "\
+module width_child(input logic [3:0] a);
+endmodule
+
+module top;
+  logic [7:0] wide;
+  width_child u(.a(wide));
+endmodule
+";
+    let mut user_config = UserConfig::default();
+    user_config.diagnostics.slang.warnings = Vec::new();
+    let (_temp_dir, client, server_thread, uri) =
+        setup_configured_diagnostics_test(ClientCapabilities::default(), user_config, text);
+
+    let (_result_id, diagnostics) = request_document_diagnostics(&client, uri, 191);
+
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic_option(diagnostic) != Some("port-width-trunc")),
+        "explicit empty warnings should suppress port width warning, got {diagnostics:?}"
+    );
 
     shutdown_test_server(&client, server_thread);
 }


### PR DESCRIPTION
## Summary
- 将 `diagnostics.slang.warnings` 的默认值改为开启 `width-expand`、`width-trunc`、`port-width-expand`、`port-width-trunc`
- 同步更新 VS Code 生成配置和 `user-config` schema，确保编辑器展示和运行时默认一致
- 增加回归测试，覆盖默认告警生效和显式空配置可关闭告警这两条路径

## Testing
- `cargo test -p vide`
- `cargo xtask check-config-artifacts`
- `cargo xtask check-schemas`