### PR TITLE
fix(preproc): preserve macro hover expansion output

### DIFF
--- a/crates/hir/src/base_db/source_db/preproc/source_mapping.rs
+++ b/crates/hir/src/base_db/source_db/preproc/source_mapping.rs
@@ -465,12 +465,11 @@ fn expansion_display_text_and_ranges(
     {
         let token_id = SourceEmittedTokenId::new(raw);
         let token = model.emitted_tokens().get(token_id)?;
-        if !text.is_empty() {
-            text.push(' ');
-        }
-        let start = text.len();
-        text.push_str(token.text.as_str());
-        let end = text.len();
+        let display = token.display.as_str();
+        let token_start_in_display = display.strip_suffix(token.text.as_str())?.len();
+        let start = text.len().checked_add(token_start_in_display)?;
+        let end = start.checked_add(token.text.len())?;
+        text.push_str(display);
         token_ranges.insert(
             token_id,
             TextRange::new(

--- a/crates/hir/src/preproc/helpers/expansion.rs
+++ b/crates/hir/src/preproc/helpers/expansion.rs
@@ -18,6 +18,13 @@ pub(in crate::preproc) fn map_macro_expansion(
         definition_id,
         definition,
         emitted_token_range: expansion.emitted_token_range,
+        display_text: mapped
+            .source_map
+            .expansion_display_text(expansion.id)
+            .ok_or(PreprocError::SourceMap(PreprocSourceMapError::MissingExpansionVirtualFile {
+                expansion: expansion.id,
+            }))?
+            .to_owned(),
         display_source: map_expansion_display_source(mapped, expansion.id)?,
         display_range: mapped
             .source_map

--- a/crates/hir/src/preproc/tests.rs
+++ b/crates/hir/src/preproc/tests.rs
@@ -412,8 +412,9 @@ endmodule
     let mapped = mapped.as_ref().as_ref().unwrap();
     let expansion_display =
         mapped.source_map.expansion_display_text(SourceMacroExpansionId::new(0)).unwrap();
-    assert_eq!(expansion_display, "logic generated ;");
-    assert_eq!(provenance.expansion.display_range, TextRange::new(0.into(), 17.into()));
+    assert_eq!(expansion_display, "\nlogic generated;");
+    assert_eq!(provenance.expansion.display_text, expansion_display);
+    assert_eq!(provenance.expansion.display_range, TextRange::new(1.into(), 17.into()));
 
     let logic = provenance
         .tokens
@@ -425,7 +426,7 @@ endmodule
     };
     assert_eq!(source.file_id(), Some(TOP));
     assert_eq!(text_at_range(root_text, *range), "logic");
-    assert_eq!(logic.display_range, TextRange::new(0.into(), 5.into()));
+    assert_eq!(logic.display_range, TextRange::new(1.into(), 6.into()));
 
     let generated = provenance
         .tokens
@@ -440,7 +441,37 @@ endmodule
     assert_eq!(*argument_index, 0);
     assert_eq!(source.file_id(), Some(TOP));
     assert_eq!(text_at_range(root_text, *range), "generated");
-    assert_eq!(generated.display_range, TextRange::new(6.into(), 15.into()));
+    assert_eq!(generated.display_range, TextRange::new(7.into(), 16.into()));
+}
+
+#[test]
+fn preproc_macro_expansion_display_keeps_emitted_token_trivia() {
+    let root_text = r#"`define BLOCK(name) \
+  always_ff @(posedge clk) begin \
+    name <= 1; \
+  end
+module top;
+  `BLOCK(q)
+endmodule
+"#;
+    let db = db_with_entries(&[(TOP, "rtl/top.v", root_text)]);
+
+    let provenance =
+        macro_expansion_provenance_at(&db, TOP, offset(root_text, "`BLOCK")).unwrap().unwrap();
+    let mapped = db.source_preproc_model(TOP);
+    let mapped = mapped.as_ref().as_ref().unwrap();
+    let display_text = mapped
+        .source_map
+        .expansion_display_text(SourceMacroExpansionId::new(provenance.expansion.id.raw()))
+        .unwrap();
+
+    assert_eq!(provenance.expansion.display_text, display_text);
+    assert!(
+        display_text.contains("\n  always_ff")
+            && display_text.contains("\n    q <= 1;")
+            && display_text.contains("\n  end"),
+        "expansion display text should preserve emitted token trivia: {display_text:?}"
+    );
 }
 
 #[test]

--- a/crates/hir/src/preproc/types.rs
+++ b/crates/hir/src/preproc/types.rs
@@ -294,6 +294,7 @@ pub struct MacroExpansion {
     pub definition_id: Option<MacroDefinitionId>,
     pub definition: MacroExpansionDefinition,
     pub emitted_token_range: SourceEmittedTokenRange,
+    pub display_text: String,
     pub display_source: MappedPreprocSource,
     pub display_range: TextRange,
     pub child_calls: Vec<MacroCallId>,

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -7,11 +7,10 @@ use hir::{
     file::HirFileId,
     hir_def::expr::Expr,
     preproc::{
-        EmittedTokenProvenance, IncludeTarget, MacroDefinition, MacroExpansionDefinition,
-        MacroParamDefinition, MacroReferenceDefinitions, RecursiveMacroExpansionProvenance,
-        include_directives_at, macro_definition_at, macro_param_definition_at,
-        macro_param_reference_definitions_at, macro_reference_definitions_at,
-        recursive_macro_expansion_provenances_at,
+        IncludeTarget, MacroDefinition, MacroExpansionDefinition, MacroParamDefinition,
+        MacroReferenceDefinitions, RecursiveMacroExpansionProvenance, include_directives_at,
+        macro_definition_at, macro_param_definition_at, macro_param_reference_definitions_at,
+        macro_reference_definitions_at, recursive_macro_expansion_provenances_at,
     },
     semantics::Semantics,
 };
@@ -235,7 +234,9 @@ fn render_recursive_expansion(
     }
     render_macro_expansion_header(markup, &root.expansion.definition);
     render_macro_expansion_separator(markup);
-    markup.push_with_code_fence(&expanded_text_from_tokens(&root.tokens));
+    markup.print("Expands to");
+    markup.newline();
+    markup.push_with_code_fence(&macro_expansion_hover_text(root.expansion.display_text.as_str()));
     render_macro_expansion_separator(markup);
     if let MacroExpansionDefinition::Source(definition) = &root.expansion.definition {
         render_macro_source_link(db, markup, definition, root.expansion.call.file_id);
@@ -370,15 +371,47 @@ fn file_link_target(path: &str) -> String {
     if path.starts_with('/') { format!("file://{path}") } else { format!("file:///{path}") }
 }
 
-fn expanded_text_from_tokens(tokens: &[EmittedTokenProvenance]) -> String {
-    let mut text = String::new();
-    for (index, token) in tokens.iter().enumerate() {
-        if index > 0 {
-            text.push(' ');
-        }
-        text.push_str(token.text.as_str());
-    }
-    text
+fn macro_expansion_hover_text(text: &str) -> String {
+    let lines = text.lines().collect::<Vec<_>>();
+    let start = lines.iter().position(|line| !line.trim().is_empty()).unwrap_or(lines.len());
+    let end = lines
+        .iter()
+        .rposition(|line| !line.trim().is_empty())
+        .map(|index| index + 1)
+        .unwrap_or(start);
+    let lines = &lines[start..end];
+
+    let common_indent = lines
+        .iter()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| leading_indent(line))
+        .reduce(common_whitespace_prefix)
+        .unwrap_or_default();
+
+    lines
+        .iter()
+        .map(|line| {
+            if line.trim().is_empty() {
+                ""
+            } else {
+                line.strip_prefix(common_indent).unwrap_or(line)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn leading_indent(line: &str) -> &str {
+    let end = line
+        .char_indices()
+        .find_map(|(index, ch)| (!matches!(ch, ' ' | '\t')).then_some(index))
+        .unwrap_or(line.len());
+    &line[..end]
+}
+
+fn common_whitespace_prefix<'a>(left: &'a str, right: &'a str) -> &'a str {
+    let end = left.bytes().zip(right.bytes()).take_while(|(left, right)| left == right).count();
+    &left[..end]
 }
 
 fn covering_range(ranges: &[TextRange]) -> Option<TextRange> {
@@ -593,4 +626,24 @@ fn handle_definition(
     }
 
     Some(res)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn macro_expansion_hover_text_dedents_common_indentation() {
+        let text = "\n    always_ff @(posedge clk) begin\n      q <= 1;\n    end\n";
+
+        assert_eq!(
+            macro_expansion_hover_text(text),
+            "always_ff @(posedge clk) begin\n  q <= 1;\nend"
+        );
+    }
+
+    #[test]
+    fn macro_expansion_hover_text_removes_single_line_callsite_indent() {
+        assert_eq!(macro_expansion_hover_text("  logic generated;"), "logic generated;");
+    }
 }

--- a/crates/ide/src/verilog_2005.rs
+++ b/crates/ide/src/verilog_2005.rs
@@ -1493,9 +1493,9 @@ endmodule
             && info.contains("Macro")
             && info.contains("`MAKE_DECL(name)")
             && !info.contains("`define `MAKE_DECL(name)")
-            && !info.contains("Expands to")
+            && info.contains("Expands to")
             && info.contains("--------------------")
-            && info.contains("logic generated ;")
+            && info.contains("logic generated;")
             && info.contains("from [feature.v]")
             && !info.contains("Context ")
             && !info.contains("Signature")
@@ -1572,9 +1572,9 @@ endmodule
             && info.contains("`DEMO_NEXT(value)")
             && !info.contains("`define `DEMO_NEXT(value)")
             && !info.contains("`MATH_ONE")
-            && !info.contains("Expands to")
+            && info.contains("Expands to")
             && info.contains("--------------------")
-            && info.contains("( ( payload_i ) + 12 'd 1 )")
+            && info.contains("((payload_i) + 12'd1)")
             && info.contains("payload_i")
             && info.contains("12")
             && info.contains("'d")
@@ -1609,9 +1609,9 @@ endmodule
             && call_info.contains("`DEMO_NEXT(value)")
             && !call_info.contains("`define `DEMO_NEXT(value)")
             && !call_info.contains("`MATH_ONE")
-            && !call_info.contains("Expands to")
+            && call_info.contains("Expands to")
             && call_info.contains("--------------------")
-            && call_info.contains("( ( payload_i ) + 12 'd 1 )")
+            && call_info.contains("((payload_i) + 12'd1)")
             && call_info.contains("payload_i")
             && call_info.contains("12")
             && call_info.contains("from [feature.v]")
@@ -1643,7 +1643,7 @@ endmodule
             && payl_info.contains("Macro")
             && payl_info.contains("`PAYL")
             && !payl_info.contains("`define `PAYL payload_i")
-            && !payl_info.contains("Expands to")
+            && payl_info.contains("Expands to")
             && payl_info.contains("--------------------")
             && payl_info.contains("payload_i")
             && payl_info.contains("from [feature.v]")
@@ -1753,7 +1753,8 @@ endmodule
         decl_info.contains("```systemverilog")
             && decl_info.contains("`DECL_PIPE(name, width)")
             && !decl_info.contains("`define `DECL_PIPE(name, width)")
-            && decl_info.contains("logic [ ( 12 ) - 1 : 0 ] sample_q")
+            && decl_info.contains("Expands to")
+            && decl_info.contains("logic [(12)-1:0] sample_q")
             && !decl_info.contains("unavailable"),
         "DECL_PIPE hover should show expansion through configured predefine: {decl_info}"
     );
@@ -1769,8 +1770,8 @@ endmodule
     assert!(
         assign_info.contains("`PIPE_ASSIGN(name, next_value)")
             && !assign_info.contains("`define `PIPE_ASSIGN(name, next_value)")
-            && assign_info
-                .contains("trace_q <= ( sample_q ^ { { ( 12 - 1 ) { 1 'b 0 } } , 1 'b 1 } )")
+            && assign_info.contains("Expands to")
+            && assign_info.contains("trace_q <= (sample_q ^ {{(12-1){1'b0}}, 1'b1});")
             && !assign_info.contains("unavailable"),
         "PIPE_ASSIGN hover should show actual-argument expansion through configured predefine: {assign_info}"
     );

--- a/crates/ide/src/verilog_2005.rs
+++ b/crates/ide/src/verilog_2005.rs
@@ -1679,6 +1679,104 @@ endmodule
 }
 
 #[test]
+fn preproc_macro_hover_expands_through_configured_predefine_argument() {
+    let dir = TestDir::new("manifest-predefine-macro-hover");
+    let top_path = dir.path().join("top.sv");
+    let manifest_path = dir.path().join("vide.toml");
+    let marked_top_text = normalize_fixture_text(
+        r#"
+`define DECL_PIPE(name, width) logic [(width)-1:0] name``_q
+`define PIPE_ASSIGN(name, next_value) \
+  always_ff @(posedge clk_i or negedge rst_ni) begin \
+    if (!rst_ni) begin \
+      name``_q <= '0; \
+    end else begin \
+      name``_q <= (next_value); \
+    end \
+  end
+module top;
+  `/*marker:decl_call*/DECL_PIPE(sample, `LANE_WIDTH);
+  `/*marker:assign_call*/PIPE_ASSIGN(trace, sample_q ^ {{(`LANE_WIDTH-1){1'b0}}, 1'b1});
+endmodule
+"#,
+    );
+    let marked_manifest_text =
+        normalize_fixture_text(r#"defines = [/*marker:def*/"LANE_WIDTH=12"]"#);
+    let (top_text, top_markers) = strip_markers(marked_top_text);
+    let (manifest_text, manifest_markers) = strip_markers(marked_manifest_text);
+    let manifest_range = marked_range(&manifest_markers, "def", TextSize::of("\"LANE_WIDTH=12\""));
+
+    let top_file_id = FileId(0);
+    let manifest_file_id = FileId(1);
+    let mut file_set = FileSet::default();
+    file_set.insert(top_file_id, VfsPath::from(top_path));
+    file_set.insert(manifest_file_id, VfsPath::from(manifest_path.clone()));
+
+    let mut change = Change::new();
+    change.set_roots(vec![SourceRoot::new_local_with_source_files(file_set, vec![top_file_id])]);
+    change.set_project_config(Arc::new(ProjectConfig::new(
+        vec![Some(CompilationProfileId(0))],
+        vec![CompilationProfile {
+            source_roots: vec![SourceRootId(0)],
+            top_modules: Vec::new(),
+            preprocess: PreprocessConfig {
+                predefines: vec![Predefine::with_source(
+                    "LANE_WIDTH=12",
+                    PredefineSource { path: manifest_path, range: manifest_range },
+                )],
+                include_dirs: Vec::new(),
+            },
+        }],
+    )));
+    change.add_changed_file(ChangedFile {
+        file_id: top_file_id,
+        change_kind: ChangeKind::Create(Arc::from(top_text.as_str()), LineEnding::Unix),
+    });
+    change.add_changed_file(ChangedFile {
+        file_id: manifest_file_id,
+        change_kind: ChangeKind::Create(Arc::from(manifest_text.as_str()), LineEnding::Unix),
+    });
+
+    let mut host = AnalysisHost::default();
+    host.apply_change(change);
+    let analysis = host.make_analysis();
+
+    let decl_hover = analysis
+        .hover(
+            position(top_file_id, &top_markers, "decl_call"),
+            HoverConfig { format: HoverFormat::PlainText },
+        )
+        .unwrap()
+        .expect("DECL_PIPE macro call hover expected");
+    let decl_info = decl_hover.info.as_str();
+    assert!(
+        decl_info.contains("```systemverilog")
+            && decl_info.contains("`DECL_PIPE(name, width)")
+            && !decl_info.contains("`define `DECL_PIPE(name, width)")
+            && decl_info.contains("logic [ ( 12 ) - 1 : 0 ] sample_q")
+            && !decl_info.contains("unavailable"),
+        "DECL_PIPE hover should show expansion through configured predefine: {decl_info}"
+    );
+
+    let assign_hover = analysis
+        .hover(
+            position(top_file_id, &top_markers, "assign_call"),
+            HoverConfig { format: HoverFormat::PlainText },
+        )
+        .unwrap()
+        .expect("PIPE_ASSIGN macro call hover expected");
+    let assign_info = assign_hover.info.as_str();
+    assert!(
+        assign_info.contains("`PIPE_ASSIGN(name, next_value)")
+            && !assign_info.contains("`define `PIPE_ASSIGN(name, next_value)")
+            && assign_info
+                .contains("trace_q <= ( sample_q ^ { { ( 12 - 1 ) { 1 'b 0 } } , 1 'b 1 } )")
+            && !assign_info.contains("unavailable"),
+        "PIPE_ASSIGN hover should show actual-argument expansion through configured predefine: {assign_info}"
+    );
+}
+
+#[test]
 fn preproc_macro_definition_supports_navigation_and_hover() {
     let text = r#"
 `define /*marker:definition*/LOCAL_WIDTH 8

--- a/crates/preproc/src/source/model/tests.rs
+++ b/crates/preproc/src/source/model/tests.rs
@@ -755,6 +755,7 @@ fn source_model_uses_direct_definition_identity_when_body_ranges_collide() {
         emitted_tokens: vec![syntax::PreprocessorTraceEmittedToken {
             raw_text: "2".to_owned(),
             value_text: "2".to_owned(),
+            display_text: "2".to_owned(),
             token_kind: TokenKind::INTEGER_LITERAL,
             provenance: PreprocessorTraceTokenProvenance::MacroBody {
                 macro_name: "B".to_owned(),
@@ -888,6 +889,7 @@ fn source_model_marks_missing_direct_identity_partial_without_range_fallback() {
         emitted_tokens: vec![SourceEmittedTokenFact {
             raw: SmolStr::new("1"),
             value: SmolStr::new("1"),
+            display: SmolStr::new("1"),
             kind: SourceTokenKind::Syntax(TokenKind::INTEGER_LITERAL),
             provenance: SourceTokenProvenanceFact::MacroBody {
                 macro_name: SmolStr::new("A"),

--- a/crates/preproc/src/source/model/tests.rs
+++ b/crates/preproc/src/source/model/tests.rs
@@ -1358,6 +1358,111 @@ endmodule
 }
 
 #[test]
+fn source_model_keeps_macro_expansion_contiguous_across_predefine_tokens() {
+    let root_text = r#"`define DECL_PIPE(name, width) logic [(width)-1:0] name``_q
+module m;
+  `DECL_PIPE(sample, `LANE_WIDTH);
+endmodule
+"#;
+    let (model, _root_source) = source_model_from_root(
+        root_text,
+        SyntaxTreeOptions {
+            predefines: vec!["LANE_WIDTH=12".to_owned()],
+            ..SyntaxTreeOptions::default()
+        },
+    );
+
+    let decl_call = model
+        .macro_calls()
+        .iter()
+        .find(|call| {
+            model
+                .macro_references()
+                .get(call.reference)
+                .is_some_and(|reference| reference.name.as_str() == "DECL_PIPE")
+        })
+        .expect("DECL_PIPE call should be traced");
+    assert_eq!(decl_call.status, SourceMacroCallStatus::ExpansionAvailable);
+
+    let SourceMacroExpansionQuery::Available(expansion_id) =
+        model.immediate_macro_expansion(decl_call.id)
+    else {
+        panic!("DECL_PIPE call should have a complete expansion");
+    };
+    let expansion = model.macro_expansions().get(expansion_id).unwrap();
+    let start = expansion.emitted_token_range.start.raw();
+    let end = start + expansion.emitted_token_range.len;
+    let expanded = (start..end)
+        .filter_map(|raw| model.emitted_tokens().get(SourceEmittedTokenId::new(raw)))
+        .map(|token| token.text.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    assert!(
+        expanded.contains("logic [ ( 12 ) - 1 : 0 ] sample_q"),
+        "predefine token should stay inside the parent expansion stream: {expanded}"
+    );
+    assert_eq!(model.capabilities().macro_expansions, CapabilityStatus::Complete);
+    assert_eq!(model.capabilities().emitted_token_provenance, CapabilityStatus::Complete);
+}
+
+#[test]
+fn source_model_keeps_macro_actual_argument_expansion_contiguous_across_predefine_tokens() {
+    let root_text = r#"`define PIPE_ASSIGN(name, next_value) \
+  always_ff @(posedge clk_i or negedge rst_ni) begin \
+    if (!rst_ni) begin \
+      name``_q <= '0; \
+    end else begin \
+      name``_q <= (next_value); \
+    end \
+  end
+module m;
+  `PIPE_ASSIGN(trace, sample_q ^ {{(`LANE_WIDTH-1){1'b0}}, 1'b1});
+endmodule
+"#;
+    let (model, _root_source) = source_model_from_root(
+        root_text,
+        SyntaxTreeOptions {
+            predefines: vec!["LANE_WIDTH=12".to_owned()],
+            ..SyntaxTreeOptions::default()
+        },
+    );
+
+    let pipe_call = model
+        .macro_calls()
+        .iter()
+        .find(|call| {
+            model
+                .macro_references()
+                .get(call.reference)
+                .is_some_and(|reference| reference.name.as_str() == "PIPE_ASSIGN")
+        })
+        .expect("PIPE_ASSIGN call should be traced");
+    assert_eq!(pipe_call.status, SourceMacroCallStatus::ExpansionAvailable);
+
+    let SourceMacroExpansionQuery::Available(expansion_id) =
+        model.immediate_macro_expansion(pipe_call.id)
+    else {
+        panic!("PIPE_ASSIGN call should have a complete expansion");
+    };
+    let expansion = model.macro_expansions().get(expansion_id).unwrap();
+    let start = expansion.emitted_token_range.start.raw();
+    let end = start + expansion.emitted_token_range.len;
+    let expanded = (start..end)
+        .filter_map(|raw| model.emitted_tokens().get(SourceEmittedTokenId::new(raw)))
+        .map(|token| token.text.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    assert!(
+        expanded.contains("trace_q <= ( sample_q ^ { { ( 12 - 1 ) { 1 'b 0 } } , 1 'b 1 } )"),
+        "predefine token and following argument tokens should stay inside the parent expansion stream: {expanded}"
+    );
+    assert_eq!(model.capabilities().macro_expansions, CapabilityStatus::Complete);
+    assert_eq!(model.capabilities().emitted_token_provenance, CapabilityStatus::Complete);
+}
+
+#[test]
 fn source_model_resolves_conditional_tokens_to_visible_defines() {
     let root_text = r#"`include "defs.vh"
 `ifdef HEADER_FLAG

--- a/crates/preproc/src/source/provenance.rs
+++ b/crates/preproc/src/source/provenance.rs
@@ -284,6 +284,7 @@ pub struct SourceEmittedTokenRange {
 pub struct SourceEmittedToken {
     pub id: SourceEmittedTokenId,
     pub text: SmolStr,
+    pub display: SmolStr,
     pub kind: SourceTokenKind,
     pub emitted_range: SourceEmittedTokenRange,
     pub provenance: SourceTokenProvenanceId,

--- a/crates/preproc/src/source/provenance/builder.rs
+++ b/crates/preproc/src/source/provenance/builder.rs
@@ -11,6 +11,8 @@ pub struct SourcePreprocModelBuilder<'a> {
     definition_ids_by_identity: BTreeMap<SourceMacroDefinitionKey, SourceMacroDefinitionId>,
     call_ids_by_identity: BTreeMap<SourceMacroCallKey, SourceMacroCallId>,
     call_ids_by_expansion_identity: BTreeMap<SourceMacroExpansionKey, SourceMacroCallId>,
+    // Expansion ownership comes from trace identities, not from source provenance.
+    emitted_token_owners: BTreeMap<SourceEmittedTokenId, SourceMacroCallId>,
     current_state: BTreeMap<SmolStr, SourceMacroDefinitionId>,
     definition_ranges_partial: bool,
     include_edges_partial: bool,
@@ -35,6 +37,7 @@ impl<'a> SourcePreprocModelBuilder<'a> {
             definition_ids_by_identity: BTreeMap::new(),
             call_ids_by_identity: BTreeMap::new(),
             call_ids_by_expansion_identity: BTreeMap::new(),
+            emitted_token_owners: BTreeMap::new(),
             current_state: BTreeMap::new(),
             definition_ranges_partial: false,
             include_edges_partial: false,
@@ -461,16 +464,13 @@ impl<'a> SourcePreprocModelBuilder<'a> {
                 *body_token_range,
             ),
             SourceTokenProvenanceFact::MacroArgument {
-                macro_name,
                 identity,
-                call_range,
                 body_token_range,
                 argument_token_range,
+                ..
             } => self.resolve_macro_argument_token_provenance(
                 token_id,
-                macro_name.clone(),
                 *identity,
-                *call_range,
                 *body_token_range,
                 *argument_token_range,
             ),
@@ -479,11 +479,13 @@ impl<'a> SourcePreprocModelBuilder<'a> {
             }
             SourceTokenProvenanceFact::TokenPaste { identity } => self
                 .resolve_macro_operation_token_provenance(
+                    token_id,
                     *identity,
                     MacroOperationProvenanceKind::TokenPaste,
                 ),
             SourceTokenProvenanceFact::Stringification { identity } => self
                 .resolve_macro_operation_token_provenance(
+                    token_id,
                     *identity,
                     MacroOperationProvenanceKind::Stringification,
                 ),
@@ -503,10 +505,6 @@ impl<'a> SourcePreprocModelBuilder<'a> {
         call_range: SourceRange,
         body_token_range: SourceRange,
     ) -> SourceTokenProvenance {
-        if self.source_is_predefine(body_token_range.source) {
-            return SourceTokenProvenance::Predefine { source: body_token_range.source };
-        }
-
         let Some(identity) = identity else {
             return self.unavailable_token_provenance(
                 SourcePreprocUnavailable::MissingEmittedTokenMacroCallIdentity,
@@ -541,15 +539,17 @@ impl<'a> SourcePreprocModelBuilder<'a> {
             );
         }
 
+        self.record_emitted_token_owner(token_id, call);
+        if self.source_is_predefine(body_token_range.source) {
+            return SourceTokenProvenance::Predefine { source: body_token_range.source };
+        }
         SourceTokenProvenance::MacroBody { identity, definition, body_token_range, call }
     }
 
     fn resolve_macro_argument_token_provenance(
         &mut self,
         token_id: SourceEmittedTokenId,
-        macro_name: SmolStr,
         identity: Option<SourceMacroArgumentIdentity>,
-        call_range: SourceRange,
         body_token_range: SourceRange,
         argument_token_range: SourceRange,
     ) -> SourceTokenProvenance {
@@ -565,16 +565,7 @@ impl<'a> SourcePreprocModelBuilder<'a> {
                 },
             );
         };
-        let call_expansion_identity = identity.parent_expansion.unwrap_or(identity.expansion);
-        let Ok(call) = self.call_for_emitted_token(EmittedTokenMacroCall {
-            token_id,
-            macro_name,
-            call_identity: identity.call,
-            definition,
-            call_range,
-            expansion_identity: call_expansion_identity,
-            parent_expansion_identity: None,
-        }) else {
+        let Some(call) = self.call_ids_by_identity.get(&identity.call).copied() else {
             return self.unavailable_token_provenance(
                 SourcePreprocUnavailable::UnknownEmittedTokenMacroCallIdentity {
                     identity: identity.call,
@@ -592,6 +583,7 @@ impl<'a> SourcePreprocModelBuilder<'a> {
             );
         };
         self.record_macro_argument(call, identity.argument_index, argument_token_range);
+        self.record_emitted_token_owner(token_id, call);
 
         SourceTokenProvenance::MacroArgument {
             identity,
@@ -604,7 +596,7 @@ impl<'a> SourcePreprocModelBuilder<'a> {
 
     fn resolve_builtin_token_provenance(
         &mut self,
-        _token_id: SourceEmittedTokenId,
+        token_id: SourceEmittedTokenId,
         name: SmolStr,
         identity: Option<SourceMacroBuiltinIdentity>,
     ) -> SourceTokenProvenance {
@@ -626,11 +618,13 @@ impl<'a> SourcePreprocModelBuilder<'a> {
         {
             return self.unavailable_token_provenance(reason);
         }
+        self.record_emitted_token_owner(token_id, call);
         SourceTokenProvenance::Builtin { name, identity, call }
     }
 
     fn resolve_macro_operation_token_provenance(
         &mut self,
+        token_id: SourceEmittedTokenId,
         identity: Option<SourceMacroOperationIdentity>,
         kind: MacroOperationProvenanceKind,
     ) -> SourceTokenProvenance {
@@ -659,6 +653,7 @@ impl<'a> SourcePreprocModelBuilder<'a> {
         {
             return self.unavailable_token_provenance(reason);
         }
+        self.record_emitted_token_owner(token_id, call);
         match kind {
             MacroOperationProvenanceKind::TokenPaste => {
                 SourceTokenProvenance::TokenPaste { identity, call }
@@ -839,7 +834,7 @@ impl<'a> SourcePreprocModelBuilder<'a> {
             return;
         }
 
-        let direct_tokens_by_call = self.direct_emitted_tokens_by_call();
+        let direct_tokens_by_call = self.direct_owned_emitted_tokens_by_call();
         let child_calls_by_parent = self.child_calls_by_parent();
         let call_ids = self.tables.macro_calls.iter().map(|call| call.id).collect::<Vec<_>>();
         let mut expansion_tokens_by_call = BTreeMap::new();
@@ -956,25 +951,12 @@ impl<'a> SourcePreprocModelBuilder<'a> {
         })
     }
 
-    fn direct_emitted_tokens_by_call(
+    fn direct_owned_emitted_tokens_by_call(
         &self,
     ) -> BTreeMap<SourceMacroCallId, Vec<SourceEmittedTokenId>> {
         let mut tokens_by_call = BTreeMap::<SourceMacroCallId, Vec<SourceEmittedTokenId>>::new();
-        for token in self.tables.emitted_tokens.iter() {
-            let Some(provenance) = self.tables.token_provenance.get(token.provenance) else {
-                continue;
-            };
-            let call = match provenance {
-                SourceTokenProvenance::MacroBody { call, .. }
-                | SourceTokenProvenance::MacroArgument { call, .. }
-                | SourceTokenProvenance::TokenPaste { call, .. }
-                | SourceTokenProvenance::Stringification { call, .. }
-                | SourceTokenProvenance::Builtin { call, .. } => *call,
-                SourceTokenProvenance::Source { .. }
-                | SourceTokenProvenance::Predefine { .. }
-                | SourceTokenProvenance::Unavailable(_) => continue,
-            };
-            tokens_by_call.entry(call).or_default().push(token.id);
+        for (token, call) in &self.emitted_token_owners {
+            tokens_by_call.entry(*call).or_default().push(*token);
         }
         tokens_by_call
     }
@@ -1073,6 +1055,10 @@ impl<'a> SourcePreprocModelBuilder<'a> {
             call.expansion = None;
             call.status = SourceMacroCallStatus::ExpansionUnavailable(reason);
         }
+    }
+
+    fn record_emitted_token_owner(&mut self, token: SourceEmittedTokenId, call: SourceMacroCallId) {
+        self.emitted_token_owners.insert(token, call);
     }
 
     fn source_is_predefine(&self, source: PreprocSourceId) -> bool {

--- a/crates/preproc/src/source/provenance/builder.rs
+++ b/crates/preproc/src/source/provenance/builder.rs
@@ -435,6 +435,7 @@ impl<'a> SourcePreprocModelBuilder<'a> {
             self.tables.emitted_tokens.push(SourceEmittedToken {
                 id: token_id,
                 text: token.raw,
+                display: token.display,
                 kind: token.kind,
                 emitted_range: SourceEmittedTokenRange { start: token_id, len: 1 },
                 provenance: provenance_id,

--- a/crates/preproc/src/source/trace.rs
+++ b/crates/preproc/src/source/trace.rs
@@ -291,6 +291,7 @@ fn emitted_token_from_trace(token: PreprocessorTraceEmittedToken) -> SourceEmitt
     SourceEmittedTokenFact {
         raw: token.raw_text.to_smolstr(),
         value: token.value_text.to_smolstr(),
+        display: token.display_text.to_smolstr(),
         kind: SourceTokenKind::Syntax(token.token_kind),
         provenance: emitted_token_provenance_from_trace(token.provenance),
     }

--- a/crates/preproc/src/source/types.rs
+++ b/crates/preproc/src/source/types.rs
@@ -234,6 +234,7 @@ pub enum SourceTokenKind {
 pub struct SourceEmittedTokenFact {
     pub raw: SmolStr,
     pub value: SmolStr,
+    pub display: SmolStr,
     pub kind: SourceTokenKind,
     pub provenance: SourceTokenProvenanceFact,
 }

--- a/crates/slang/bindings/rust/ffi.rs
+++ b/crates/slang/bindings/rust/ffi.rs
@@ -134,6 +134,7 @@ mod slang_ffi {
     struct RawPreprocessorTraceEmittedToken {
         raw_text: String,
         value_text: String,
+        display_text: String,
         token_kind: u16,
         provenance_kind: u8,
         macro_name: String,

--- a/crates/slang/bindings/rust/ffi/wrapper.cc
+++ b/crates/slang/bindings/rust/ffi/wrapper.cc
@@ -4,6 +4,7 @@
 #include "slang/parsing/ParserMetadata.h"
 #include "slang/parsing/PreprocessorTrace.h"
 #include "slang/syntax/AllSyntax.h"
+#include "slang/syntax/SyntaxPrinter.h"
 
 #include <algorithm>
 #include <filesystem>
@@ -175,6 +176,7 @@ constexpr uint8_t TRACE_TOKEN_PROVENANCE_STRINGIFICATION = 6;
   ::RawPreprocessorTraceEmittedToken token;
   token.raw_text = rust::String();
   token.value_text = rust::String();
+  token.display_text = rust::String();
   token.token_kind = static_cast<uint16_t>(slang::parsing::TokenKind::Unknown);
   token.provenance_kind = TRACE_TOKEN_PROVENANCE_UNAVAILABLE;
   token.macro_name = rust::String();
@@ -197,6 +199,13 @@ constexpr uint8_t TRACE_TOKEN_PROVENANCE_STRINGIFICATION = 6;
   token.body_token_range = empty_source_buffer_range();
   token.argument_token_range = empty_source_buffer_range();
   return token;
+}
+
+std::string emitted_token_display_text(slang::parsing::Token token) {
+  return slang::syntax::SyntaxPrinter()
+      .setSquashNewlines(false)
+      .print(token)
+      .str();
 }
 
 bool is_single_buffer_range(slang::SourceRange range) {
@@ -505,6 +514,7 @@ template<typename TTokens>
 
   result.raw_text = rust::String(std::string(token.rawText()));
   result.value_text = rust::String(std::string(token.valueText()));
+  result.display_text = rust::String(emitted_token_display_text(token));
   result.token_kind = static_cast<uint16_t>(token.kind);
 
   auto location = token.location();

--- a/crates/slang/bindings/rust/lib.rs
+++ b/crates/slang/bindings/rust/lib.rs
@@ -186,6 +186,7 @@ pub struct PreprocessorTraceEvent {
 pub struct PreprocessorTraceEmittedToken {
     pub raw_text: String,
     pub value_text: String,
+    pub display_text: String,
     pub token_kind: TokenKind,
     pub provenance: PreprocessorTraceTokenProvenance,
 }
@@ -482,6 +483,7 @@ impl PreprocessorTraceEmittedToken {
         let ffi::RawPreprocessorTraceEmittedToken {
             raw_text,
             value_text,
+            display_text,
             token_kind,
             provenance_kind,
             macro_name,
@@ -507,6 +509,7 @@ impl PreprocessorTraceEmittedToken {
         Self {
             raw_text,
             value_text,
+            display_text,
             token_kind: TokenKind::from_id(token_kind),
             provenance: PreprocessorTraceTokenProvenance::from_raw(
                 RawPreprocessorTraceTokenProvenance {

--- a/crates/slang/bindings/rust/tests.rs
+++ b/crates/slang/bindings/rust/tests.rs
@@ -1345,6 +1345,29 @@ endmodule
 }
 
 #[test]
+fn preprocessor_trace_emitted_tokens_keep_display_trivia() {
+    let source = r#"`define BLOCK(name) \
+  always_ff @(posedge clk) begin \
+    name <= 1; \
+  end
+module m;
+  `BLOCK(q)
+endmodule
+"#;
+    let trace =
+        preprocessor_trace(source, "source", "sample/rtl/top.sv", &SyntaxTreeOptions::default());
+    let display =
+        trace.emitted_tokens.iter().map(|token| token.display_text.as_str()).collect::<String>();
+
+    assert!(
+        display.contains("\n  always_ff")
+            && display.contains("\n    q <= 1;")
+            && display.contains("\n  end"),
+        "emitted token display text should preserve Slang token trivia: {display:?}"
+    );
+}
+
+#[test]
 fn preprocessor_trace_reports_nested_macro_usage_in_actual_argument() {
     let source = r#"`define PAYL payload_i
 `define NEXT(x) ((x) + 12'd1)


### PR DESCRIPTION
﻿## Summary

This change fixes macro expansion hover for configured predefine tokens and preserves readable expansion layout in hover output.

## Root Cause

The expansion graph grouped direct emitted tokens by reading token provenance variants. Tokens that came from configured predefines had `Predefine` provenance, so they were skipped even when trace identities showed they belonged to the parent macro expansion.

The display path also rebuilt expansion text by joining emitted token text with single spaces. Slang already keeps leading trivia on emitted tokens, but the Rust trace/model boundary did not retain that display spelling, so hover lost line breaks and indentation.

## Fix

- Record emitted-token expansion ownership from trace macro call identities while building the source preproc model.
- Carry emitted token display text from Slang tokens through the FFI trace and preproc model.
- Build HIR display-only expansion text from emitted token display text instead of rejoining token text.
- Render hover expansions from display text, trim common indentation for the Markdown code block, and label the result with `Expands to`.
- Add regression coverage for configured predefine expansion ownership, emitted token display trivia, HIR display mapping, and hover output.

## Validation

- `cargo test --workspace`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets`