### PR TITLE
fix(release): use English changelog for release body

### DIFF
--- a/docs/scripts/release-body-from-changelog.mjs
+++ b/docs/scripts/release-body-from-changelog.mjs
@@ -33,12 +33,12 @@ if (!values.tag || !values.output) {
 const tag = values.tag;
 const output = values.output;
 const page = tag.replaceAll('.', '-');
-const sourceDir = `changelog/${page}`;
+const sourceDir = `en/changelog/${page}`;
 const source = path.posix.join(docsRoot, sourceDir, 'index.mdx');
 
 if (!fs.existsSync(source)) {
   console.error(`Missing ${source}`);
-  console.error(`Add a changelog page for ${tag} before publishing the release.`);
+  console.error(`Add an English changelog page for ${tag} before publishing the release.`);
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary

- Generate GitHub Release descriptions from the English changelog page.
- Keep docs changelog pages bilingual, but use the English page for release notes because GitHub Releases are the public package-facing surface.
- Keep Markdown processing through the existing AST-based release body script.

## Validation

- `node docs/scripts/release-body-from-changelog.mjs --tag v1.1.0 --output ...`
- `git diff --check`