### PR TITLE
fix(docs): keep language selector caret inside control

### DIFF
--- a/docs/src/assets/landing.css
+++ b/docs/src/assets/landing.css
@@ -61,7 +61,7 @@ starlight-lang-select label::after {
   grid-area: 1 / 1;
   padding-block: 0.625rem;
   padding-inline: calc(var(--sl-label-icon-size) + var(--sl-inline-padding) + 0.25rem)
-    calc(var(--sl-caret-size) + var(--sl-inline-padding) + 0.25rem);
+    calc(var(--sl-caret-size) + var(--sl-inline-padding) + var(--sl-inline-padding) + 0.25rem);
   color: inherit;
   line-height: 1;
   pointer-events: none;
@@ -72,6 +72,10 @@ starlight-lang-select select {
   grid-area: 1 / 1;
   width: 100%;
   color: transparent;
+}
+
+starlight-lang-select .caret {
+  inset-inline-end: var(--sl-inline-padding);
 }
 
 starlight-lang-select option {


### PR DESCRIPTION
## Summary
- Move the documentation language selector caret into the control's inline padding.
- Reserve matching right-side gutter for the bilingual label so the caret is not clipped when the native select is focused or opened.

## Validation
- `git diff --check origin/master..HEAD`
- Visual check of the language selector dropdown