### PR TITLE
fix(vscode): use C++ linker for Alpine packaging

### DIFF
--- a/crates/slang/bindings/rust/build.rs
+++ b/crates/slang/bindings/rust/build.rs
@@ -66,6 +66,13 @@ fn build_cpp_lib(cxxbridge_dir: &Path, debug: bool) -> PathBuf {
             .define("CMAKE_CXX_COMPILER_LAUNCHER", launcher.as_ref());
     }
 
+    if let Some(linker_flags) = target_linker_flags() {
+        config
+            .define("CMAKE_EXE_LINKER_FLAGS", linker_flags.as_str())
+            .define("CMAKE_SHARED_LINKER_FLAGS", linker_flags.as_str())
+            .define("CMAKE_MODULE_LINKER_FLAGS", linker_flags.as_str());
+    }
+
     if !emscripten && !debug && cfg!(target_env = "msvc") {
         // cmake-rs still sets config-specific MSVC flags for Visual Studio
         // generators to preserve /MD or /MT. That replaces CMake's built-in
@@ -79,6 +86,10 @@ fn build_cpp_lib(cxxbridge_dir: &Path, debug: bool) -> PathBuf {
     }
 
     config.build()
+}
+
+fn target_linker_flags() -> Option<String> {
+    env::var("TARGET_LDFLAGS").ok().filter(|flags| !flags.trim().is_empty())
 }
 
 fn cmake_sccache_launcher() -> Option<PathBuf> {

--- a/editors/vscode/scripts/package.ts
+++ b/editors/vscode/scripts/package.ts
@@ -110,6 +110,49 @@ function cargoBuildArgs(profile: BuildProfile, cargoTarget?: string): string[] {
   return args;
 }
 
+function cargoTargetEnvName(cargoTarget: string): string {
+  return cargoTarget.toUpperCase().replace(/-/g, '_');
+}
+
+function cargoTargetLinkerEnvKey(cargoTarget: string): string {
+  return `CARGO_TARGET_${cargoTargetEnvName(cargoTarget)}_LINKER`;
+}
+
+function cxxCompilerEnvKey(cargoTarget: string): string {
+  return `CXX_${cargoTarget.replace(/-/g, '_')}`;
+}
+
+function cargoLinkerForTarget(target: PlatformFolder, cargoTarget: string): string | undefined {
+  if (!target.startsWith('alpine-')) {
+    return undefined;
+  }
+
+  return (
+    optionalEnv(cxxCompilerEnvKey(cargoTarget)) ??
+    optionalEnv('TARGET_CXX') ??
+    `${cargoTarget}-g++`
+  );
+}
+
+function cargoBuildEnv(target: PlatformFolder, cargoTarget?: string): NodeJS.ProcessEnv {
+  if (!cargoTarget) {
+    return process.env;
+  }
+
+  const linkerEnvKey = cargoTargetLinkerEnvKey(cargoTarget);
+  if (optionalEnv(linkerEnvKey)) {
+    return process.env;
+  }
+
+  const linker = cargoLinkerForTarget(target, cargoTarget);
+  if (!linker) {
+    return process.env;
+  }
+
+  console.log(`Using Cargo linker for ${cargoTarget}: ${linker}`);
+  return { ...process.env, [linkerEnvKey]: linker };
+}
+
 function cargoOutputDir(profile: BuildProfile, cargoTarget?: string): string {
   const pathParts = [repoRoot, 'target'];
   if (cargoTarget) {
@@ -155,7 +198,12 @@ function ensureTargetServerBinary(
     run('rustup', ['target', 'add', cargoTarget], repoRoot);
   }
 
-  run('cargo', cargoBuildArgs(profile, cargoTarget), repoRoot);
+  run(
+    'cargo',
+    cargoBuildArgs(profile, cargoTarget),
+    repoRoot,
+    cargoBuildEnv(target, cargoTarget),
+  );
 
   const sourcePath = path.join(cargoOutputDir(profile, cargoTarget), binFile);
   const destPath = path.join(serverOutDir, binFile);

--- a/editors/vscode/scripts/package.ts
+++ b/editors/vscode/scripts/package.ts
@@ -134,23 +134,57 @@ function cargoLinkerForTarget(target: PlatformFolder, cargoTarget: string): stri
   );
 }
 
+function lateRustLinkFlagsForTarget(target: PlatformFolder): string[] {
+  if (!target.startsWith('alpine-')) {
+    return [];
+  }
+
+  // Static libstdc++ can introduce libc references after rustc's own musl -lc.
+  return ['-C', 'link-arg=-lc'];
+}
+
+function appendRustFlags(env: NodeJS.ProcessEnv, flags: string[]): NodeJS.ProcessEnv {
+  if (flags.length === 0) {
+    return env;
+  }
+
+  const encodedFlags = env.CARGO_ENCODED_RUSTFLAGS;
+  if (encodedFlags) {
+    return {
+      ...env,
+      CARGO_ENCODED_RUSTFLAGS: `${encodedFlags}\x1f${flags.join('\x1f')}`,
+    };
+  }
+
+  const rustFlags = env.RUSTFLAGS?.trim();
+  return {
+    ...env,
+    RUSTFLAGS: rustFlags ? `${rustFlags} ${flags.join(' ')}` : flags.join(' '),
+  };
+}
+
 function cargoBuildEnv(target: PlatformFolder, cargoTarget?: string): NodeJS.ProcessEnv {
   if (!cargoTarget) {
     return process.env;
   }
 
+  let env = process.env;
   const linkerEnvKey = cargoTargetLinkerEnvKey(cargoTarget);
-  if (optionalEnv(linkerEnvKey)) {
-    return process.env;
+  if (!optionalEnv(linkerEnvKey)) {
+    const linker = cargoLinkerForTarget(target, cargoTarget);
+    if (linker) {
+      console.log(`Using Cargo linker for ${cargoTarget}: ${linker}`);
+      env = { ...env, [linkerEnvKey]: linker };
+    }
   }
 
-  const linker = cargoLinkerForTarget(target, cargoTarget);
-  if (!linker) {
-    return process.env;
+  const lateLinkArgs = lateRustLinkFlagsForTarget(target);
+  if (lateLinkArgs.length > 0) {
+    console.log(`Adding Cargo link args for ${cargoTarget}: ${lateLinkArgs.join(' ')}`);
+    env = appendRustFlags(env, lateLinkArgs);
   }
 
-  console.log(`Using Cargo linker for ${cargoTarget}: ${linker}`);
-  return { ...process.env, [linkerEnvKey]: linker };
+  return env;
 }
 
 function cargoOutputDir(profile: BuildProfile, cargoTarget?: string): string {


### PR DESCRIPTION
This change makes Alpine server packaging use the musl C++ driver as Cargo's target linker when no Cargo linker override is already configured. It also passes target linker flags through the Slang CMake build and adds a late musl libc link arg for Alpine packaging, so the C++ static runtime and musl libc dependencies are closed without changing non-Alpine targets.