### PR TITLE
fix(release): avoid pipefail in manylinux version logs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,11 +175,11 @@ jobs:
 
           rustc --version
           cargo --version
-          g++ --version | head -n 1
+          g++ -dumpfullversion -dumpversion
           cargo build --release
 
           server="${CARGO_TARGET_DIR}/release/vide"
-          ldd --version | head -n 1
+          ldd --version
           ldd "$server"
           "$server" --version
           if readelf -V "$server" | grep -E 'Name: GLIBC_2\.([2-9][0-9]|1[89])\b|Name: GLIBCXX_3\.4\.([2-9][0-9]|1[0-9][0-9])\b|Name: CXXABI_1\.3\.([89]|[1-9][0-9])\b'; then


### PR DESCRIPTION
## Summary

- Remove fragile pipes from version logging inside the manylinux2014 release build script.
- Keep the actual readelf compatibility check that verifies the linux-x64 server does not require symbols newer than the CentOS 7 baseline.
- Fix the release job exit 141 caused by pipefail and SIGPIPE from head.

## Validation

- `actionlint .github/workflows/release.yml`
- `git diff --check`