### PR TITLE
feat(hir): link manifest predefines to source ranges

### DIFF
--- a/crates/hir/src/base_db/compilation_plan.rs
+++ b/crates/hir/src/base_db/compilation_plan.rs
@@ -140,17 +140,13 @@ fn profile_inputs(
             profile.source_roots.clone(),
             profile.top_modules.clone(),
             profile.preprocess.include_dirs.clone(),
-            profile.preprocess.predefines.clone(),
+            profile.preprocess.predefine_strings(),
         );
     }
 
     let preprocess = project_config.preprocess_for_profile(profile_id);
-    (
-        root_scoped_source_root.into_iter().collect(),
-        Vec::new(),
-        preprocess.include_dirs,
-        preprocess.predefines,
-    )
+    let predefines = preprocess.predefine_strings();
+    (root_scoped_source_root.into_iter().collect(), Vec::new(), preprocess.include_dirs, predefines)
 }
 
 fn all_non_ignored_roots(db: &dyn SourceRootDb) -> Vec<SourceRootId> {

--- a/crates/hir/src/base_db/project.rs
+++ b/crates/hir/src/base_db/project.rs
@@ -1,5 +1,5 @@
 use triomphe::Arc;
-use utils::paths::AbsPathBuf;
+use utils::{line_index::TextRange, paths::AbsPathBuf};
 
 use crate::base_db::source_root::SourceRootId;
 
@@ -8,14 +8,66 @@ pub struct CompilationProfileId(pub u32);
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct PreprocessConfig {
-    pub predefines: Vec<String>,
+    pub predefines: Vec<Predefine>,
     pub include_dirs: Vec<AbsPathBuf>,
 }
 
 impl PreprocessConfig {
+    pub fn with_predefine_strings(
+        predefines: impl IntoIterator<Item = impl Into<String>>,
+        include_dirs: Vec<AbsPathBuf>,
+    ) -> Self {
+        Self {
+            predefines: predefines.into_iter().map(|predefine| Predefine::new(predefine)).collect(),
+            include_dirs,
+        }
+    }
+
     pub fn include_dir_strings(&self) -> Vec<String> {
         self.include_dirs.iter().map(ToString::to_string).collect()
     }
+
+    pub fn predefine_strings(&self) -> Vec<String> {
+        self.predefines.iter().map(|predefine| predefine.definition.clone()).collect()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Predefine {
+    pub definition: String,
+    pub source: Option<PredefineSource>,
+}
+
+impl Predefine {
+    pub fn new(definition: impl Into<String>) -> Self {
+        Self { definition: definition.into(), source: None }
+    }
+
+    pub fn with_source(definition: impl Into<String>, source: PredefineSource) -> Self {
+        Self { definition: definition.into(), source: Some(source) }
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.definition.as_str()
+    }
+}
+
+impl From<String> for Predefine {
+    fn from(value: String) -> Self {
+        Predefine::new(value)
+    }
+}
+
+impl From<&str> for Predefine {
+    fn from(value: &str) -> Self {
+        Predefine::new(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PredefineSource {
+    pub path: AbsPathBuf,
+    pub range: TextRange,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/hir/src/base_db/source_db.rs
+++ b/crates/hir/src/base_db/source_db.rs
@@ -23,7 +23,7 @@ use vfs::{FileId, VfsPath, anchored_path::AnchoredPath};
 use crate::base_db::{
     compilation_plan::{self, CompilationPlan},
     diagnostics_config::{DiagnosticSource, DiagnosticsConfig},
-    project::{CompilationProfileId, PreprocessConfig, ProjectConfig},
+    project::{CompilationProfileId, Predefine, PreprocessConfig, ProjectConfig},
     source_root::{SourceRoot, SourceRootId},
 };
 
@@ -104,7 +104,7 @@ fn parse_src(db: &dyn SourceDb, file_id: FileId) -> SyntaxTree {
             let preprocess = db.file_preprocess_config(file_id);
             let include_paths = preprocess.include_dir_strings();
             let options = syntax::SyntaxTreeOptions {
-                predefines: preprocess.predefines.clone(),
+                predefines: preprocess.predefine_strings(),
                 include_paths,
                 ..syntax::SyntaxTreeOptions::without_include_expansion()
             };
@@ -146,6 +146,7 @@ pub struct MappedSourcePreprocModel {
 pub struct PreprocSourceMap {
     entries: FxHashMap<PreprocSourceId, PreprocSourceMapping>,
     expansion_entries: FxHashMap<SourceMacroExpansionId, PreprocExpansionMapping>,
+    predefine_sources: FxHashMap<PreprocSourceId, PreprocManifestSource>,
     text_lengths: FxHashMap<PreprocSourceId, usize>,
     range_offsets: FxHashMap<PreprocSourceId, usize>,
 }
@@ -165,6 +166,12 @@ pub struct PreprocExpansionMapping {
     pub text: String,
     pub emitted_range: SourceEmittedTokenRange,
     token_ranges: FxHashMap<SourceEmittedTokenId, TextRange>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PreprocManifestSource {
+    pub file_id: FileId,
+    pub range: TextRange,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -208,6 +215,7 @@ pub enum PreprocSourceMapError {
 impl PreprocSourceMap {
     pub fn insert_real_file(&mut self, source: PreprocSourceId, file_id: FileId, text_len: usize) {
         self.entries.insert(source, PreprocSourceMapping::RealFile(file_id));
+        self.predefine_sources.remove(&source);
         self.text_lengths.insert(source, text_len);
         self.range_offsets.insert(source, 0);
     }
@@ -233,18 +241,35 @@ impl PreprocSourceMap {
         range_offset: usize,
     ) {
         self.entries.insert(source, PreprocSourceMapping::VirtualFile { file_id, path, origin });
+        self.predefine_sources.remove(&source);
         self.text_lengths.insert(source, text_len);
         self.range_offsets.insert(source, range_offset);
     }
 
     pub fn insert_unmapped(&mut self, source: PreprocSourceId, reason: SourcePreprocUnavailable) {
         self.entries.insert(source, PreprocSourceMapping::Unmapped(reason));
+        self.predefine_sources.remove(&source);
         self.text_lengths.remove(&source);
         self.range_offsets.remove(&source);
     }
 
+    fn insert_predefine_manifest_source(
+        &mut self,
+        source: PreprocSourceId,
+        manifest_source: PreprocManifestSource,
+    ) {
+        self.predefine_sources.insert(source, manifest_source);
+    }
+
     pub fn get(&self, source: PreprocSourceId) -> Option<&PreprocSourceMapping> {
         self.entries.get(&source)
+    }
+
+    pub fn predefine_manifest_source(
+        &self,
+        source: PreprocSourceId,
+    ) -> Option<PreprocManifestSource> {
+        self.predefine_sources.get(&source).copied()
     }
 
     pub fn insert_expansion_virtual_file(
@@ -445,6 +470,7 @@ fn source_preproc_file_ids(
     profile_id: Option<CompilationProfileId>,
     trace: &PreprocessorTrace,
     options: &SyntaxTreeOptions,
+    preprocess: &PreprocessConfig,
 ) -> Result<PreprocSourceMap, SourcePreprocQueryError> {
     let mut source_map = PreprocSourceMap::default();
     let path_file_ids = path_file_ids(db);
@@ -458,7 +484,7 @@ fn source_preproc_file_ids(
         .map(|source| PreprocSourceId::from(source.buffer_id))
         .collect::<Vec<_>>();
     let predefine_map =
-        PredefineVirtualMapping::new(db, profile_id, &options.predefines, predefine_sources);
+        PredefineVirtualMapping::new(db, profile_id, &preprocess.predefines, predefine_sources);
 
     for source in &trace.source_buffers {
         let source_id = PreprocSourceId::from(source.buffer_id);
@@ -507,6 +533,9 @@ fn source_preproc_file_ids(
                         entry.text_len,
                         entry.range_offset,
                     );
+                    if let Some(manifest_source) = entry.manifest_source(&path_file_ids) {
+                        source_map.insert_predefine_manifest_source(source_id, manifest_source);
+                    }
                 } else {
                     source_map.insert_unmapped(
                         source_id,
@@ -625,13 +654,14 @@ struct PredefineVirtualEntry {
     path: VfsPath,
     text_len: usize,
     range_offset: usize,
+    predefine: Predefine,
 }
 
 impl PredefineVirtualMapping {
     fn new(
         db: &dyn SourceRootDb,
         profile_id: Option<CompilationProfileId>,
-        predefines: &[String],
+        predefines: &[Predefine],
         mut sources: Vec<PreprocSourceId>,
     ) -> Self {
         sources.sort_by_key(|source| source.raw());
@@ -641,17 +671,23 @@ impl PredefineVirtualMapping {
 
         let texts = predefines
             .iter()
-            .map(|predefine| materialized_predefine_text(predefine))
+            .map(|predefine| materialized_predefine_text(predefine.as_str()))
             .collect::<Vec<_>>();
         let text_len = texts.iter().map(String::len).sum();
         let path = preproc_virtual_predefines_path(profile_id);
         let file_id = preproc_virtual_file_id(db, &path);
         let mut range_offset = 0usize;
         let mut entries = FxHashMap::default();
-        for (source, text) in sources.into_iter().zip(texts) {
+        for (index, (source, text)) in sources.into_iter().zip(texts).enumerate() {
             entries.insert(
                 source,
-                PredefineVirtualEntry { file_id, path: path.clone(), text_len, range_offset },
+                PredefineVirtualEntry {
+                    file_id,
+                    path: path.clone(),
+                    text_len,
+                    range_offset,
+                    predefine: predefines[index].clone(),
+                },
             );
             range_offset += text.len();
         }
@@ -661,6 +697,17 @@ impl PredefineVirtualMapping {
 
     fn entry(&self, source: PreprocSourceId) -> Option<&PredefineVirtualEntry> {
         self.entries.get(&source)
+    }
+}
+
+impl PredefineVirtualEntry {
+    fn manifest_source(
+        &self,
+        path_file_ids: &PathIdentityIndex<FileId>,
+    ) -> Option<PreprocManifestSource> {
+        let source = self.predefine.source.as_ref()?;
+        let file_id = path_file_ids.get_path(source.path.as_path())?;
+        Some(PreprocManifestSource { file_id, range: source.range })
     }
 }
 
@@ -778,7 +825,7 @@ fn syntax_tree_options_for_file(
     let profile_id = db.file_compilation_profile(file_id);
     let include_buffers = db.include_buffers_for_profile(profile_id).as_ref().clone();
     syntax::SyntaxTreeOptions {
-        predefines: preprocess.predefines.clone(),
+        predefines: preprocess.predefine_strings(),
         include_paths: preprocess.include_dir_strings(),
         include_buffers,
         ..syntax::SyntaxTreeOptions::default()
@@ -793,7 +840,7 @@ fn syntax_tree_options_for_profile(
     let preprocess = project_config.preprocess_for_profile(profile_id);
     let include_paths = preprocess.include_dir_strings();
     syntax::SyntaxTreeOptions {
-        predefines: preprocess.predefines,
+        predefines: preprocess.predefine_strings(),
         include_paths,
         include_buffers,
         ..syntax::SyntaxTreeOptions::default()
@@ -1016,6 +1063,7 @@ fn source_preproc_model(
     let text = db.file_text(file_id);
     let identity = source_file_identity(db, file_id);
     let profile_id = db.file_compilation_profile(file_id);
+    let preprocess = db.file_preprocess_config(file_id);
     let options = syntax_tree_options_for_file(db, file_id);
     let Some(trace) =
         SyntaxTree::preprocessor_trace(&text, &identity.name, &identity.path, &options)
@@ -1023,10 +1071,11 @@ fn source_preproc_model(
         return Arc::new(Err(SourcePreprocQueryError::TraceUnavailable));
     };
 
-    let mut source_map = match source_preproc_file_ids(db, file_id, profile_id, &trace, &options) {
-        Ok(source_map) => source_map,
-        Err(err) => return Arc::new(Err(err)),
-    };
+    let mut source_map =
+        match source_preproc_file_ids(db, file_id, profile_id, &trace, &options, &preprocess) {
+            Ok(source_map) => source_map,
+            Err(err) => return Arc::new(Err(err)),
+        };
     let model = match SourcePreprocModel::from_trace(trace) {
         Ok(model) => model,
         Err(err) => return Arc::new(Err(SourcePreprocQueryError::Model(err))),
@@ -1362,7 +1411,9 @@ mod tests {
             emitted_tokens: Vec::new(),
         };
         let options = SyntaxTreeOptions::default();
-        let source_map = source_preproc_file_ids(&db, TOP, None, &trace, &options).unwrap();
+        let preprocess = PreprocessConfig::default();
+        let source_map =
+            source_preproc_file_ids(&db, TOP, None, &trace, &options, &preprocess).unwrap();
 
         assert_eq!(
             source_map.get(PreprocSourceId::from(2)),
@@ -1406,8 +1457,11 @@ mod tests {
             predefines: vec!["FIRST=1".to_owned(), "SECOND".to_owned()],
             ..SyntaxTreeOptions::default()
         };
+        let preprocess =
+            PreprocessConfig::with_predefine_strings(["FIRST=1", "SECOND"], Vec::new());
 
-        let source_map = source_preproc_file_ids(&db, TOP, None, &trace, &options).unwrap();
+        let source_map =
+            source_preproc_file_ids(&db, TOP, None, &trace, &options, &preprocess).unwrap();
         let first = PreprocSourceId::from(2);
         let second = PreprocSourceId::from(3);
         let expected_path = preproc_virtual_predefines_path(None);
@@ -1473,9 +1527,16 @@ mod tests {
             ..SyntaxTreeOptions::default()
         };
 
-        let source_map =
-            source_preproc_file_ids(&db, TOP, Some(CompilationProfileId(7)), &trace, &options)
-                .unwrap();
+        let preprocess = PreprocessConfig::default();
+        let source_map = source_preproc_file_ids(
+            &db,
+            TOP,
+            Some(CompilationProfileId(7)),
+            &trace,
+            &options,
+            &preprocess,
+        )
+        .unwrap();
         let source = PreprocSourceId::from(4);
         let Some(PreprocSourceMapping::VirtualFile { path, origin, .. }) = source_map.get(source)
         else {

--- a/crates/hir/src/preproc.rs
+++ b/crates/hir/src/preproc.rs
@@ -24,7 +24,7 @@ use utils::{
 use vfs::FileId;
 
 use crate::base_db::{
-    project::CompilationProfileId,
+    project::{CompilationProfileId, Predefine},
     source_db::{
         MappedSourcePreprocModel, PreprocSourceMapError, PreprocSourceMapping,
         PreprocVirtualOrigin, SourceFileKind, SourcePreprocQueryError, SourceRootDb,
@@ -65,6 +65,7 @@ pub enum PreprocUnavailable {
     AmbiguousMacroReferenceContexts { contexts: usize },
     AmbiguousMacroExpansionContexts { contexts: usize },
     AmbiguousMacroParamContexts { contexts: usize },
+    AmbiguousMacroDefinitionContexts { contexts: usize },
     AmbiguousDiagnosticProvenance { targets: usize },
     AmbiguousIncludeTargets { targets: usize },
 }
@@ -95,11 +96,25 @@ macro_rules! mapped_preproc_id {
     };
 }
 
-mapped_preproc_id!(MacroDefinitionId, SourceMacroDefinitionId);
 mapped_preproc_id!(MacroReferenceId, SourceMacroReferenceId);
 mapped_preproc_id!(IncludeDirectiveId, SourceIncludeDirectiveId);
 mapped_preproc_id!(MacroCallId, SourceMacroCallId);
 mapped_preproc_id!(MacroExpansionId, SourceMacroExpansionId);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MacroDefinitionId {
+    Source(SourceMacroDefinitionId),
+    ConfiguredPredefine { file_id: FileId, range: TextRange },
+}
+
+impl From<SourceMacroDefinitionId> for MacroDefinitionId {
+    fn from(value: SourceMacroDefinitionId) -> Self {
+        Self::Source(value)
+    }
+}
+
+const CONFIGURED_PREDEFINE_DEFINE_INDEX: usize = usize::MAX;
+const CONFIGURED_PREDEFINE_EVENT_ID: u32 = u32::MAX;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MappedPreprocSource {
@@ -570,13 +585,13 @@ fn configured_predefine_names(db: &dyn SourceRootDb, file_id: FileId) -> Vec<Smo
 
     let profile_id = db.file_compilation_profile(file_id);
     for predefine in &db.project_config().preprocess_for_profile(profile_id).predefines {
-        if let Some(name) = predefine_macro_name(predefine) {
+        if let Some(name) = predefine_macro_name(predefine.as_str()) {
             names.push_unique(name);
         }
     }
 
     for predefine in &db.file_preprocess_config(file_id).predefines {
-        if let Some(name) = predefine_macro_name(predefine) {
+        if let Some(name) = predefine_macro_name(predefine.as_str()) {
             names.push_unique(name);
         }
     }
@@ -590,21 +605,136 @@ fn predefine_macro_name(predefine: &str) -> Option<SmolStr> {
     if name.is_empty() { None } else { Some(SmolStr::new(name)) }
 }
 
+fn configured_predefine_definitions_for_name(
+    db: &dyn SourceRootDb,
+    context_file_id: FileId,
+    name: &SmolStr,
+) -> Vec<MacroDefinition> {
+    let mut definitions = Vec::new();
+    let profile_id = db.file_compilation_profile(context_file_id);
+    let project_preprocess = db.project_config().preprocess_for_profile(profile_id);
+    for predefine in &project_preprocess.predefines {
+        if let Some(definition) = configured_predefine_definition(db, predefine, name) {
+            push_unique_macro_definition(&mut definitions, definition);
+        }
+    }
+    for predefine in &db.file_preprocess_config(context_file_id).predefines {
+        if let Some(definition) = configured_predefine_definition(db, predefine, name) {
+            push_unique_macro_definition(&mut definitions, definition);
+        }
+    }
+    definitions
+}
+
+fn configured_predefine_definitions_at(
+    db: &dyn SourceRootDb,
+    file_id: FileId,
+    offset: TextSize,
+) -> Vec<MacroDefinition> {
+    let mut definitions = Vec::new();
+    for context_file_id in source_preproc_query_model_file_ids(db, file_id) {
+        let profile_id = db.file_compilation_profile(context_file_id);
+        let project_preprocess = db.project_config().preprocess_for_profile(profile_id);
+        for predefine in &project_preprocess.predefines {
+            if let Some(definition) =
+                configured_predefine_definition_at(db, predefine, file_id, offset)
+            {
+                push_unique_macro_definition(&mut definitions, definition);
+            }
+        }
+        for predefine in &db.file_preprocess_config(context_file_id).predefines {
+            if let Some(definition) =
+                configured_predefine_definition_at(db, predefine, file_id, offset)
+            {
+                push_unique_macro_definition(&mut definitions, definition);
+            }
+        }
+    }
+    definitions
+}
+
+fn configured_predefine_definition_at(
+    db: &dyn SourceRootDb,
+    predefine: &Predefine,
+    file_id: FileId,
+    offset: TextSize,
+) -> Option<MacroDefinition> {
+    let definition =
+        configured_predefine_definition(db, predefine, &predefine_macro_name(predefine.as_str())?)?;
+    (definition.file_id == file_id && range_contains_offset(definition.name_range, offset))
+        .then_some(definition)
+}
+
+fn configured_predefine_definition(
+    db: &dyn SourceRootDb,
+    predefine: &Predefine,
+    name: &SmolStr,
+) -> Option<MacroDefinition> {
+    let predefine_name = predefine_macro_name(predefine.as_str())?;
+    if &predefine_name != name {
+        return None;
+    }
+    let source = predefine.source.as_ref()?;
+    let file_id = file_id_for_predefine_source_path(db, &source.path)?;
+    Some(MacroDefinition {
+        id: MacroDefinitionId::ConfiguredPredefine { file_id, range: source.range },
+        source: MappedPreprocSource::RealFile { file_id },
+        capability: PreprocAvailability::Complete,
+        file_id,
+        name: predefine_name,
+        define_index: CONFIGURED_PREDEFINE_DEFINE_INDEX,
+        event_id: CONFIGURED_PREDEFINE_EVENT_ID,
+        directive_range: source.range,
+        name_range: source.range,
+    })
+}
+
+fn file_id_for_predefine_source_path(
+    db: &dyn SourceRootDb,
+    path: &utils::paths::AbsPathBuf,
+) -> Option<FileId> {
+    db.files().iter().copied().find(|file_id| db.file_path(*file_id).as_ref() == Some(path))
+}
+
 pub fn macro_definition_at(
     db: &dyn SourceRootDb,
     file_id: FileId,
     offset: TextSize,
 ) -> PreprocResult<Option<MacroDefinition>> {
-    let mapped = db.source_preproc_model(file_id);
-    let mapped = mapped_result(mapped.as_ref())?;
+    let mut first_error = None;
+    for model_file_id in source_preproc_query_model_file_ids(db, file_id) {
+        let mapped = db.source_preproc_model(model_file_id);
+        let mapped = match mapped_result(mapped.as_ref()) {
+            Ok(mapped) => mapped,
+            Err(error) => {
+                record_first_error(&mut first_error, error);
+                continue;
+            }
+        };
 
-    for definition in mapped.model.macro_definitions().iter() {
-        let mapped_definition = map_macro_definition(mapped, definition)?;
-        if mapped_definition.file_id == file_id
-            && range_contains_offset(mapped_definition.name_range, offset)
-        {
-            return Ok(Some(mapped_definition));
+        for definition in mapped.model.macro_definitions().iter() {
+            let mapped_definition = map_macro_definition(mapped, definition)?;
+            if mapped_definition.file_id == file_id
+                && range_contains_offset(mapped_definition.name_range, offset)
+            {
+                return Ok(Some(mapped_definition));
+            }
         }
+    }
+
+    let mut configured_definitions = configured_predefine_definitions_at(db, file_id, offset);
+    match configured_definitions.len() {
+        0 => {}
+        1 => return Ok(configured_definitions.pop()),
+        contexts => {
+            return Err(PreprocError::Unavailable {
+                reason: PreprocUnavailable::AmbiguousMacroDefinitionContexts { contexts },
+            });
+        }
+    }
+
+    if let Some(error) = first_error {
+        return Err(error);
     }
 
     Ok(None)
@@ -939,30 +1069,42 @@ pub fn macro_reference_definitions_at(
                     continue;
                 }
             };
-            push_unique_macro_reference_context(&mut references, mapped_reference);
+            push_unique_macro_reference_context(&mut references, mapped_reference.clone());
 
-            let SourceMacroResolutionFact::Resolved { definition, .. } = &reference.resolution
-            else {
-                continue;
-            };
-            let Some(definition) = mapped.model.macro_definitions().get(*definition) else {
-                record_first_error(
-                    &mut first_error,
-                    PreprocError::SourceQuery(SourcePreprocQueryError::Model(
-                        SourcePreprocError::MissingEvent { event_id: reference.event_id.raw() },
-                    )),
-                );
-                continue;
-            };
-            let definition = match map_macro_definition(mapped, definition) {
-                Ok(definition) => definition,
-                Err(error) => {
-                    record_first_error(&mut first_error, error);
-                    continue;
+            match &reference.resolution {
+                SourceMacroResolutionFact::Resolved { definition, .. } => {
+                    let Some(definition) = mapped.model.macro_definitions().get(*definition) else {
+                        record_first_error(
+                            &mut first_error,
+                            PreprocError::SourceQuery(SourcePreprocQueryError::Model(
+                                SourcePreprocError::MissingEvent {
+                                    event_id: reference.event_id.raw(),
+                                },
+                            )),
+                        );
+                        continue;
+                    };
+                    let definition = match map_macro_definition(mapped, definition) {
+                        Ok(definition) => definition,
+                        Err(error) => {
+                            record_first_error(&mut first_error, error);
+                            continue;
+                        }
+                    };
+
+                    push_unique_macro_definition(&mut definitions, definition);
                 }
-            };
-
-            push_unique_macro_definition(&mut definitions, definition);
+                SourceMacroResolutionFact::Undefined => {
+                    for definition in configured_predefine_definitions_for_name(
+                        db,
+                        model_file_id,
+                        &mapped_reference.name,
+                    ) {
+                        push_unique_macro_definition(&mut definitions, definition);
+                    }
+                }
+                SourceMacroResolutionFact::Unavailable(_) => {}
+            }
         }
     }
 
@@ -1345,19 +1487,24 @@ pub(crate) fn build_macro_reference_index(
                 continue;
             }
         };
-        collect_macro_references_in_model(mapped, model_file_id, &mut index);
+        collect_macro_references_in_model(db, mapped, model_file_id, &mut index);
     }
 
     index
 }
 
 fn collect_macro_references_in_model(
+    db: &dyn SourceRootDb,
     mapped: &MappedSourcePreprocModel,
     model_file_id: FileId,
     index: &mut MacroReferenceIndex,
 ) {
     for reference in mapped.model.macro_references().iter() {
         let SourceMacroResolutionFact::Resolved { definition, .. } = reference.resolution else {
+            if reference.resolution == SourceMacroResolutionFact::Undefined {
+                collect_configured_predefine_reference(db, mapped, model_file_id, reference, index);
+                continue;
+            }
             if let SourceMacroResolutionFact::Unavailable(reason) = &reference.resolution {
                 index.push_issue(MacroReferenceIndexIssue::UnavailableReference {
                     file_id: model_file_id,
@@ -1399,6 +1546,29 @@ fn collect_macro_references_in_model(
             }
         };
         index.push(definition, reference);
+    }
+}
+
+fn collect_configured_predefine_reference(
+    db: &dyn SourceRootDb,
+    mapped: &MappedSourcePreprocModel,
+    model_file_id: FileId,
+    source_reference: &SourceMacroReferenceFact,
+    index: &mut MacroReferenceIndex,
+) {
+    let reference = match map_macro_reference(mapped, source_reference) {
+        Ok(reference) => reference,
+        Err(error) => {
+            index.push_issue(MacroReferenceIndexIssue::SkippedModel {
+                file_id: model_file_id,
+                error,
+            });
+            return;
+        }
+    };
+    for definition in configured_predefine_definitions_for_name(db, model_file_id, &reference.name)
+    {
+        index.push(definition, reference.clone());
     }
 }
 
@@ -1632,12 +1802,19 @@ fn map_macro_definition(
     mapped: &MappedSourcePreprocModel,
     definition: &SourceMacroDefinitionFact,
 ) -> PreprocResult<MacroDefinition> {
-    let (source, directive_range, name_range) = map_definition_ranges(
+    let (mut source, mut directive_range, mut name_range) = map_definition_ranges(
         mapped,
         definition.event_id.raw(),
         definition.directive_range,
         definition.name_range,
     )?;
+    if let Some(manifest_source) =
+        mapped.source_map.predefine_manifest_source(definition.name_range.source)
+    {
+        source = MappedPreprocSource::RealFile { file_id: manifest_source.file_id };
+        directive_range = manifest_source.range;
+        name_range = manifest_source.range;
+    }
     Ok(MacroDefinition {
         id: definition.id.into(),
         file_id: source.file_id(),
@@ -2449,7 +2626,10 @@ mod tests {
     use crate::{
         base_db::{
             diagnostics_config::DiagnosticsConfig,
-            project::{CompilationProfile, CompilationProfileId, PreprocessConfig, ProjectConfig},
+            project::{
+                CompilationProfile, CompilationProfileId, Predefine, PredefineSource,
+                PreprocessConfig, ProjectConfig,
+            },
             salsa::{self, Durability},
             source_db::{
                 FileLoader, PreprocVirtualOrigin, SourceDb, SourceDbStorage, SourceFileKind,
@@ -2466,6 +2646,7 @@ mod tests {
     const TOP: FileId = FileId(0);
     const HEADER: FileId = FileId(1);
     const LEAF: FileId = FileId(2);
+    const MANIFEST: FileId = FileId(3);
     const ROOT: SourceRootId = SourceRootId(0);
     const PROFILE: CompilationProfileId = CompilationProfileId(0);
 
@@ -2509,6 +2690,16 @@ mod tests {
     fn db_with_entries_and_predefines(
         entries: &[(FileId, &str, &str)],
         predefines: Vec<String>,
+    ) -> TestDb {
+        db_with_entries_and_predefine_entries(
+            entries,
+            predefines.into_iter().map(Predefine::new).collect(),
+        )
+    }
+
+    fn db_with_entries_and_predefine_entries(
+        entries: &[(FileId, &str, &str)],
+        predefines: Vec<Predefine>,
     ) -> TestDb {
         let include_dir = abs_path("include");
 
@@ -2843,6 +3034,59 @@ endmodule
 
         assert!(names.iter().any(|name| name == "A005_LOCAL"), "{names:?}");
         assert!(names.iter().any(|name| name == "A005_MAGIC"), "{names:?}");
+    }
+
+    #[test]
+    fn preproc_manifest_predefine_definition_uses_manifest_provenance() {
+        let root_text = r#"`ifdef FROM_MANIFEST
+module top;
+localparam int W = `FROM_MANIFEST;
+endmodule
+`endif
+"#;
+        let manifest_text = "defines = [\"FROM_MANIFEST=1\"]\n";
+        let manifest_range = TextRange::new(
+            offset(manifest_text, "\"FROM_MANIFEST=1\""),
+            offset_after(manifest_text, "\"FROM_MANIFEST=1\""),
+        );
+        let predefine = Predefine::with_source(
+            "FROM_MANIFEST=1",
+            PredefineSource { path: abs_path("vide.toml"), range: manifest_range },
+        );
+        let db = db_with_entries_and_predefine_entries(
+            &[(TOP, "rtl/top.v", root_text), (MANIFEST, "vide.toml", manifest_text)],
+            vec![predefine],
+        );
+
+        let resolution = macro_reference_definitions_at(
+            &db,
+            TOP,
+            offset_after_n(root_text, "`FROM_MANIFEST", 0),
+        )
+        .unwrap()
+        .unwrap();
+        assert!(
+            resolution.definitions.iter().any(|definition| {
+                definition.file_id == MANIFEST && definition.name_range == manifest_range
+            }),
+            "predefine reference should target the manifest source range: {resolution:?}"
+        );
+
+        let definition =
+            macro_definition_at(&db, MANIFEST, manifest_range.start()).unwrap().unwrap();
+        assert_eq!(definition.file_id, MANIFEST);
+        assert_eq!(definition.name.as_str(), "FROM_MANIFEST");
+        assert_eq!(definition.name_range, manifest_range);
+        assert_eq!(text_at_range(manifest_text, definition.name_range), "\"FROM_MANIFEST=1\"");
+
+        let references = macro_references(&db, MANIFEST, &definition).unwrap();
+        assert!(
+            references.references.iter().any(|reference| {
+                reference.file_id == TOP
+                    && text_at_range(root_text, reference.range) == "FROM_MANIFEST"
+            }),
+            "manifest predefine definition should find source references: {references:?}"
+        );
     }
 
     #[test]

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -495,7 +495,7 @@ mod tests {
             files,
             SourceRootRole::Local,
             true,
-            PreprocessConfig { predefines, ..PreprocessConfig::default() },
+            PreprocessConfig::with_predefine_strings(predefines, Vec::new()),
         )
     }
 
@@ -833,7 +833,10 @@ mod tests {
             vec![CompilationProfile {
                 source_roots: vec![SourceRootId(0)],
                 top_modules: Vec::new(),
-                preprocess: PreprocessConfig { predefines: Vec::new(), include_dirs: vec![root] },
+                preprocess: PreprocessConfig {
+                    include_dirs: vec![root],
+                    ..PreprocessConfig::default()
+                },
             }],
         )));
         db.apply_change(change);
@@ -950,8 +953,8 @@ mod tests {
                 source_roots: vec![SourceRootId(0)],
                 top_modules: Vec::new(),
                 preprocess: PreprocessConfig {
-                    predefines: Vec::new(),
                     include_dirs: vec![include_root],
+                    ..PreprocessConfig::default()
                 },
             }],
         )));

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -83,11 +83,11 @@ fn handle_preproc_macro(
     file_id: FileId,
     offset: TextSize,
 ) -> Option<RangeInfo<Vec<NavTarget>>> {
-    if let Some(definition) = macro_param_definition_at(db, file_id, offset).ok()? {
+    if let Ok(Some(definition)) = macro_param_definition_at(db, file_id, offset) {
         return Some(RangeInfo::new(definition.range, vec![macro_param_nav_target(definition)]));
     }
 
-    if let Some(resolution) = macro_param_reference_definitions_at(db, file_id, offset).ok()? {
+    if let Ok(Some(resolution)) = macro_param_reference_definitions_at(db, file_id, offset) {
         let reference_range = resolution.range;
         let targets = resolution.definitions.into_iter().map(macro_param_nav_target).collect_vec();
         if targets.is_empty() {
@@ -96,17 +96,20 @@ fn handle_preproc_macro(
         return Some(RangeInfo::new(reference_range, targets));
     }
 
-    if let Some(definition) = macro_definition_at(db, file_id, offset).ok()? {
+    if let Ok(Some(definition)) = macro_definition_at(db, file_id, offset) {
         return Some(RangeInfo::new(definition.name_range, vec![macro_nav_target(definition)]));
     }
 
-    let resolution = macro_reference_definitions_at(db, file_id, offset).ok()??;
-    let reference_range = resolution.range;
-    let targets = resolution.definitions.into_iter().map(macro_nav_target).collect_vec();
-    if targets.is_empty() {
-        return None;
+    if let Ok(Some(resolution)) = macro_reference_definitions_at(db, file_id, offset) {
+        let reference_range = resolution.range;
+        let targets = resolution.definitions.into_iter().map(macro_nav_target).collect_vec();
+        if targets.is_empty() {
+            return None;
+        }
+        return Some(RangeInfo::new(reference_range, targets));
     }
-    Some(RangeInfo::new(reference_range, targets))
+
+    None
 }
 
 fn macro_param_nav_target(definition: MacroParamDefinition) -> NavTarget {

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -117,12 +117,11 @@ fn handle_preproc_macro(
     file_id: FileId,
     offset: TextSize,
 ) -> Option<RangeInfo<Markup>> {
-    if let Some(definition) = macro_param_definition_at(db, file_id, offset).ok()? {
+    if let Ok(Some(definition)) = macro_param_definition_at(db, file_id, offset) {
         return Some(RangeInfo::new(definition.range, macro_param_definition_markup(&definition)));
     }
 
-    let param_resolution = macro_param_reference_definitions_at(db, file_id, offset).ok()?;
-    if let Some(param_resolution) = param_resolution {
+    if let Ok(Some(param_resolution)) = macro_param_reference_definitions_at(db, file_id, offset) {
         if param_resolution.definitions.is_empty() {
             return None;
         }
@@ -132,18 +131,24 @@ fn handle_preproc_macro(
         ));
     }
 
-    if let Some(definition) = macro_definition_at(db, file_id, offset).ok()? {
+    if let Ok(Some(definition)) = macro_definition_at(db, file_id, offset) {
         return Some(RangeInfo::new(
             definition.name_range,
             macro_definition_markup(db, &definition),
         ));
     }
 
-    let resolution = macro_reference_definitions_at(db, file_id, offset).ok()??;
-    if resolution.definitions.is_empty() {
-        return None;
+    if let Ok(Some(resolution)) = macro_reference_definitions_at(db, file_id, offset) {
+        if resolution.definitions.is_empty() {
+            return None;
+        }
+        return Some(RangeInfo::new(
+            resolution.range,
+            macro_definitions_markup(db, &resolution.definitions),
+        ));
     }
-    Some(RangeInfo::new(resolution.range, macro_definitions_markup(db, &resolution.definitions)))
+
+    None
 }
 
 fn macro_param_definition_markup(definition: &MacroParamDefinition) -> Markup {

--- a/crates/ide/src/verilog_2005.rs
+++ b/crates/ide/src/verilog_2005.rs
@@ -7,7 +7,10 @@ use std::{
 use hir::{
     base_db::{
         change::Change,
-        project::{CompilationProfile, CompilationProfileId, PreprocessConfig, ProjectConfig},
+        project::{
+            CompilationProfile, CompilationProfileId, Predefine, PredefineSource, PreprocessConfig,
+            ProjectConfig,
+        },
         salsa::Durability,
         source_db::SourceDb,
         source_root::{SourceRoot, SourceRootId},
@@ -202,7 +205,7 @@ fn setup_marked_with_predefines(
         vec![CompilationProfile {
             source_roots: vec![SourceRootId(0)],
             top_modules: Vec::new(),
-            preprocess: PreprocessConfig { predefines, include_dirs: Vec::new() },
+            preprocess: PreprocessConfig::with_predefine_strings(predefines, Vec::new()),
         }],
     )));
     change.add_changed_file(ChangedFile {
@@ -259,8 +262,8 @@ fn setup_include_macro_project(
             source_roots: vec![SourceRootId(0)],
             top_modules: Vec::new(),
             preprocess: PreprocessConfig {
-                predefines: Vec::new(),
                 include_dirs: vec![include_dir],
+                ..PreprocessConfig::default()
             },
         }],
     )));
@@ -918,6 +921,85 @@ endmodule
 }
 
 #[test]
+fn manifest_predefine_usage_navigates_to_vide_toml_define() {
+    let dir = TestDir::new("manifest-predefine-navigation");
+    let top_path = dir.path().join("top.sv");
+    let manifest_path = dir.path().join("vide.toml");
+    let marked_top_text = normalize_fixture_text(
+        r#"
+`ifdef FROM_MANIFEST
+module top;
+localparam int W = `/*marker:usage*/FROM_MANIFEST;
+endmodule
+`endif
+"#,
+    );
+    let marked_manifest_text =
+        normalize_fixture_text(r#"defines = [/*marker:def*/"FROM_MANIFEST=1"]"#);
+    let (top_text, top_markers) = strip_markers(marked_top_text);
+    let (manifest_text, manifest_markers) = strip_markers(marked_manifest_text);
+    let manifest_range =
+        marked_range(&manifest_markers, "def", TextSize::of("\"FROM_MANIFEST=1\""));
+
+    let top_file_id = FileId(0);
+    let manifest_file_id = FileId(1);
+    let mut file_set = FileSet::default();
+    file_set.insert(top_file_id, VfsPath::from(top_path));
+    file_set.insert(manifest_file_id, VfsPath::from(manifest_path.clone()));
+
+    let mut change = Change::new();
+    change.set_roots(vec![SourceRoot::new_local_with_source_files(file_set, vec![top_file_id])]);
+    change.set_project_config(Arc::new(ProjectConfig::new(
+        vec![Some(CompilationProfileId(0))],
+        vec![CompilationProfile {
+            source_roots: vec![SourceRootId(0)],
+            top_modules: Vec::new(),
+            preprocess: PreprocessConfig {
+                predefines: vec![Predefine::with_source(
+                    "FROM_MANIFEST=1",
+                    PredefineSource { path: manifest_path, range: manifest_range },
+                )],
+                include_dirs: Vec::new(),
+            },
+        }],
+    )));
+    change.add_changed_file(ChangedFile {
+        file_id: top_file_id,
+        change_kind: ChangeKind::Create(Arc::from(top_text.as_str()), LineEnding::Unix),
+    });
+    change.add_changed_file(ChangedFile {
+        file_id: manifest_file_id,
+        change_kind: ChangeKind::Create(Arc::from(manifest_text.as_str()), LineEnding::Unix),
+    });
+
+    let mut host = AnalysisHost::default();
+    host.apply_change(change);
+    let analysis = host.make_analysis();
+
+    let nav = analysis
+        .goto_definition(position(top_file_id, &top_markers, "usage"))
+        .unwrap()
+        .expect("manifest predefine navigation expected");
+    assert!(
+        nav.info.iter().any(|target| {
+            target.file_id == manifest_file_id && target.focus_range == Some(manifest_range)
+        }),
+        "predefine usage should navigate to vide.toml define: {nav:?}"
+    );
+
+    let manifest_nav = analysis
+        .goto_definition(position(manifest_file_id, &manifest_markers, "def"))
+        .unwrap()
+        .expect("manifest predefine definition should be linkable");
+    assert!(
+        manifest_nav.info.iter().any(|target| {
+            target.file_id == manifest_file_id && target.focus_range == Some(manifest_range)
+        }),
+        "manifest define should resolve to its own authoritative range: {manifest_nav:?}"
+    );
+}
+
+#[test]
 fn file_preprocess_config_selects_same_ifdef_branch_for_diagnostics_and_navigation() {
     let text = r#"
 module ifdef_nav(
@@ -1029,8 +1111,8 @@ endmodule
             source_roots: vec![SourceRootId(0)],
             top_modules: Vec::new(),
             preprocess: PreprocessConfig {
-                predefines: Vec::new(),
                 include_dirs: vec![src_dir.clone()],
+                ..PreprocessConfig::default()
             },
         }],
     )));

--- a/crates/project-model/src/lib.rs
+++ b/crates/project-model/src/lib.rs
@@ -58,6 +58,8 @@ pub struct WorkspaceRoot {
     pub source_directories: PathMatcher,
     /// Literal source files from the manifest.
     pub source_files: Vec<AbsPathBuf>,
+    /// Non-source files that still need a VFS identity for IDE features.
+    pub extra_files: Vec<AbsPathBuf>,
     /// Include/search roots loaded as headers and passed to preprocessing.
     pub include_dirs: Vec<AbsPathBuf>,
     pub exclude_globs: Option<PathGlobMatcher>,
@@ -71,6 +73,8 @@ impl WorkspaceRoot {
     pub fn file_set_paths(&self) -> Vec<AbsPathBuf> {
         let mut paths = self.include_dirs.clone();
         paths.extend(self.source.scan_roots().cloned());
+        paths.extend(self.source_files.iter().cloned());
+        paths.extend(self.extra_files.iter().cloned());
         sort_and_remove_subfolders(&mut paths);
         paths
     }
@@ -89,6 +93,7 @@ impl WorkspaceRoot {
 
     fn has_load_paths(&self) -> bool {
         !self.source_files.is_empty()
+            || !self.extra_files.is_empty()
             || !self.include_dirs.is_empty()
             || !self.source_directories.is_empty()
     }
@@ -166,6 +171,7 @@ impl Workspace {
 
     fn from_toml(toml: TomlWorkspace, is_lib: bool) -> anyhow::Result<Self> {
         let TomlWorkspace {
+            manifest_path,
             top_modules,
             workspace_root,
             macro_defs,
@@ -209,6 +215,7 @@ impl Workspace {
             source,
             source_directories,
             source_files: source_locations.source_files,
+            extra_files: vec![manifest_path.clone()],
             include_dirs: include_dirs.clone(),
             exclude_globs,
         };
@@ -216,7 +223,7 @@ impl Workspace {
         let semantic_profile = roots
             .iter()
             .any(|root| root.role.participates_in_semantic_profile())
-            .then(|| semantic_profile(top_modules, macro_defs, include_dirs));
+            .then(|| semantic_profile(top_modules, macro_defs, include_dirs, Some(manifest_path)));
 
         Ok(Self { workspace_root, library_paths, kind, roots, semantic_profile })
     }
@@ -230,6 +237,7 @@ impl Workspace {
             source: source.clone(),
             source_directories: source,
             source_files: Vec::new(),
+            extra_files: Vec::new(),
             include_dirs: include_dirs.clone(),
             exclude_globs: None,
         };
@@ -237,7 +245,7 @@ impl Workspace {
         let semantic_profile = roots
             .iter()
             .any(|root| root.role.participates_in_semantic_profile())
-            .then(|| semantic_profile(Vec::new(), MacroDef::default(), include_dirs));
+            .then(|| semantic_profile(Vec::new(), MacroDef::default(), include_dirs, None));
 
         Self {
             workspace_root: path.clone(),
@@ -273,11 +281,12 @@ fn semantic_profile(
     top_modules: Vec<String>,
     macro_defs: MacroDef,
     include_dirs: Vec<AbsPathBuf>,
+    manifest_path: Option<AbsPathBuf>,
 ) -> WorkspaceSemanticProfile {
     WorkspaceSemanticProfile {
         top_modules,
         preprocess: PreprocessConfig {
-            predefines: macro_defs.to_predefine_strings(),
+            predefines: macro_defs.to_predefines(manifest_path.as_ref()),
             include_dirs,
         },
     }
@@ -290,6 +299,7 @@ struct WorkspaceRootParts {
     source: PathMatcher,
     source_directories: PathMatcher,
     source_files: Vec<AbsPathBuf>,
+    extra_files: Vec<AbsPathBuf>,
     include_dirs: Vec<AbsPathBuf>,
     exclude_globs: Option<PathGlobMatcher>,
 }
@@ -300,6 +310,7 @@ impl WorkspaceRootParts {
             source: PathMatcher::all_under_roots(Vec::new()),
             source_directories: PathMatcher::all_under_roots(Vec::new()),
             source_files: Vec::new(),
+            extra_files: self.extra_files.clone(),
             include_dirs: self.include_dirs.clone(),
             exclude_globs: self.exclude_globs.clone(),
         }
@@ -310,6 +321,7 @@ impl WorkspaceRootParts {
             source: self.source.clone(),
             source_directories: self.source_directories.clone(),
             source_files: self.source_files.clone(),
+            extra_files: Vec::new(),
             include_dirs: Vec::new(),
             exclude_globs: self.exclude_globs.clone(),
         }
@@ -358,6 +370,7 @@ fn push_workspace_root(
         source: parts.source,
         source_directories: parts.source_directories,
         source_files: parts.source_files,
+        extra_files: parts.extra_files,
         include_dirs: parts.include_dirs,
         exclude_globs: parts.exclude_globs,
     };
@@ -610,8 +623,17 @@ pub fn get_workspace_folder(
             if !root.source.is_empty() {
                 include.push(root.source.clone());
             }
-            let source =
+            if !root.source_files.is_empty() {
+                include.push(PathMatcher::all_under_roots(root.source_files.clone()));
+            }
+            if !root.extra_files.is_empty() {
+                include.push(PathMatcher::all_under_roots(root.extra_files.clone()));
+            }
+            let mut source =
                 if root.source.is_empty() { Vec::new() } else { vec![root.source.clone()] };
+            if !root.source_files.is_empty() {
+                source.push(PathMatcher::all_under_roots(root.source_files.clone()));
+            }
 
             let mut load_entries = Vec::new();
             let source_files = root
@@ -641,6 +663,18 @@ pub fn get_workspace_folder(
                     exclude_globs: root.exclude_globs.clone(),
                 };
                 load_entries.push(vfs::loader::Entry::Directories(dirs));
+            }
+
+            let extra_files = root
+                .extra_files
+                .iter()
+                .filter(|path| {
+                    !is_excluded_load_file(path.as_path(), &exclude_paths, &root.exclude_globs)
+                })
+                .cloned()
+                .collect_vec();
+            if !extra_files.is_empty() {
+                load_entries.push(vfs::loader::Entry::Files(extra_files));
             }
 
             let root_idx = fsc.len();
@@ -901,33 +935,10 @@ libraries = ["../pkg/rtl"]
     }
 
     #[test]
-    fn empty_manifest_has_no_compilation_profile() {
+    fn empty_manifest_loads_manifest_without_systemverilog_source() {
         let root = TestDir::new("project-model-empty-manifest");
-        fs::write(root.join(project_manifest::MANIFEST_FILE_NAME), "").unwrap();
-
-        let manifest = ProjectManifest::from_path(&root.path().to_path_buf()).unwrap();
-        let (model, errors) = ProjectModel::load(vec![manifest]);
-        let (_, _, source_root_config, project_config) =
-            get_workspace_folder(&model.workspaces, &[]);
-
-        assert!(errors.is_empty(), "{errors:#?}");
-        assert_eq!(model.workspaces.len(), 1);
-        assert_eq!(model.workspaces[0].roots()[0].role, SourceRootRole::BestEffortIndex);
-        assert_eq!(
-            source_root_config.fileset_roles,
-            vec![SourceRootRole::BestEffortIndex, SourceRootRole::Ignored]
-        );
-        assert_eq!(project_config.profile_for_root(SourceRootId(0)), None);
-    }
-
-    #[test]
-    fn syntax_only_default_manifest_has_no_compilation_profile() {
-        let root = TestDir::new("project-model-syntax-only-manifest");
-        fs::write(
-            root.join(project_manifest::MANIFEST_FILE_NAME),
-            "sources = []\ninclude_dirs = []\n",
-        )
-        .unwrap();
+        let manifest_path = root.join(project_manifest::MANIFEST_FILE_NAME);
+        fs::write(&manifest_path, "").unwrap();
 
         let manifest = ProjectManifest::from_path(&root.path().to_path_buf()).unwrap();
         let (model, errors) = ProjectModel::load(vec![manifest]);
@@ -936,10 +947,42 @@ libraries = ["../pkg/rtl"]
 
         assert!(errors.is_empty(), "{errors:#?}");
         assert_eq!(model.workspaces.len(), 1);
-        assert!(model.workspaces[0].roots().is_empty());
-        assert!(load.is_empty());
-        assert_eq!(source_root_config.fileset_roles, vec![SourceRootRole::Ignored]);
-        assert_eq!(project_config.profile_for_root(SourceRootId(0)), None);
+        assert_eq!(model.workspaces[0].roots()[0].role, SourceRootRole::Local);
+        assert_eq!(
+            source_root_config.fileset_roles,
+            vec![SourceRootRole::Local, SourceRootRole::BestEffortIndex, SourceRootRole::Ignored]
+        );
+        assert_eq!(load.len(), 2);
+        assert!(
+            matches!(&load[0], vfs::loader::Entry::Files(files) if files == std::slice::from_ref(&manifest_path))
+        );
+        assert!(matches!(&load[1], vfs::loader::Entry::Directories(_)));
+        assert!(project_config.profile_for_root(SourceRootId(0)).is_some());
+    }
+
+    #[test]
+    fn syntax_only_default_manifest_loads_manifest_without_systemverilog_source() {
+        let root = TestDir::new("project-model-syntax-only-manifest");
+        let manifest_path = root.join(project_manifest::MANIFEST_FILE_NAME);
+        fs::write(&manifest_path, "sources = []\ninclude_dirs = []\n").unwrap();
+
+        let manifest = ProjectManifest::from_path(&root.path().to_path_buf()).unwrap();
+        let (model, errors) = ProjectModel::load(vec![manifest]);
+        let (load, _, source_root_config, project_config) =
+            get_workspace_folder(&model.workspaces, &[]);
+
+        assert!(errors.is_empty(), "{errors:#?}");
+        assert_eq!(model.workspaces.len(), 1);
+        assert_eq!(model.workspaces[0].roots()[0].role, SourceRootRole::Local);
+        assert_eq!(load.len(), 1);
+        assert!(
+            matches!(&load[0], vfs::loader::Entry::Files(files) if files == std::slice::from_ref(&manifest_path))
+        );
+        assert_eq!(
+            source_root_config.fileset_roles,
+            vec![SourceRootRole::Local, SourceRootRole::Ignored]
+        );
+        assert!(project_config.profile_for_root(SourceRootId(0)).is_some());
     }
 
     #[test]
@@ -961,7 +1004,7 @@ include_dirs = ["include"]
         let (load, _, source_root_config, _) = get_workspace_folder(&model.workspaces, &[]);
 
         assert!(errors.is_empty(), "{errors:#?}");
-        assert_eq!(load.len(), 1);
+        assert_eq!(load.len(), 2);
         assert_eq!(
             source_root_config.fileset_roles,
             vec![SourceRootRole::Local, SourceRootRole::Ignored]
@@ -991,7 +1034,7 @@ include_dirs = ["include"]
             get_workspace_folder(&model.workspaces, &[]);
 
         assert!(errors.is_empty(), "{errors:#?}");
-        assert_eq!(load.len(), 2);
+        assert_eq!(load.len(), 3);
         assert_eq!(
             source_root_config.fileset_roles,
             vec![SourceRootRole::Local, SourceRootRole::BestEffortIndex, SourceRootRole::Ignored]
@@ -1048,6 +1091,39 @@ include_dirs = ["include"]
     }
 
     #[test]
+    fn manifest_file_is_loaded_for_navigation_without_becoming_systemverilog_source() {
+        let root = TestDir::new("project-model-manifest-vfs-root");
+        let rtl = root.create_dir_all("rtl");
+        let top = rtl.join("top.sv");
+        fs::write(&top, "module top; endmodule\n").unwrap();
+        let manifest = root.join(project_manifest::MANIFEST_FILE_NAME);
+        fs::write(&manifest, "sources = [\"rtl/**\"]\ndefines = [\"FROM_MANIFEST=1\"]\n").unwrap();
+
+        let project_manifest = ProjectManifest::from_path(&root.path().to_path_buf()).unwrap();
+        let (model, errors) = ProjectModel::load(vec![project_manifest]);
+        let (load, _, source_root_config, _) = get_workspace_folder(&model.workspaces, &[]);
+
+        assert!(errors.is_empty(), "{errors:#?}");
+        assert!(load.iter().any(|entry| {
+            matches!(entry, vfs::loader::Entry::Files(files) if files.contains(&manifest))
+        }));
+
+        let mut vfs = Vfs::default();
+        for file in [&top, &manifest] {
+            vfs.set_file_contents(
+                &VfsPath::from(file.clone()),
+                LoadResult::Loaded(String::new(), LineEnding::Unix),
+            );
+        }
+
+        let roots = source_root_config.partition(&vfs);
+        let manifest_id = roots[0].file_for_path(&VfsPath::from(manifest)).unwrap();
+        let top_id = roots[0].file_for_path(&VfsPath::from(top)).unwrap();
+        assert_eq!(roots[0].file_kind(&manifest_id), SourceFileKind::ProjectManifest);
+        assert_eq!(roots[0].file_kind(&top_id), SourceFileKind::SystemVerilog);
+    }
+
+    #[test]
     fn exclude_globs_filter_loaded_source_files() {
         let base = TestDir::new("project-model-excluded-source-root");
         let root = base.join("root");
@@ -1066,7 +1142,7 @@ exclude = ["rtl/**"]
         let (load, _, _, project_config) = get_workspace_folder(&model.workspaces, &[]);
 
         assert!(errors.is_empty(), "{errors:#?}");
-        assert_eq!(load.len(), 1);
+        assert_eq!(load.len(), 2);
         let dirs = match &load[0] {
             vfs::loader::Entry::Directories(dirs) => dirs,
             other => panic!("expected directory loader entry, got {other:?}"),
@@ -1099,7 +1175,7 @@ exclude = ["rtl/excluded/**"]
         let (load, _, source_root_config, _) = get_workspace_folder(&model.workspaces, &[]);
 
         assert!(errors.is_empty(), "{errors:#?}");
-        assert_eq!(load.len(), 1);
+        assert_eq!(load.len(), 2);
         let dirs = match &load[0] {
             vfs::loader::Entry::Directories(dirs) => dirs,
             other => panic!("expected directory loader entry, got {other:?}"),
@@ -1224,7 +1300,7 @@ include_dirs = []
         let (load, _, source_root_config, _) = get_workspace_folder(&model.workspaces, &[]);
 
         assert!(errors.is_empty(), "{errors:#?}");
-        assert_eq!(load.len(), 1);
+        assert_eq!(load.len(), 2);
         assert!(
             matches!(&load[0], vfs::loader::Entry::Files(files) if files == std::slice::from_ref(&top))
         );

--- a/crates/project-model/src/macro_def.rs
+++ b/crates/project-model/src/macro_def.rs
@@ -1,5 +1,7 @@
+use hir::base_db::project::{Predefine, PredefineSource};
 use rustc_hash::FxHashSet;
 use smol_str::SmolStr;
+use utils::{line_index::TextRange, paths::AbsPathBuf};
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 pub enum MacroAtom {
@@ -10,19 +12,48 @@ pub enum MacroAtom {
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct MacroDef {
     pub macros: FxHashSet<MacroAtom>,
+    pub sources: Vec<MacroDefSource>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct MacroDefSource {
+    pub atom: MacroAtom,
+    pub range: TextRange,
 }
 
 impl MacroDef {
     pub fn to_predefine_strings(&self) -> Vec<String> {
+        self.to_predefines(None).into_iter().map(|predefine| predefine.definition).collect()
+    }
+
+    pub fn to_predefines(&self, manifest_path: Option<&AbsPathBuf>) -> Vec<Predefine> {
         let mut predefines = self
             .macros
             .iter()
-            .map(|macro_atom| match macro_atom {
-                MacroAtom::Flag(name) => name.to_string(),
-                MacroAtom::KeyValue { key, value } => format!("{key}={value}"),
+            .map(|macro_atom| {
+                let definition = macro_atom.predefine_string();
+                let source = manifest_path.and_then(|path| {
+                    let mut matches = self
+                        .sources
+                        .iter()
+                        .filter(|source| source.atom == *macro_atom)
+                        .map(|source| source.range);
+                    let range = matches.next()?;
+                    matches.next().is_none().then(|| PredefineSource { path: path.clone(), range })
+                });
+                Predefine { definition, source }
             })
             .collect::<Vec<_>>();
-        predefines.sort();
+        predefines.sort_by(|left, right| left.definition.cmp(&right.definition));
         predefines
+    }
+}
+
+impl MacroAtom {
+    fn predefine_string(&self) -> String {
+        match self {
+            MacroAtom::Flag(name) => name.to_string(),
+            MacroAtom::KeyValue { key, value } => format!("{key}={value}"),
+        }
     }
 }

--- a/crates/project-model/src/toml_workspace.rs
+++ b/crates/project-model/src/toml_workspace.rs
@@ -6,9 +6,13 @@ use regex::Regex;
 use rustc_hash::FxHashSet;
 use serde::Deserialize;
 use smol_str::SmolStr;
-use utils::paths::{AbsPathBuf, Utf8PathBuf};
+use toml::Spanned;
+use utils::{
+    line_index::{TextRange, TextSize},
+    paths::{AbsPathBuf, Utf8PathBuf},
+};
 
-use crate::macro_def::{MacroAtom, MacroDef};
+use crate::macro_def::{MacroAtom, MacroDef, MacroDefSource};
 #[cfg(feature = "manifest-schema")]
 use crate::project_manifest::MANIFEST_FILE_NAME;
 
@@ -144,54 +148,59 @@ fn de_macros<'de, D>(deserializer: D) -> Result<MacroDef, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    let res = Vec::<SmolStr>::deserialize(deserializer)?;
+    let res = Vec::<Spanned<SmolStr>>::deserialize(deserializer)?;
     let ident_re = IDENT_RE.as_ref().map_err(|err| {
         serde::de::Error::custom(format!("invalid macro identifier regex: {err}"))
     })?;
     let kv_re = KV_RE
         .as_ref()
         .map_err(|err| serde::de::Error::custom(format!("invalid macro key-value regex: {err}")))?;
-    let macros = res
-        .into_iter()
-        .map(|macr: SmolStr| {
-            if ident_re.is_match(&macr) {
-                Ok(MacroAtom::Flag(macr))
-            } else if let Some(caps) = kv_re.captures(&macr) {
-                let Some(key_match) = caps.get(1) else {
+    let mut macros = FxHashSet::default();
+    let mut sources = Vec::new();
+    for macr in res {
+        let range = spanned_text_range(macr.span()).map_err(serde::de::Error::custom)?;
+        let macr = macr.into_inner();
+        let atom = if ident_re.is_match(&macr) {
+            Ok(MacroAtom::Flag(macr))
+        } else if let Some(caps) = kv_re.captures(&macr) {
+            let Some(key_match) = caps.get(1) else {
+                return Err(serde::de::Error::custom(format!("Invalid macro definition: {macr}")));
+            };
+            let Some(value_match) = caps.get(2) else {
+                return Err(serde::de::Error::custom(format!("Invalid macro definition: {macr}")));
+            };
+            let mut key: SmolStr = key_match.as_str().into();
+            let value = value_match.as_str().into();
+            if key.starts_with('\\') {
+                let Some(stripped) = key.strip_prefix('\\').and_then(|key| key.strip_suffix(' '))
+                else {
                     return Err(serde::de::Error::custom(format!(
-                        "Invalid macro definition: {macr}"
+                        "Invalid escaped macro name: {macr}"
                     )));
                 };
-                let Some(value_match) = caps.get(2) else {
-                    return Err(serde::de::Error::custom(format!(
-                        "Invalid macro definition: {macr}"
-                    )));
-                };
-                let mut key: SmolStr = key_match.as_str().into();
-                let value = value_match.as_str().into();
-                if key.starts_with('\\') {
-                    let Some(stripped) =
-                        key.strip_prefix('\\').and_then(|key| key.strip_suffix(' '))
-                    else {
-                        return Err(serde::de::Error::custom(format!(
-                            "Invalid escaped macro name: {macr}"
-                        )));
-                    };
-                    key = stripped.into();
-                }
-                Ok(MacroAtom::KeyValue { key, value })
-            } else {
-                Err(serde::de::Error::custom(format!("Invalid macro definition: {macr}")))
+                key = stripped.into();
             }
-        })
-        .collect::<Result<Vec<_>, _>>()?
-        .into_iter()
-        .collect::<FxHashSet<_>>();
-    Ok(MacroDef { macros })
+            Ok(MacroAtom::KeyValue { key, value })
+        } else {
+            Err(serde::de::Error::custom(format!("Invalid macro definition: {macr}")))
+        }?;
+        macros.insert(atom.clone());
+        sources.push(MacroDefSource { atom, range });
+    }
+    Ok(MacroDef { macros, sources })
+}
+
+fn spanned_text_range(span: std::ops::Range<usize>) -> Result<TextRange, String> {
+    let start = u32::try_from(span.start)
+        .map_err(|_| format!("manifest range start is too large: {}", span.start))?;
+    let end = u32::try_from(span.end)
+        .map_err(|_| format!("manifest range end is too large: {}", span.end))?;
+    Ok(TextRange::new(TextSize::from(start), TextSize::from(end)))
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct TomlWorkspace {
+    pub manifest_path: AbsPathBuf,
     pub top_modules: Vec<String>,
     pub workspace_root: AbsPathBuf,
     pub macro_defs: MacroDef,
@@ -228,6 +237,7 @@ impl TomlWorkspace {
         let exclude_patterns = toml_schema.exclude;
 
         Ok(TomlWorkspace {
+            manifest_path: toml.clone(),
             top_modules,
             workspace_root,
             macro_defs,
@@ -267,7 +277,22 @@ defines = [
         macros.insert(MacroAtom::KeyValue { key: "BAR".into(), value: "foo".into() });
         macros.insert(MacroAtom::KeyValue { key: "BAZ".into(), value: "foo bar".into() });
         macros.insert(MacroAtom::KeyValue { key: "eqwe".into(), value: "123".into() });
-        assert_eq!(toml_schema.defines, MacroDef { macros });
+        assert_eq!(toml_schema.defines.macros, macros);
+        assert_eq!(toml_schema.defines.sources.len(), 6);
+        assert_eq!(
+            toml_schema.defines.sources[0],
+            MacroDefSource {
+                atom: MacroAtom::Flag("foo".into()),
+                range: range_of(toml, "\"foo\"")
+            }
+        );
+        assert_eq!(
+            toml_schema.defines.sources[2],
+            MacroDefSource {
+                atom: MacroAtom::KeyValue { key: "FOO".into(), value: "bar".into() },
+                range: range_of(toml, "\"FOO=bar\"")
+            }
+        );
     }
 
     #[test]
@@ -280,6 +305,29 @@ defines = [
         "#;
         let toml_schema: TomlManifestSchema = toml::from_str(toml).unwrap();
         assert_eq!(toml_schema.defines.to_predefine_strings(), ["BAR=foo", "FOO"]);
+    }
+
+    #[test]
+    fn macro_predefines_keep_manifest_source_ranges() {
+        let root = TestDir::new("manifest-predefine-ranges");
+        let manifest_text = r#"
+defines = [
+    "BAR=foo",
+    "FOO",
+]
+"#;
+        let manifest = root.write("vide.toml", manifest_text);
+
+        let workspace = TomlWorkspace::load_from_file(&manifest).unwrap();
+        let predefines = workspace.macro_defs.to_predefines(Some(&workspace.manifest_path));
+
+        let foo = predefines
+            .iter()
+            .find(|predefine| predefine.definition == "FOO")
+            .expect("FOO predefine expected");
+        let source = foo.source.as_ref().expect("FOO should carry manifest source");
+        assert_eq!(source.path, manifest);
+        assert_eq!(source.range, range_of(manifest_text, "\"FOO\""));
     }
 
     #[test]
@@ -345,5 +393,13 @@ libraries = ["../pkg"]
 
         assert_eq!(workspace.include_dirs, Some(vec![root.join("include")]));
         assert_eq!(workspace.libraries, [root.join("../pkg")]);
+    }
+
+    fn range_of(text: &str, needle: &str) -> TextRange {
+        let start = text.find(needle).expect("needle should exist in fixture");
+        TextRange::new(
+            TextSize::from(u32::try_from(start).unwrap()),
+            TextSize::from(u32::try_from(start + needle.len()).unwrap()),
+        )
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4156,6 +4156,80 @@ endmodule
 }
 
 #[test]
+fn manifest_defined_macro_powers_lsp_ide_features() {
+    let temp_dir = TempDir::new("manifest-macro-lsp-features");
+    let rtl_dir = temp_dir.path().join("rtl");
+    fs::create_dir_all(&rtl_dir).unwrap();
+
+    let top_text = r#"`ifdef FROM_MANIFEST
+module top;
+  localparam int W = `FROM_MANIFEST;
+endmodule
+`endif
+"#;
+    let manifest_text =
+        "top_modules = [\"top\"]\nsources = [\"rtl/*.sv\"]\ndefines = [\"FROM_MANIFEST=1\"]\n";
+
+    let top_path = rtl_dir.join("top.sv");
+    let manifest_path = temp_dir.path().join("vide.toml");
+    fs::write(&top_path, top_text).unwrap();
+    fs::write(&manifest_path, manifest_text).unwrap();
+
+    let (client, server_thread) = spawn_test_workspace(
+        temp_dir.path().to_path_buf(),
+        ClientCapabilities::default(),
+        UserConfig::default(),
+    );
+    let top_uri = to_proto::url_from_abs_path(top_path.as_path()).unwrap();
+    let manifest_uri = to_proto::url_from_abs_path(manifest_path.as_path()).unwrap();
+    open_test_document(&client, top_uri.clone(), top_text);
+
+    let (_result_id, diagnostics) = request_document_diagnostics(&client, top_uri.clone(), 1);
+    assert!(
+        diagnostics.iter().all(|diag| !diag.message.contains("unknown macro")),
+        "manifest define should feed preprocessor diagnostics: {diagnostics:?}"
+    );
+
+    let definition_uris =
+        request_goto_definition_uris(&client, top_uri.clone(), top_text, "FROM_MANIFEST;", 2);
+    assert!(
+        definition_uris.contains(&manifest_uri),
+        "manifest macro goto should reach vide.toml define: {definition_uris:?}"
+    );
+
+    let hover = request_hover(&client, top_uri.clone(), top_text, "FROM_MANIFEST;", 3)
+        .expect("manifest macro hover expected from source use");
+    let hover_text = format!("{:?}", hover.contents);
+    assert!(
+        hover_text.contains("FROM_MANIFEST"),
+        "manifest macro hover should mention macro name: {hover_text}"
+    );
+
+    let manifest_hover =
+        request_hover(&client, manifest_uri.clone(), manifest_text, "FROM_MANIFEST=1", 4)
+            .expect("manifest macro hover expected from manifest define");
+    let manifest_hover_text = format!("{:?}", manifest_hover.contents);
+    assert!(
+        manifest_hover_text.contains("FROM_MANIFEST"),
+        "manifest define hover should mention macro name: {manifest_hover_text}"
+    );
+
+    let manifest_definition_uris = request_goto_definition_uris(
+        &client,
+        manifest_uri.clone(),
+        manifest_text,
+        "FROM_MANIFEST=1",
+        5,
+    );
+    assert!(
+        manifest_definition_uris.contains(&manifest_uri),
+        "manifest define should be linkable to itself: {manifest_definition_uris:?}"
+    );
+
+    shutdown_test_server(&client, server_thread);
+}
+
+#[test]
 fn references_request_respects_include_declaration() {
     let temp_dir = TempDir::new("references-include-declaration");
     let rtl_dir = temp_dir.path().join("rtl");


### PR DESCRIPTION
## Summary
- preserve manifest source ranges for configured predefines from vide.toml
- expose manifest-backed predefine definitions through HIR preproc navigation/reference APIs
- load project manifests as non-source VFS files so IDE goto/hover can target them without passing them to slang diagnostics

## Validation
- cargo fmt --check
- cargo test -p project-model -- --nocapture
- cargo test -p preproc
- cargo test -p hir preproc -- --nocapture
- cargo test -p ide preproc -- --nocapture
- cargo test -p vide manifest_defined_macro_powers_lsp_ide_features -- --nocapture
- cargo test -p vide project_manifest_is_not_diagnosed_as_systemverilog -- --nocapture
- cargo check -p ide
- cargo check -p vide
- git diff --check