### PR TITLE
ci: drop alpine arm64 dev package

### DIFF
--- a/.github/scripts/ci-plan.mjs
+++ b/.github/scripts/ci-plan.mjs
@@ -21,14 +21,6 @@ const DEV_ALPINE_TARGETS = new Map([
       "rust-target": "x86_64-unknown-linux-musl",
     },
   ],
-  [
-    "alpine-arm64",
-    {
-      target: "alpine-arm64",
-      image: "ghcr.io/blackdex/rust-musl:aarch64-musl-nightly",
-      "rust-target": "aarch64-unknown-linux-musl",
-    },
-  ],
 ]);
 
 export async function planCi({ github, context, core, filters }) {


### PR DESCRIPTION
﻿## Summary

- remove `alpine-arm64` from the CI dev package matrix
- keep `alpine-x64` dev package coverage unchanged

## Validation

Not run; this only removes an unsupported CI matrix target.
