### PR TITLE
fix(ide): align inactive branch semantics

### DIFF
--- a/crates/hir/src/base_db/source_db.rs
+++ b/crates/hir/src/base_db/source_db.rs
@@ -209,10 +209,15 @@ fn syntax_tree_options_for_file(
     file_id: FileId,
 ) -> syntax::SyntaxTreeOptions {
     let _span = tracing::info_span!("slang.syntax_tree_options.file", ?file_id).entered();
-    let project_config = db.project_config();
+    let preprocess = db.file_preprocess_config(file_id);
     let profile_id = db.file_compilation_profile(file_id);
     let include_buffers = db.include_buffers_for_profile(profile_id).as_ref().clone();
-    syntax_tree_options_for_profile(&project_config, profile_id, include_buffers)
+    syntax::SyntaxTreeOptions {
+        predefines: preprocess.predefines.clone(),
+        include_paths: preprocess.include_dir_strings(),
+        include_buffers,
+        ..syntax::SyntaxTreeOptions::default()
+    }
 }
 
 fn syntax_tree_options_for_profile(

--- a/crates/hir/src/db.rs
+++ b/crates/hir/src/db.rs
@@ -2,7 +2,7 @@ use syntax::SyntaxTree;
 use triomphe::Arc;
 
 use crate::{
-    base_db::{salsa, source_db::SourceDb},
+    base_db::{salsa, source_db::SourceRootDb},
     file::HirFileId,
     hir_def::{
         block::{self, Block, BlockId, BlockLoc, BlockSourceMap},
@@ -26,7 +26,7 @@ pub(crate) macro impl_intern($id:ident, $loc:ident, $intern:ident, $lookup:ident
 }
 
 #[salsa::query_group(InternDbStorage)]
-pub trait InternDb: SourceDb {
+pub trait InternDb: SourceRootDb {
     #[salsa::interned]
     fn intern_ty(&self, ty: BuiltinDataTy) -> BuiltinDataTyId;
 
@@ -106,7 +106,7 @@ pub trait HirDb: InternDb {
 }
 
 fn parse(db: &dyn HirDb, file_id: HirFileId) -> SyntaxTree {
-    db.parse_src(file_id.file_id())
+    db.parse_src_for_compilation(file_id.file_id())
 }
 
 fn hir_file(db: &dyn HirDb, file_id: HirFileId) -> Arc<HirFile> {

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -110,7 +110,8 @@ impl<'db> SemanticsImpl<'db> {
     }
 
     pub fn parse_file(&self, file_id: FileId) -> ParsedFile {
-        ParsedFile { file_id: file_id.into(), tree: self.db.parse_src(file_id) }
+        let file_id = file_id.into();
+        ParsedFile { file_id, tree: self.db.parse(file_id) }
     }
 
     pub fn container_for_node(&self, file_id: HirFileId, node: SyntaxNode) -> Option<ContainerId> {

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -446,7 +446,12 @@ mod tests {
         source_root::{SourceRoot, SourceRootId, SourceRootRole},
     };
     use triomphe::Arc;
-    use utils::{lines::LineEnding, paths::AbsPathBuf, test_support::TestDir};
+    use utils::{
+        line_index::{TextRange, TextSize},
+        lines::LineEnding,
+        paths::AbsPathBuf,
+        test_support::TestDir,
+    };
     use vfs::{ChangeKind, ChangedFile, FileId, FileSet, VfsPath};
 
     use super::{
@@ -457,6 +462,15 @@ mod tests {
 
     fn db_with_files(files: &[(&str, &str)], configured: bool) -> RootDb {
         db_with_files_in_role(files, SourceRootRole::Local, configured)
+    }
+
+    fn db_with_predefines(files: &[(&str, &str)], predefines: Vec<String>) -> RootDb {
+        db_with_files_in_role_and_preprocess(
+            files,
+            SourceRootRole::Local,
+            true,
+            PreprocessConfig { predefines, ..PreprocessConfig::default() },
+        )
     }
 
     fn disable_diagnostics(db: &mut RootDb) {
@@ -470,6 +484,15 @@ mod tests {
         files: &[(&str, &str)],
         role: SourceRootRole,
         configured: bool,
+    ) -> RootDb {
+        db_with_files_in_role_and_preprocess(files, role, configured, PreprocessConfig::default())
+    }
+
+    fn db_with_files_in_role_and_preprocess(
+        files: &[(&str, &str)],
+        role: SourceRootRole,
+        configured: bool,
+        preprocess: PreprocessConfig,
     ) -> RootDb {
         let mut db = RootDb::new(None);
         let mut file_set = FileSet::default();
@@ -492,12 +515,17 @@ mod tests {
                 vec![CompilationProfile {
                     source_roots: vec![SourceRootId(0)],
                     top_modules: Vec::new(),
-                    preprocess: PreprocessConfig::default(),
+                    preprocess,
                 }],
             )));
         }
         db.apply_change(change);
         db
+    }
+
+    fn range_of(text: &str, needle: &str) -> TextRange {
+        let start = TextSize::from(u32::try_from(text.find(needle).unwrap()).unwrap());
+        TextRange::new(start, start + TextSize::of(needle))
     }
 
     #[test]
@@ -590,10 +618,8 @@ mod tests {
 
     #[test]
     fn inactive_preprocessor_branch_reports_unnecessary_hint() {
-        let db = db_with_files(
-            &[("/top.sv", "`ifdef USE_IMPL\nlogic active;\n`else\nlogic inactive;\n`endif\n")],
-            false,
-        );
+        let text = "`ifdef USE_IMPL\nlogic if_body;\n`else\nlogic else_body;\n`endif\n";
+        let db = db_with_files(&[("/top.sv", text)], false);
 
         let diagnostics = diagnostics(&db, FileId(0));
         let inactive = diagnostics
@@ -604,6 +630,21 @@ mod tests {
         assert_eq!(inactive.severity, syntax::DiagnosticSeverity::Note);
         assert_eq!(inactive.tags, vec![DiagnosticTag::Unnecessary]);
         assert_eq!(inactive.message_key, Some(DIAGNOSTIC_INACTIVE_PREPROCESSOR_BRANCH));
+        assert_eq!(inactive.range, range_of(text, "logic if_body;"));
+    }
+
+    #[test]
+    fn inactive_preprocessor_branch_marks_else_body_when_ifdef_is_defined() {
+        let text = "`ifdef USE_IMPL\nlogic if_body;\n`else\nlogic else_body;\n`endif\n";
+        let db = db_with_predefines(&[("/top.sv", text)], vec!["USE_IMPL".to_owned()]);
+
+        let diagnostics = diagnostics(&db, FileId(0));
+        let inactive = diagnostics
+            .iter()
+            .find(|diag| diag.name == INACTIVE_PREPROCESSOR_BRANCH.name)
+            .expect("expected inactive preprocessor branch diagnostic");
+
+        assert_eq!(inactive.range, range_of(text, "logic else_body;"));
     }
 
     #[test]

--- a/crates/ide/src/verilog_2005.rs
+++ b/crates/ide/src/verilog_2005.rs
@@ -8,6 +8,7 @@ use hir::{
     base_db::{
         change::Change,
         project::{CompilationProfile, CompilationProfileId, PreprocessConfig, ProjectConfig},
+        salsa::Durability,
         source_db::SourceDb,
         source_root::{SourceRoot, SourceRootId},
     },
@@ -913,6 +914,190 @@ endmodule
     assert!(
         !ranges.contains(&inactive_ref),
         "inactive reference should not be classified as the active definition: {ranges:?}"
+    );
+}
+
+#[test]
+fn file_preprocess_config_selects_same_ifdef_branch_for_diagnostics_and_navigation() {
+    let text = r#"
+module ifdef_nav(
+  input logic clk_i,
+  input logic /*marker:def*/d_i,
+  output logic q
+);
+`ifdef SOMETHING
+/*marker:if_branch*/  always @(posedge clk_i) q <= ~/*marker:if_ref*/d_i;
+`else
+/*marker:else_branch*/  always @(posedge clk_i) q <= /*marker:else_ref*/d_i;
+`endif
+endmodule
+"#;
+    let (mut host, file_id, _clean_text, markers) =
+        setup_marked_with_predefines(text, vec!["SOMETHING=1".to_owned()]);
+    host.raw_db_mut().set_file_preprocess_config_with_durability(
+        file_id,
+        Arc::new(PreprocessConfig::default()),
+        Durability::LOW,
+    );
+
+    let analysis = host.make_analysis();
+    let range_at = |marker: &str, len: TextSize| {
+        let start = markers[marker];
+        TextRange::new(start, start + len)
+    };
+    let d_i_range = range_at("def", TextSize::of("d_i"));
+    let if_branch = range_at("if_branch", TextSize::of("  always @(posedge clk_i) q <= ~d_i;"));
+    let else_branch = range_at("else_branch", TextSize::of("  always @(posedge clk_i) q <= d_i;"));
+
+    let diagnostics = analysis.diagnostics(file_id).unwrap();
+    let inactive = diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.name == "inactive-preprocessor-branch")
+        .expect("expected inactive branch diagnostic");
+    assert!(
+        inactive.range.intersect(if_branch).is_some(),
+        "file-level preprocess should mark the if branch inactive: {diagnostics:?}"
+    );
+    assert!(
+        inactive.range.intersect(else_branch).is_none(),
+        "file-level preprocess should keep the else branch semantically active: {diagnostics:?}"
+    );
+
+    assert!(
+        analysis.goto_definition(position(file_id, &markers, "if_ref")).unwrap().is_none(),
+        "inactive if branch should not drive semantic navigation"
+    );
+
+    let nav = analysis
+        .goto_definition(position(file_id, &markers, "else_ref"))
+        .unwrap()
+        .expect("active else branch should navigate");
+    assert!(
+        nav.info.iter().any(|target| target.focus_range == Some(d_i_range)),
+        "active else branch should resolve d_i to the port definition: {nav:?}"
+    );
+}
+
+#[test]
+fn included_macro_selects_same_ifdef_branch_for_diagnostics_navigation_and_tokens() {
+    let dir = TestDir::new("issue-233-include-ifdef");
+    let src_dir = dir.path().join("src");
+    std::fs::create_dir_all(&src_dir).unwrap();
+
+    let top_path = src_dir.join("top.v");
+    let define_path = src_dir.join("define.vh");
+    let marked_top_text = normalize_fixture_text(
+        r#"
+`include "define.vh"
+
+module top (
+    input  wire clk_i,
+    input  wire /*marker:def*/d_i,
+    output wire q_o
+);
+
+reg q = 0;
+
+`ifdef SOMETHING
+/*marker:if_branch*/  always @(posedge clk_i) q <= ~/*marker:if_ref*/d_i;
+`else
+/*marker:else_branch*/  always @(posedge clk_i) q <= /*marker:else_ref*/d_i;
+`endif
+
+assign q_o = q;
+
+endmodule
+"#,
+    );
+    let (top_text, markers) = strip_markers(marked_top_text);
+    let define_text =
+        "`ifndef __DEFINE_VH__\n`define __DEFINE_VH__\n\n`define SOMETHING\n\n`endif\n";
+    std::fs::write(&top_path, &top_text).unwrap();
+    std::fs::write(&define_path, define_text).unwrap();
+
+    let top_file_id = FileId(0);
+    let define_file_id = FileId(1);
+    let mut file_set = FileSet::default();
+    file_set.insert(top_file_id, VfsPath::from(top_path));
+    file_set.insert(define_file_id, VfsPath::from(define_path));
+
+    let mut change = Change::new();
+    change.set_roots(vec![SourceRoot::new_local(file_set)]);
+    change.set_project_config(Arc::new(ProjectConfig::new(
+        vec![Some(CompilationProfileId(0))],
+        vec![CompilationProfile {
+            source_roots: vec![SourceRootId(0)],
+            top_modules: Vec::new(),
+            preprocess: PreprocessConfig {
+                predefines: Vec::new(),
+                include_dirs: vec![src_dir.clone()],
+            },
+        }],
+    )));
+    change.add_changed_file(ChangedFile {
+        file_id: top_file_id,
+        change_kind: ChangeKind::Create(Arc::from(top_text.as_str()), LineEnding::Unix),
+    });
+    change.add_changed_file(ChangedFile {
+        file_id: define_file_id,
+        change_kind: ChangeKind::Create(Arc::from(define_text), LineEnding::Unix),
+    });
+
+    let mut host = AnalysisHost::default();
+    host.apply_change(change);
+    let analysis = host.make_analysis();
+    let range_at = |marker: &str, len: TextSize| {
+        let start = markers[marker];
+        TextRange::new(start, start + len)
+    };
+    let d_i_range = range_at("def", TextSize::of("d_i"));
+    let if_ref = range_at("if_ref", TextSize::of("d_i"));
+    let else_ref = range_at("else_ref", TextSize::of("d_i"));
+    let if_branch = range_at("if_branch", TextSize::of("  always @(posedge clk_i) q <= ~d_i;"));
+    let else_branch = range_at("else_branch", TextSize::of("  always @(posedge clk_i) q <= d_i;"));
+
+    let diagnostics = analysis.diagnostics(top_file_id).unwrap();
+    let inactive = diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.name == "inactive-preprocessor-branch")
+        .expect("expected inactive branch diagnostic");
+    assert!(
+        inactive.range.intersect(else_branch).is_some(),
+        "included define should mark the else branch inactive: {diagnostics:?}"
+    );
+    assert!(
+        inactive.range.intersect(if_branch).is_none(),
+        "included define should keep the if branch active: {diagnostics:?}"
+    );
+
+    let nav = analysis
+        .goto_definition(position(top_file_id, &markers, "if_ref"))
+        .unwrap()
+        .expect("active if branch should navigate");
+    assert!(
+        nav.info.iter().any(|target| target.focus_range == Some(d_i_range)),
+        "active if branch should resolve d_i to the port definition: {nav:?}"
+    );
+    assert!(
+        analysis.goto_definition(position(top_file_id, &markers, "else_ref")).unwrap().is_none(),
+        "inactive else branch should not drive semantic navigation"
+    );
+
+    let full_range = TextRange::up_to(TextSize::of(top_text.as_str()));
+    let tokens = analysis
+        .semantic_tokens(
+            top_file_id,
+            SemaTokenConfig { port: SemaTokenPortConfig { clk_rst: true, io: true } },
+            Some(full_range),
+        )
+        .unwrap();
+    assert!(
+        tokens.iter().any(|token| token.range == if_ref && !token.is_empty()),
+        "active if branch should produce a semantic token for d_i: {tokens:?}"
+    );
+    assert!(
+        tokens.iter().all(|token| token.range != else_ref || token.is_empty()),
+        "inactive else branch must not produce semantic tokens for d_i: {tokens:?}"
     );
 }
 


### PR DESCRIPTION
Closes #233.

## Summary
- use the per-file effective preprocess config when building syntax options for file-scoped IDE/HIR queries
- parse HIR semantic files through the include-aware compilation parse path so included macro definitions select the same `ifdef` branch for diagnostics, navigation, and semantic tokens
- add regressions for both manifest predefines and included-header defines driving inactive branch behavior

## Validation
- `cargo test -p hir preproc -- --nocapture`
- `cargo test -p ide preproc -- --nocapture`
- `cargo test -p ide included_macro_selects_same_ifdef_branch_for_diagnostics_navigation_and_tokens -- --nocapture`
- `cargo test -p ide verilog_2005 -- --nocapture`
- `cargo fmt --check`
- `git diff --check`