### PR TITLE
fix: keep workspace snapshots self-consistent

### DIFF
--- a/crates/ide/src/analysis.rs
+++ b/crates/ide/src/analysis.rs
@@ -66,6 +66,10 @@ impl Analysis {
         self.with_db(|db| db.file_text(file_id))
     }
 
+    pub fn file_ids(&self) -> Cancellable<Vec<FileId>> {
+        self.with_db(|db| db.files().iter().copied().collect())
+    }
+
     pub fn diagnostics(&self, file_id: FileId) -> Cancellable<Vec<diagnostics::Diagnostic>> {
         self.with_db(|db| diagnostics::diagnostics(db, file_id))
     }

--- a/src/global_state/snapshot.rs
+++ b/src/global_state/snapshot.rs
@@ -389,8 +389,7 @@ impl GlobalStateSnapshot {
     }
 
     pub(crate) fn file_ids(&self) -> Vec<FileId> {
-        let vfs = self.vfs.read();
-        vfs.0.iter().map(|(file_id, _)| file_id).collect()
+        self.analysis.file_ids().unwrap_or_default()
     }
 
     /// Returns the VFS primary URI for a file.
@@ -452,5 +451,61 @@ impl GlobalStateSnapshot {
     pub(crate) fn url_file_version(&self, url: &Url) -> Option<i32> {
         let path = from_proto::vfs_path(url).ok()?;
         self.mem_docs.version_for_path(&path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lsp_server::Connection;
+    use lsp_types::{ClientCapabilities, TraceValue};
+    use utils::{lines::LineEnding, test_support::TestDir};
+    use vfs::{FileId, VfsPath, loader::LoadResult};
+
+    use crate::{
+        Opt,
+        config::{self, user_config::UserConfig},
+        global_state::GlobalState,
+        i18n::I18n,
+    };
+
+    #[test]
+    fn snapshot_file_ids_stay_in_analysis_snapshot() {
+        let root = TestDir::new("snapshot-file-ids-analysis-boundary");
+        let root_path = root.path().to_path_buf();
+        let config = config::Config::new(
+            Opt {
+                process_name: "vide-test".to_string(),
+                log: "error".to_string(),
+                log_filename: None,
+                profile_trace: None,
+            },
+            root_path.clone(),
+            ClientCapabilities::default(),
+            vec![root_path],
+            I18n::default(),
+            UserConfig::default(),
+            Vec::new(),
+        );
+        let (server, _client) = Connection::memory();
+        let mut state = GlobalState::new(server.sender, config, TraceValue::Off);
+
+        state.vfs.write().0.set_file_contents(
+            &VfsPath::from(root.join("top.sv")),
+            LoadResult::Loaded("module top; endmodule\n".to_owned(), LineEnding::Unix),
+        );
+        assert!(state.process_changes());
+        let snapshot = state.make_snapshot();
+
+        state.vfs.write().0.set_file_contents(
+            &VfsPath::from(root.join("child.sv")),
+            LoadResult::Loaded("module child; endmodule\n".to_owned(), LineEnding::Unix),
+        );
+
+        let mut live_file_ids =
+            state.vfs.read().0.iter().map(|(file_id, _)| file_id).collect::<Vec<_>>();
+        live_file_ids.sort_unstable_by_key(|file_id| file_id.0);
+        assert_eq!(live_file_ids, vec![FileId(0), FileId(1)]);
+
+        assert_eq!(snapshot.file_ids(), vec![FileId(0)]);
     }
 }


### PR DESCRIPTION
## Summary
- Read workspace file ids from the analysis snapshot instead of the live VFS.
- Add a regression test that proves an existing snapshot is not polluted by later VFS file additions.

## Root Cause
A workspace request could capture an old analysis snapshot, then read file ids from the live VFS after a file rename had added a new `FileId`. Passing that new id into the old salsa snapshot caused `source_root_id` to panic because the snapshot had no value for it.

## Validation
- `cargo fmt --check`
- `cargo test -p vide snapshot_file_ids_stay_in_analysis_snapshot -- --nocapture`
- `cargo test -p vide workspace_file_rename_updates_symbol_and_definition_locations -- --nocapture`
- `cargo test -p vide --lib -- --nocapture`
- `cargo test -p ide --lib`
- `git diff --check`