### PR TITLE
chore(release): prepare 1.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vide"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 authors = ["roifewu <roifewu@gmail.com>", "hongjr03 <hongjr03@gmail.com>"]
 repository = "https://github.com/pascal-lab/vide"

--- a/docs/src/content/docs/changelog/index.mdx
+++ b/docs/src/content/docs/changelog/index.mdx
@@ -9,6 +9,11 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard
+    title="1.2.1"
+    href="./v1-2-1/"
+    description="修复配置预定义宏和嵌套宏实参场景下的宏展开悬停，并保留展开代码的换行缩进。"
+  />
+  <LinkCard
     title="1.2.0"
     href="./v1-2-0/"
     description="宏和 include 来源模型、宏展开悬停、更多自动重构、struct 符号大纲、Qihe 选项生成，以及发布包流程优化。"

--- a/docs/src/content/docs/changelog/v1-2-1/index.mdx
+++ b/docs/src/content/docs/changelog/v1-2-1/index.mdx
@@ -1,0 +1,25 @@
+---
+title: 1.2.1
+description: Vide 1.2.1 更新日志。
+---
+
+Vide 1.2.1 修复宏展开悬停在配置预定义宏和嵌套宏实参场景下的显示问题，并调整 1.2.0 更新日志里的自动重构说明。
+
+## 修复
+
+### 宏展开悬停
+
+- 宏展开经过 `vide.toml` 中配置的预定义宏时，悬停信息现在会继续显示完整展开结果，不再丢失展开内容。([#245](https://github.com/pascal-lab/vide/pull/245) by [@hongjr03](https://github.com/hongjr03))
+- 展开结果现在保留预处理 trace 中的换行和缩进，悬停里的 `Expands to` 代码块更接近实际展开后的代码形态。([#245](https://github.com/pascal-lab/vide/pull/245) by [@hongjr03](https://github.com/hongjr03))
+
+## 文档
+
+- 调整 1.2.0 更新日志里的自动重构说明，让新增代码动作的范围更准确。([#244](https://github.com/pascal-lab/vide/pull/244) by [@hongjr03](https://github.com/hongjr03))
+
+## 贡献者
+
+感谢本次发布的所有贡献者：
+
+- [@hongjr03](https://github.com/hongjr03)
+
+**完整更新列表**: [v1.2.0...v1.2.1](https://github.com/pascal-lab/vide/compare/v1.2.0...v1.2.1)

--- a/docs/src/content/docs/en/changelog/index.mdx
+++ b/docs/src/content/docs/en/changelog/index.mdx
@@ -9,6 +9,11 @@ Browse Vide changes by version.
 
 <CardGrid>
   <LinkCard
+    title="1.2.1"
+    href="./v1-2-1/"
+    description="Fixes macro expansion hover through configured predefines and nested macro arguments, with line breaks and indentation preserved in expansion output."
+  />
+  <LinkCard
     title="1.2.0"
     href="./v1-2-0/"
     description="Macro and include provenance, macro expansion hover, more automatic refactoring, struct document symbols, Qihe options generation, and release packaging updates."

--- a/docs/src/content/docs/en/changelog/v1-2-1/index.mdx
+++ b/docs/src/content/docs/en/changelog/v1-2-1/index.mdx
@@ -1,0 +1,25 @@
+---
+title: 1.2.1
+description: Vide 1.2.1 release notes.
+---
+
+Vide 1.2.1 fixes macro expansion hover output for configured predefines and nested macro arguments, and updates the 1.2.0 code action notes.
+
+## Fixes
+
+### Macro Expansion Hover
+
+- Macro hover now keeps showing the complete expansion when the output passes through predefines configured in `vide.toml`. ([#245](https://github.com/pascal-lab/vide/pull/245) by [@hongjr03](https://github.com/hongjr03))
+- Expansion output now preserves line breaks and indentation from the preprocessor trace, so the hover's `Expands to` code block more closely matches the expanded code. ([#245](https://github.com/pascal-lab/vide/pull/245) by [@hongjr03](https://github.com/hongjr03))
+
+## Documentation
+
+- Updated the 1.2.0 release note wording for automatic refactoring code actions so the listed scope is more accurate. ([#244](https://github.com/pascal-lab/vide/pull/244) by [@hongjr03](https://github.com/hongjr03))
+
+## Contributors
+
+Thanks to everyone who contributed to this release:
+
+- [@hongjr03](https://github.com/hongjr03)
+
+**Full Changelog**: [v1.2.0...v1.2.1](https://github.com/pascal-lab/vide/compare/v1.2.0...v1.2.1)

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vide-ide",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vide-ide",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vide-ide",
   "displayName": "Vide - Verilog/SystemVerilog Coding IDE",
   "description": "%extension.description%",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "publisher": "pascal-lab",
   "license": "MIT",
   "icon": "media/icon.png",


### PR DESCRIPTION
﻿## Summary

- bump the Rust and VS Code extension versions to 1.2.1
- add Chinese and English changelog pages for 1.2.1
- add 1.2.1 to the changelog indexes

## Validation

- `git diff --check`
- `node docs/scripts/release-body-from-changelog.mjs --tag v1.2.1 --output $env:TEMP/vide-release-body-1.2.1.md`
- `npm --prefix docs run build`
- `cargo test --workspace`
- `npm --prefix editors/vscode run package:vsix:debug`
