### PR TITLE
docs: improve language switcher label

### DIFF
--- a/docs/src/assets/landing.css
+++ b/docs/src/assets/landing.css
@@ -51,6 +51,38 @@
   white-space: nowrap;
 }
 
+starlight-lang-select label {
+  --vide-language-label-width: 9.5em;
+}
+
+starlight-lang-select label::after {
+  content: '语言/Languages';
+  position: absolute;
+  inset-inline-start: calc(var(--sl-label-icon-size) + var(--sl-inline-padding) + 0.25rem);
+  inset-inline-end: calc(var(--sl-caret-size) + var(--sl-inline-padding) + 0.25rem);
+  top: 50%;
+  transform: translateY(-50%);
+  color: inherit;
+  line-height: 1;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+starlight-lang-select select {
+  width: calc(var(--vide-language-label-width) + var(--sl-inline-padding) * 2);
+  color: transparent;
+}
+
+starlight-lang-select option {
+  color: var(--sl-color-gray-1);
+}
+
+@media (min-width: 50rem) {
+  starlight-lang-select label::after {
+    font-size: var(--sl-text-sm);
+  }
+}
+
 @media (max-width: 57.999rem) {
   .title-wrapper .site-title + ul {
     display: none;


### PR DESCRIPTION
Keeps Starlight's existing language selector and translate icon. The closed selector displays `语言/Languages`, while the dropdown options stay `简体中文` and `English`.

Validated with `git diff --check` and `npm --prefix docs run build`.