### PR TITLE
refactor(ide): dispatch source-aware IDE targets

### DIFF
--- a/crates/hir/src/preproc/helpers/expansion.rs
+++ b/crates/hir/src/preproc/helpers/expansion.rs
@@ -329,15 +329,28 @@ pub(in crate::preproc) fn map_token_provenance(
             let (source, range) = map_mapped_source_range(mapped, *token_range)?;
             TokenProvenance::SourceToken { source, range }
         }
-        SourceTokenProvenanceFact::MacroBody { definition, body_token_range, call, .. } => {
+        SourceTokenProvenanceFact::MacroBody {
+            definition,
+            body_token_range,
+            call,
+            identity,
+            ..
+        } => {
             let call = mapped_macro_call(mapped, *call)?;
             let (source, range) = map_mapped_source_range(mapped, *body_token_range)?;
-            TokenProvenance::MacroBody { call, definition_id: (*definition).into(), source, range }
+            TokenProvenance::MacroBody {
+                identity: (*identity).into(),
+                call,
+                definition_id: (*definition).into(),
+                source,
+                range,
+            }
         }
         SourceTokenProvenanceFact::MacroArgument {
             call,
             argument_index,
             argument_token_range,
+            identity,
             ..
         } => {
             let call = mapped_macro_call(mapped, *call)?;
@@ -346,7 +359,13 @@ pub(in crate::preproc) fn map_token_provenance(
                     SourcePreprocUnavailable::UnsupportedEmittedTokenProvenance,
                 )));
             };
-            TokenProvenance::MacroArgument { call, argument_index: *argument_index, source, range }
+            TokenProvenance::MacroArgument {
+                identity: (*identity).into(),
+                call,
+                argument_index: *argument_index,
+                source,
+                range,
+            }
         }
         SourceTokenProvenanceFact::TokenPaste { call, .. } => {
             TokenProvenance::TokenPaste { call: mapped_macro_call(mapped, *call)? }
@@ -396,10 +415,10 @@ pub(in crate::preproc) fn diagnostic_target_for_source_expansion(
             TokenProvenance::SourceToken { source, range } => {
                 return Ok(DiagnosticProvenance::SourceToken { source, range });
             }
-            TokenProvenance::MacroBody { call, definition_id, source, range } => {
+            TokenProvenance::MacroBody { call, definition_id, source, range, .. } => {
                 return Ok(DiagnosticProvenance::MacroBody { call, definition_id, source, range });
             }
-            TokenProvenance::MacroArgument { call, argument_index, source, range } => {
+            TokenProvenance::MacroArgument { call, argument_index, source, range, .. } => {
                 return Ok(DiagnosticProvenance::MacroArgument {
                     call,
                     argument_index,

--- a/crates/hir/src/preproc/tests.rs
+++ b/crates/hir/src/preproc/tests.rs
@@ -421,20 +421,32 @@ endmodule
         .iter()
         .find(|token| token.text.as_str() == "logic")
         .expect("macro body token should be present");
-    let TokenProvenance::MacroBody { source, range, .. } = &logic.provenance else {
+    let TokenProvenance::MacroBody {
+        identity: logic_identity,
+        source,
+        range,
+        ..
+    } = &logic.provenance
+    else {
         panic!("logic should come from the macro body: {logic:?}");
     };
     assert_eq!(source.file_id(), Some(TOP));
     assert_eq!(text_at_range(root_text, *range), "logic");
     assert_eq!(logic.display_range, TextRange::new(1.into(), 6.into()));
+    assert_eq!(logic_identity.body_token_index, 0);
 
     let generated = provenance
         .tokens
         .iter()
         .find(|token| token.text.as_str() == "generated")
         .expect("macro argument token should be present");
-    let TokenProvenance::MacroArgument { source, range, argument_index, .. } =
-        &generated.provenance
+    let TokenProvenance::MacroArgument {
+        identity: generated_identity,
+        source,
+        range,
+        argument_index,
+        ..
+    } = &generated.provenance
     else {
         panic!("generated should come from the macro argument: {generated:?}");
     };
@@ -442,6 +454,12 @@ endmodule
     assert_eq!(source.file_id(), Some(TOP));
     assert_eq!(text_at_range(root_text, *range), "generated");
     assert_eq!(generated.display_range, TextRange::new(7.into(), 16.into()));
+    assert_eq!(generated_identity.call, logic_identity.call);
+    assert_eq!(generated_identity.definition, logic_identity.definition);
+    assert_eq!(generated_identity.parent_expansion, Some(logic_identity.expansion));
+    assert_eq!(generated_identity.body_token_index, 1);
+    assert_eq!(generated_identity.argument_index, 0);
+    assert_eq!(generated_identity.argument_token_index, 0);
 }
 
 #[test]

--- a/crates/hir/src/preproc/tests.rs
+++ b/crates/hir/src/preproc/tests.rs
@@ -421,12 +421,8 @@ endmodule
         .iter()
         .find(|token| token.text.as_str() == "logic")
         .expect("macro body token should be present");
-    let TokenProvenance::MacroBody {
-        identity: logic_identity,
-        source,
-        range,
-        ..
-    } = &logic.provenance
+    let TokenProvenance::MacroBody { identity: logic_identity, source, range, .. } =
+        &logic.provenance
     else {
         panic!("logic should come from the macro body: {logic:?}");
     };

--- a/crates/hir/src/preproc/types.rs
+++ b/crates/hir/src/preproc/types.rs
@@ -2,8 +2,9 @@ use std::collections::BTreeMap;
 
 use preproc::source::{
     SourceEmittedTokenId, SourceEmittedTokenRange, SourceIncludeDirectiveId, SourceMacroCallId,
-    SourceMacroDefinitionId, SourceMacroExpansionId, SourceMacroReferenceId, SourcePreprocError,
-    SourcePreprocUnavailable,
+    SourceMacroArgumentIdentity, SourceMacroBodyIdentity, SourceMacroCallKey,
+    SourceMacroDefinitionId, SourceMacroDefinitionKey, SourceMacroExpansionId,
+    SourceMacroExpansionKey, SourceMacroReferenceId, SourcePreprocError, SourcePreprocUnavailable,
 };
 use smol_str::SmolStr;
 use utils::{
@@ -351,12 +352,14 @@ pub enum TokenProvenance {
         range: TextRange,
     },
     MacroBody {
+        identity: MacroBodyTokenIdentity,
         call: MacroCall,
         definition_id: MacroDefinitionId,
         source: MappedPreprocSource,
         range: TextRange,
     },
     MacroArgument {
+        identity: MacroArgumentTokenIdentity,
         call: MacroCall,
         argument_index: usize,
         source: MappedPreprocSource,
@@ -376,6 +379,167 @@ pub enum TokenProvenance {
         call: MacroCall,
     },
     Unavailable(PreprocUnavailable),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MacroCallIdentity(u32);
+
+impl MacroCallIdentity {
+    pub fn raw(self) -> u32 {
+        self.0
+    }
+}
+
+impl From<SourceMacroCallKey> for MacroCallIdentity {
+    fn from(value: SourceMacroCallKey) -> Self {
+        Self(value.raw())
+    }
+}
+
+impl From<syntax::PreprocessorTraceMacroCallId> for MacroCallIdentity {
+    fn from(value: syntax::PreprocessorTraceMacroCallId) -> Self {
+        Self(value.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MacroDefinitionIdentity(u32);
+
+impl MacroDefinitionIdentity {
+    pub fn raw(self) -> u32 {
+        self.0
+    }
+}
+
+impl From<SourceMacroDefinitionKey> for MacroDefinitionIdentity {
+    fn from(value: SourceMacroDefinitionKey) -> Self {
+        Self(value.raw())
+    }
+}
+
+impl From<syntax::PreprocessorTraceMacroDefinitionId> for MacroDefinitionIdentity {
+    fn from(value: syntax::PreprocessorTraceMacroDefinitionId) -> Self {
+        Self(value.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MacroExpansionIdentity(u32);
+
+impl MacroExpansionIdentity {
+    pub fn raw(self) -> u32 {
+        self.0
+    }
+}
+
+impl From<SourceMacroExpansionKey> for MacroExpansionIdentity {
+    fn from(value: SourceMacroExpansionKey) -> Self {
+        Self(value.raw())
+    }
+}
+
+impl From<syntax::PreprocessorTraceMacroExpansionId> for MacroExpansionIdentity {
+    fn from(value: syntax::PreprocessorTraceMacroExpansionId) -> Self {
+        Self(value.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MacroBodyTokenIdentity {
+    pub call: MacroCallIdentity,
+    pub definition: MacroDefinitionIdentity,
+    pub expansion: MacroExpansionIdentity,
+    pub parent_expansion: Option<MacroExpansionIdentity>,
+    pub body_token_index: usize,
+}
+
+impl From<SourceMacroBodyIdentity> for MacroBodyTokenIdentity {
+    fn from(value: SourceMacroBodyIdentity) -> Self {
+        Self {
+            call: value.call.into(),
+            definition: value.definition.into(),
+            expansion: value.expansion.into(),
+            parent_expansion: value.parent_expansion.map(Into::into),
+            body_token_index: value.body_token_index,
+        }
+    }
+}
+
+impl From<syntax::PreprocessorTraceMacroBodyIdentity> for MacroBodyTokenIdentity {
+    fn from(value: syntax::PreprocessorTraceMacroBodyIdentity) -> Self {
+        Self {
+            call: value.call_id.into(),
+            definition: value.definition_id.into(),
+            expansion: value.expansion_id.into(),
+            parent_expansion: value.parent_expansion_id.map(Into::into),
+            body_token_index: value.body_token_index as usize,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MacroArgumentTokenIdentity {
+    pub call: MacroCallIdentity,
+    pub definition: MacroDefinitionIdentity,
+    pub expansion: MacroExpansionIdentity,
+    pub parent_expansion: Option<MacroExpansionIdentity>,
+    pub body_token_index: usize,
+    pub argument_index: usize,
+    pub argument_token_index: usize,
+}
+
+impl From<SourceMacroArgumentIdentity> for MacroArgumentTokenIdentity {
+    fn from(value: SourceMacroArgumentIdentity) -> Self {
+        Self {
+            call: value.call.into(),
+            definition: value.definition.into(),
+            expansion: value.expansion.into(),
+            parent_expansion: value.parent_expansion.map(Into::into),
+            body_token_index: value.body_token_index,
+            argument_index: value.argument_index,
+            argument_token_index: value.argument_token_index,
+        }
+    }
+}
+
+impl From<syntax::PreprocessorTraceMacroArgumentIdentity> for MacroArgumentTokenIdentity {
+    fn from(value: syntax::PreprocessorTraceMacroArgumentIdentity) -> Self {
+        Self {
+            call: value.call_id.into(),
+            definition: value.definition_id.into(),
+            expansion: value.expansion_id.into(),
+            parent_expansion: value.parent_expansion_id.map(Into::into),
+            body_token_index: value.body_token_index as usize,
+            argument_index: value.argument_index as usize,
+            argument_token_index: value.argument_token_index as usize,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MacroTokenIdentity {
+    Body(MacroBodyTokenIdentity),
+    Argument(MacroArgumentTokenIdentity),
+}
+
+impl MacroTokenIdentity {
+    pub fn from_syntax_provenance(
+        provenance: syntax::PreprocessorTraceTokenProvenance,
+    ) -> Option<Self> {
+        match provenance {
+            syntax::PreprocessorTraceTokenProvenance::MacroBody { identity, .. } => {
+                Some(Self::Body(identity.into()))
+            }
+            syntax::PreprocessorTraceTokenProvenance::MacroArgument { identity, .. } => {
+                Some(Self::Argument(identity.into()))
+            }
+            syntax::PreprocessorTraceTokenProvenance::Source { .. }
+            | syntax::PreprocessorTraceTokenProvenance::Builtin { .. }
+            | syntax::PreprocessorTraceTokenProvenance::TokenPaste { .. }
+            | syntax::PreprocessorTraceTokenProvenance::Stringification { .. }
+            | syntax::PreprocessorTraceTokenProvenance::Unavailable => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/hir/src/preproc/types.rs
+++ b/crates/hir/src/preproc/types.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 
 use preproc::source::{
-    SourceEmittedTokenId, SourceEmittedTokenRange, SourceIncludeDirectiveId, SourceMacroCallId,
-    SourceMacroArgumentIdentity, SourceMacroBodyIdentity, SourceMacroCallKey,
+    SourceEmittedTokenId, SourceEmittedTokenRange, SourceIncludeDirectiveId,
+    SourceMacroArgumentIdentity, SourceMacroBodyIdentity, SourceMacroCallId, SourceMacroCallKey,
     SourceMacroDefinitionId, SourceMacroDefinitionKey, SourceMacroExpansionId,
     SourceMacroExpansionKey, SourceMacroReferenceId, SourcePreprocError, SourcePreprocUnavailable,
 };

--- a/crates/ide/src/document_highlight.rs
+++ b/crates/ide/src/document_highlight.rs
@@ -33,7 +33,7 @@ pub(crate) fn document_highlight(
     let hir_file_id = file_id.into();
     let parsed_file = sema.parse_file(file_id);
     let root = parsed_file.root()?;
-    let tokens = crate::source_tokens::source_token_resolution_at_offset(
+    let tokens = crate::source_targets::source_target_at_offset(
         db,
         file_id,
         root,

--- a/crates/ide/src/goto_declaration.rs
+++ b/crates/ide/src/goto_declaration.rs
@@ -17,7 +17,7 @@ pub(crate) fn goto_declaration(
     let hir_file_id = file_id.into();
     let parsed_file = sema.parse_file(file_id);
     let root = parsed_file.root()?;
-    let selection = crate::source_tokens::source_token_resolution_at_offset(
+    let target = crate::source_targets::source_target_at_offset(
         db,
         file_id,
         root,
@@ -25,7 +25,7 @@ pub(crate) fn goto_declaration(
         goto_definition::token_precedence,
     )?
     .resolved()?;
-    let (range, tokens) = selection.into_parts();
+    let (range, tokens) = target.into_parts();
 
     let origins = tokens
         .into_iter()

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -40,7 +40,7 @@ pub(crate) fn goto_definition(
     let hir_file_id = file_id.into();
     let parsed_file = sema.parse_file(file_id);
     let root = parsed_file.root()?;
-    let selection = crate::source_tokens::source_token_resolution_at_offset(
+    let target = crate::source_targets::source_target_at_offset(
         db,
         file_id,
         root,
@@ -48,7 +48,7 @@ pub(crate) fn goto_definition(
         token_precedence,
     )?
     .resolved()?;
-    let (range, tokens) = selection.into_parts();
+    let (range, tokens) = target.into_parts();
     let navs = tokens
         .into_iter()
         .filter_map(|token| nav_targets_for_token(db, &sema, hir_file_id, token))

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -27,16 +27,16 @@ use crate::{
 };
 
 enum DefinitionTarget<'tree> {
-    Preproc(PreprocDefinitionTarget),
+    Preproc(Box<PreprocDefinitionTarget>),
     Include(Vec<IncludeDirective>),
     Source(SourceTarget<'tree>),
 }
 
 enum PreprocDefinitionTarget {
-    MacroParamDefinition(MacroParamDefinition),
-    MacroParamReference(MacroParamReferenceDefinitions),
-    MacroDefinition(MacroDefinition),
-    MacroReference(MacroReferenceDefinitions),
+    ParamDefinition(MacroParamDefinition),
+    ParamReference(MacroParamReferenceDefinitions),
+    Definition(MacroDefinition),
+    Reference(MacroReferenceDefinitions),
 }
 
 pub(crate) fn goto_definition(
@@ -56,7 +56,7 @@ fn dispatch_definition_target<'tree>(
     root: Option<SyntaxNode<'tree>>,
 ) -> Option<DefinitionTarget<'tree>> {
     if let Some(target) = dispatch_preproc_definition_target(db, file_id, offset) {
-        return Some(DefinitionTarget::Preproc(target));
+        return Some(DefinitionTarget::Preproc(Box::new(target)));
     }
     if let Some(includes) = dispatch_include_definition_target(db, file_id, offset) {
         return Some(DefinitionTarget::Include(includes));
@@ -74,7 +74,7 @@ fn render_definition_target(
     target: DefinitionTarget<'_>,
 ) -> Option<RangeInfo<Vec<NavTarget>>> {
     match target {
-        DefinitionTarget::Preproc(target) => render_preproc_definition_target(target),
+        DefinitionTarget::Preproc(target) => render_preproc_definition_target(*target),
         DefinitionTarget::Include(includes) => render_include_definition_target(db, includes),
         DefinitionTarget::Source(target) => {
             render_source_definition_target(db, file_id, sema, target)
@@ -92,7 +92,7 @@ fn render_source_definition_target(
     let (range, tokens) = target.into_parts();
     let navs = tokens
         .into_iter()
-        .filter_map(|token| nav_targets_for_token(db, &sema, hir_file_id, token))
+        .filter_map(|token| nav_targets_for_token(db, sema, hir_file_id, token))
         .flatten()
         .unique()
         .collect_vec();
@@ -126,19 +126,19 @@ fn dispatch_preproc_definition_target(
     offset: TextSize,
 ) -> Option<PreprocDefinitionTarget> {
     if let Ok(Some(definition)) = macro_param_definition_at(db, file_id, offset) {
-        return Some(PreprocDefinitionTarget::MacroParamDefinition(definition));
+        return Some(PreprocDefinitionTarget::ParamDefinition(definition));
     }
 
     if let Ok(Some(resolution)) = macro_param_reference_definitions_at(db, file_id, offset) {
-        return Some(PreprocDefinitionTarget::MacroParamReference(resolution));
+        return Some(PreprocDefinitionTarget::ParamReference(resolution));
     }
 
     if let Ok(Some(definition)) = macro_definition_at(db, file_id, offset) {
-        return Some(PreprocDefinitionTarget::MacroDefinition(definition));
+        return Some(PreprocDefinitionTarget::Definition(definition));
     }
 
     if let Ok(Some(resolution)) = macro_reference_definitions_at(db, file_id, offset) {
-        return Some(PreprocDefinitionTarget::MacroReference(resolution));
+        return Some(PreprocDefinitionTarget::Reference(resolution));
     }
 
     None
@@ -148,19 +148,19 @@ fn render_preproc_definition_target(
     target: PreprocDefinitionTarget,
 ) -> Option<RangeInfo<Vec<NavTarget>>> {
     match target {
-        PreprocDefinitionTarget::MacroParamDefinition(definition) => {
+        PreprocDefinitionTarget::ParamDefinition(definition) => {
             Some(RangeInfo::new(definition.range, vec![macro_param_nav_target(definition)]))
         }
-        PreprocDefinitionTarget::MacroParamReference(resolution) => {
+        PreprocDefinitionTarget::ParamReference(resolution) => {
             let reference_range = resolution.range;
             let targets =
                 resolution.definitions.into_iter().map(macro_param_nav_target).collect_vec();
             (!targets.is_empty()).then_some(RangeInfo::new(reference_range, targets))
         }
-        PreprocDefinitionTarget::MacroDefinition(definition) => {
+        PreprocDefinitionTarget::Definition(definition) => {
             Some(RangeInfo::new(definition.name_range, vec![macro_nav_target(definition)]))
         }
-        PreprocDefinitionTarget::MacroReference(resolution) => {
+        PreprocDefinitionTarget::Reference(resolution) => {
             let reference_range = resolution.range;
             let targets = resolution.definitions.into_iter().map(macro_nav_target).collect_vec();
             (!targets.is_empty()).then_some(RangeInfo::new(reference_range, targets))

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -3,7 +3,8 @@ use hir::{
     container::InFile,
     file::HirFileId,
     preproc::{
-        IncludeTarget, MacroDefinition, MacroParamDefinition, include_directives_at,
+        IncludeDirective, IncludeTarget, MacroDefinition, MacroParamDefinition,
+        MacroParamReferenceDefinitions, MacroReferenceDefinitions, include_directives_at,
         macro_definition_at, macro_param_definition_at, macro_param_reference_definitions_at,
         macro_reference_definitions_at,
     },
@@ -11,7 +12,7 @@ use hir::{
 };
 use itertools::Itertools;
 use syntax::{
-    SyntaxTokenWithParent, TokenKind,
+    SyntaxNode, SyntaxTokenWithParent, TokenKind,
     token::{TokenKindExt, pair_token},
 };
 use utils::line_index::{TextRange, TextSize};
@@ -22,32 +23,72 @@ use crate::{
     db::root_db::RootDb,
     definitions::DefinitionClass,
     navigation_target::{NavTarget, ToNav},
+    source_targets::{SourceTarget, source_target_at_offset},
 };
+
+enum DefinitionTarget<'tree> {
+    Preproc(PreprocDefinitionTarget),
+    Include(Vec<IncludeDirective>),
+    Source(SourceTarget<'tree>),
+}
+
+enum PreprocDefinitionTarget {
+    MacroParamDefinition(MacroParamDefinition),
+    MacroParamReference(MacroParamReferenceDefinitions),
+    MacroDefinition(MacroDefinition),
+    MacroReference(MacroReferenceDefinitions),
+}
 
 pub(crate) fn goto_definition(
     db: &RootDb,
     FilePosition { file_id, offset }: FilePosition,
 ) -> Option<RangeInfo<Vec<NavTarget>>> {
-    if let Some(macro_definition) = handle_preproc_macro(db, file_id, offset) {
-        return Some(macro_definition);
-    }
-
-    if let Some(include) = handle_preproc_include(db, file_id, offset) {
-        return Some(include);
-    }
-
     let sema = Semantics::new(db);
-    let hir_file_id = file_id.into();
     let parsed_file = sema.parse_file(file_id);
-    let root = parsed_file.root()?;
-    let target = crate::source_targets::source_target_at_offset(
-        db,
-        file_id,
-        root,
-        offset,
-        token_precedence,
-    )?
-    .resolved()?;
+    let target = dispatch_definition_target(db, file_id, offset, parsed_file.root())?;
+    render_definition_target(db, file_id, &sema, target)
+}
+
+fn dispatch_definition_target<'tree>(
+    db: &RootDb,
+    file_id: FileId,
+    offset: TextSize,
+    root: Option<SyntaxNode<'tree>>,
+) -> Option<DefinitionTarget<'tree>> {
+    if let Some(target) = dispatch_preproc_definition_target(db, file_id, offset) {
+        return Some(DefinitionTarget::Preproc(target));
+    }
+    if let Some(includes) = dispatch_include_definition_target(db, file_id, offset) {
+        return Some(DefinitionTarget::Include(includes));
+    }
+    let root = root?;
+    let target =
+        source_target_at_offset(db, file_id, root, offset, token_precedence)?.resolved()?;
+    Some(DefinitionTarget::Source(target))
+}
+
+fn render_definition_target(
+    db: &RootDb,
+    file_id: FileId,
+    sema: &Semantics<RootDb>,
+    target: DefinitionTarget<'_>,
+) -> Option<RangeInfo<Vec<NavTarget>>> {
+    match target {
+        DefinitionTarget::Preproc(target) => render_preproc_definition_target(target),
+        DefinitionTarget::Include(includes) => render_include_definition_target(db, includes),
+        DefinitionTarget::Source(target) => {
+            render_source_definition_target(db, file_id, sema, target)
+        }
+    }
+}
+
+fn render_source_definition_target(
+    db: &RootDb,
+    file_id: FileId,
+    sema: &Semantics<RootDb>,
+    target: SourceTarget<'_>,
+) -> Option<RangeInfo<Vec<NavTarget>>> {
+    let hir_file_id = file_id.into();
     let (range, tokens) = target.into_parts();
     let navs = tokens
         .into_iter()
@@ -79,38 +120,52 @@ fn nav_targets_for_token(
     })
 }
 
-fn handle_preproc_macro(
+fn dispatch_preproc_definition_target(
     db: &RootDb,
     file_id: FileId,
     offset: TextSize,
-) -> Option<RangeInfo<Vec<NavTarget>>> {
+) -> Option<PreprocDefinitionTarget> {
     if let Ok(Some(definition)) = macro_param_definition_at(db, file_id, offset) {
-        return Some(RangeInfo::new(definition.range, vec![macro_param_nav_target(definition)]));
+        return Some(PreprocDefinitionTarget::MacroParamDefinition(definition));
     }
 
     if let Ok(Some(resolution)) = macro_param_reference_definitions_at(db, file_id, offset) {
-        let reference_range = resolution.range;
-        let targets = resolution.definitions.into_iter().map(macro_param_nav_target).collect_vec();
-        if targets.is_empty() {
-            return None;
-        }
-        return Some(RangeInfo::new(reference_range, targets));
+        return Some(PreprocDefinitionTarget::MacroParamReference(resolution));
     }
 
     if let Ok(Some(definition)) = macro_definition_at(db, file_id, offset) {
-        return Some(RangeInfo::new(definition.name_range, vec![macro_nav_target(definition)]));
+        return Some(PreprocDefinitionTarget::MacroDefinition(definition));
     }
 
     if let Ok(Some(resolution)) = macro_reference_definitions_at(db, file_id, offset) {
-        let reference_range = resolution.range;
-        let targets = resolution.definitions.into_iter().map(macro_nav_target).collect_vec();
-        if targets.is_empty() {
-            return None;
-        }
-        return Some(RangeInfo::new(reference_range, targets));
+        return Some(PreprocDefinitionTarget::MacroReference(resolution));
     }
 
     None
+}
+
+fn render_preproc_definition_target(
+    target: PreprocDefinitionTarget,
+) -> Option<RangeInfo<Vec<NavTarget>>> {
+    match target {
+        PreprocDefinitionTarget::MacroParamDefinition(definition) => {
+            Some(RangeInfo::new(definition.range, vec![macro_param_nav_target(definition)]))
+        }
+        PreprocDefinitionTarget::MacroParamReference(resolution) => {
+            let reference_range = resolution.range;
+            let targets =
+                resolution.definitions.into_iter().map(macro_param_nav_target).collect_vec();
+            (!targets.is_empty()).then_some(RangeInfo::new(reference_range, targets))
+        }
+        PreprocDefinitionTarget::MacroDefinition(definition) => {
+            Some(RangeInfo::new(definition.name_range, vec![macro_nav_target(definition)]))
+        }
+        PreprocDefinitionTarget::MacroReference(resolution) => {
+            let reference_range = resolution.range;
+            let targets = resolution.definitions.into_iter().map(macro_nav_target).collect_vec();
+            (!targets.is_empty()).then_some(RangeInfo::new(reference_range, targets))
+        }
+    }
 }
 
 fn macro_param_nav_target(definition: MacroParamDefinition) -> NavTarget {
@@ -137,12 +192,19 @@ fn macro_nav_target(definition: MacroDefinition) -> NavTarget {
     }
 }
 
-fn handle_preproc_include(
+fn dispatch_include_definition_target(
     db: &RootDb,
     file_id: FileId,
     offset: TextSize,
-) -> Option<RangeInfo<Vec<NavTarget>>> {
+) -> Option<Vec<IncludeDirective>> {
     let includes = include_directives_at(db, file_id, offset).ok()?;
+    (!includes.is_empty()).then_some(includes)
+}
+
+fn render_include_definition_target(
+    db: &RootDb,
+    includes: Vec<IncludeDirective>,
+) -> Option<RangeInfo<Vec<NavTarget>>> {
     let range = includes.first()?.range;
     let targets = includes
         .into_iter()

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -43,7 +43,7 @@ struct MacroSourceLink {
 }
 
 enum HoverTarget<'tree> {
-    Macro(MacroHoverTarget),
+    Macro(Box<MacroHoverTarget>),
     Include(Vec<IncludeDirective>),
     Source(SourceTarget<'tree>),
 }
@@ -84,7 +84,7 @@ fn dispatch_hover_target<'tree>(
     root: Option<SyntaxNode<'tree>>,
 ) -> Option<HoverTarget<'tree>> {
     if let Some(macro_target) = dispatch_macro_hover_target(db, file_id, offset) {
-        return Some(HoverTarget::Macro(macro_target));
+        return Some(HoverTarget::Macro(Box::new(macro_target)));
     }
     if let Some(includes) = dispatch_include_hover_target(db, file_id, offset) {
         return Some(HoverTarget::Include(includes));
@@ -103,7 +103,7 @@ fn render_hover_target(
     target: HoverTarget<'_>,
 ) -> Option<RangeInfo<Markup>> {
     match target {
-        HoverTarget::Macro(target) => render_macro_hover_target(db, file_id, offset, target),
+        HoverTarget::Macro(target) => render_macro_hover_target(db, file_id, offset, *target),
         HoverTarget::Include(includes) => render_include_hover(db, includes),
         HoverTarget::Source(target) => {
             let hover = hover_for_source_target(sema, file_id.into(), target)?;

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -27,7 +27,7 @@ use vfs::FileId;
 
 use crate::{
     FilePosition, RangeInfo, db::root_db::RootDb, definitions::DefinitionClass, markup::Markup,
-    render, source_tokens::SourceTokenSelection,
+    render, source_targets::SourceTarget,
 };
 
 const MACRO_EXPANSION_SEPARATOR: &str = "--------------------";
@@ -73,7 +73,7 @@ pub(crate) fn hover(
     let hir_file_id = file_id.into();
     let parsed_file = sema.parse_file(file_id);
     let root = parsed_file.root()?;
-    let selection = crate::source_tokens::source_token_resolution_at_offset(
+    let target = crate::source_targets::source_target_at_offset(
         db,
         file_id,
         root,
@@ -81,16 +81,16 @@ pub(crate) fn hover(
         token_precedence,
     )?
     .resolved()?;
-    let hover = hover_for_source_token_selection(&sema, hir_file_id, selection)?;
+    let hover = hover_for_source_target(&sema, hir_file_id, target)?;
     Some(with_expanded_macro_hover(db, file_id, offset, hover))
 }
 
-fn hover_for_source_token_selection(
+fn hover_for_source_target(
     sema: &Semantics<RootDb>,
     hir_file_id: HirFileId,
-    selection: SourceTokenSelection<'_>,
+    target: SourceTarget<'_>,
 ) -> Option<RangeInfo<Markup>> {
-    let (range, tokens) = selection.into_parts();
+    let (range, tokens) = target.into_parts();
     hover_for_token_selection(sema, hir_file_id, range, tokens)
 }
 

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -7,15 +7,16 @@ use hir::{
     file::HirFileId,
     hir_def::expr::Expr,
     preproc::{
-        IncludeTarget, MacroDefinition, MacroExpansionDefinition, MacroParamDefinition,
-        MacroReferenceDefinitions, RecursiveMacroExpansionProvenance, include_directives_at,
-        macro_definition_at, macro_param_definition_at, macro_param_reference_definitions_at,
+        IncludeDirective, IncludeTarget, MacroDefinition, MacroExpansionDefinition,
+        MacroParamDefinition, MacroParamReferenceDefinitions, MacroReferenceDefinitions,
+        RecursiveMacroExpansionProvenance, include_directives_at, macro_definition_at,
+        macro_param_definition_at, macro_param_reference_definitions_at,
         macro_reference_definitions_at, recursive_macro_expansion_provenances_at,
     },
     semantics::Semantics,
 };
 use syntax::{
-    SyntaxTokenWithParent, TokenKind,
+    SyntaxNode, SyntaxTokenWithParent, TokenKind,
     ast::{self, AstNode},
     token::TokenKindExt,
 };
@@ -26,8 +27,12 @@ use utils::{
 use vfs::FileId;
 
 use crate::{
-    FilePosition, RangeInfo, db::root_db::RootDb, definitions::DefinitionClass, markup::Markup,
-    render, source_targets::SourceTarget,
+    FilePosition, RangeInfo,
+    db::root_db::RootDb,
+    definitions::DefinitionClass,
+    markup::Markup,
+    render,
+    source_targets::{SourceTarget, source_target_at_offset},
 };
 
 const MACRO_EXPANSION_SEPARATOR: &str = "--------------------";
@@ -37,9 +42,17 @@ struct MacroSourceLink {
     target: String,
 }
 
-struct PreprocMacroHover {
-    hover: RangeInfo<Markup>,
-    reference_definitions: Option<MacroReferenceDefinitions>,
+enum HoverTarget<'tree> {
+    Macro(MacroHoverTarget),
+    Include(Vec<IncludeDirective>),
+    Source(SourceTarget<'tree>),
+}
+
+enum MacroHoverTarget {
+    ParamDefinition(MacroParamDefinition),
+    ParamReference(MacroParamReferenceDefinitions),
+    Definition(MacroDefinition),
+    Reference(MacroReferenceDefinitions),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -58,31 +71,45 @@ pub(crate) fn hover(
     FilePosition { file_id, offset }: FilePosition,
     _config: HoverConfig,
 ) -> Option<RangeInfo<Markup>> {
-    if let Some(macro_hover) = handle_preproc_macro(db, file_id, offset) {
-        return Some(
-            expanded_macro_hover(db, file_id, offset, macro_hover.reference_definitions.as_ref())
-                .unwrap_or(macro_hover.hover),
-        );
-    }
-
-    if let Some(include) = handle_preproc_include(db, file_id, offset) {
-        return Some(include);
-    }
-
     let sema = Semantics::new(db);
-    let hir_file_id = file_id.into();
     let parsed_file = sema.parse_file(file_id);
-    let root = parsed_file.root()?;
-    let target = crate::source_targets::source_target_at_offset(
-        db,
-        file_id,
-        root,
-        offset,
-        token_precedence,
-    )?
-    .resolved()?;
-    let hover = hover_for_source_target(&sema, hir_file_id, target)?;
-    Some(with_expanded_macro_hover(db, file_id, offset, hover))
+    let target = dispatch_hover_target(db, file_id, offset, parsed_file.root())?;
+    render_hover_target(db, file_id, offset, &sema, target)
+}
+
+fn dispatch_hover_target<'tree>(
+    db: &RootDb,
+    file_id: FileId,
+    offset: TextSize,
+    root: Option<SyntaxNode<'tree>>,
+) -> Option<HoverTarget<'tree>> {
+    if let Some(macro_target) = dispatch_macro_hover_target(db, file_id, offset) {
+        return Some(HoverTarget::Macro(macro_target));
+    }
+    if let Some(includes) = dispatch_include_hover_target(db, file_id, offset) {
+        return Some(HoverTarget::Include(includes));
+    }
+    let root = root?;
+    let target =
+        source_target_at_offset(db, file_id, root, offset, token_precedence)?.resolved()?;
+    Some(HoverTarget::Source(target))
+}
+
+fn render_hover_target(
+    db: &RootDb,
+    file_id: FileId,
+    offset: TextSize,
+    sema: &Semantics<RootDb>,
+    target: HoverTarget<'_>,
+) -> Option<RangeInfo<Markup>> {
+    match target {
+        HoverTarget::Macro(target) => render_macro_hover_target(db, file_id, offset, target),
+        HoverTarget::Include(includes) => render_include_hover(db, includes),
+        HoverTarget::Source(target) => {
+            let hover = hover_for_source_target(sema, file_id.into(), target)?;
+            Some(with_expanded_macro_hover(db, file_id, offset, hover))
+        }
+    }
 }
 
 fn hover_for_source_target(
@@ -420,56 +447,63 @@ fn covering_range(ranges: &[TextRange]) -> Option<TextRange> {
     Some(TextRange::new(start, end))
 }
 
-fn handle_preproc_macro(
+fn dispatch_macro_hover_target(
     db: &RootDb,
     file_id: FileId,
     offset: TextSize,
-) -> Option<PreprocMacroHover> {
+) -> Option<MacroHoverTarget> {
     if let Ok(Some(definition)) = macro_param_definition_at(db, file_id, offset) {
-        return Some(PreprocMacroHover {
-            hover: RangeInfo::new(definition.range, macro_param_definition_markup(&definition)),
-            reference_definitions: None,
-        });
+        return Some(MacroHoverTarget::ParamDefinition(definition));
     }
 
     if let Ok(Some(param_resolution)) = macro_param_reference_definitions_at(db, file_id, offset) {
         if param_resolution.definitions.is_empty() {
             return None;
         }
-        return Some(PreprocMacroHover {
-            hover: RangeInfo::new(
-                param_resolution.range,
-                macro_param_definitions_markup(&param_resolution.definitions),
-            ),
-            reference_definitions: None,
-        });
+        return Some(MacroHoverTarget::ParamReference(param_resolution));
     }
 
     if let Ok(Some(definition)) = macro_definition_at(db, file_id, offset) {
-        return Some(PreprocMacroHover {
-            hover: RangeInfo::new(
-                definition.name_range,
-                macro_definition_markup(db, file_id, &definition),
-            ),
-            reference_definitions: None,
-        });
+        return Some(MacroHoverTarget::Definition(definition));
     }
 
     if let Ok(Some(resolution)) = macro_reference_definitions_at(db, file_id, offset) {
-        if resolution.definitions.is_empty() {
-            if let Some(hover) = expanded_macro_hover(db, file_id, offset, Some(&resolution)) {
-                return Some(PreprocMacroHover { hover, reference_definitions: Some(resolution) });
-            }
-            return None;
-        }
-        let hover = RangeInfo::new(
-            resolution.range,
-            macro_definitions_markup(db, file_id, &resolution.definitions),
-        );
-        return Some(PreprocMacroHover { hover, reference_definitions: Some(resolution) });
+        return Some(MacroHoverTarget::Reference(resolution));
     }
 
     None
+}
+
+fn render_macro_hover_target(
+    db: &RootDb,
+    file_id: FileId,
+    offset: TextSize,
+    target: MacroHoverTarget,
+) -> Option<RangeInfo<Markup>> {
+    match target {
+        MacroHoverTarget::ParamDefinition(definition) => {
+            Some(RangeInfo::new(definition.range, macro_param_definition_markup(&definition)))
+        }
+        MacroHoverTarget::ParamReference(param_resolution) => Some(RangeInfo::new(
+            param_resolution.range,
+            macro_param_definitions_markup(&param_resolution.definitions),
+        )),
+        MacroHoverTarget::Definition(definition) => Some(RangeInfo::new(
+            definition.name_range,
+            macro_definition_markup(db, file_id, &definition),
+        )),
+        MacroHoverTarget::Reference(resolution) => {
+            if resolution.definitions.is_empty() {
+                return expanded_macro_hover(db, file_id, offset, Some(&resolution));
+            }
+            expanded_macro_hover(db, file_id, offset, Some(&resolution)).or_else(|| {
+                Some(RangeInfo::new(
+                    resolution.range,
+                    macro_definitions_markup(db, file_id, &resolution.definitions),
+                ))
+            })
+        }
+    }
 }
 
 fn macro_param_definition_markup(definition: &MacroParamDefinition) -> Markup {
@@ -568,12 +602,16 @@ fn macro_definition_body_text(definition: &MacroDefinition) -> String {
     definition.body_tokens.iter().map(|token| token.as_str()).collect::<Vec<_>>().join(" ")
 }
 
-fn handle_preproc_include(
+fn dispatch_include_hover_target(
     db: &RootDb,
     file_id: FileId,
     offset: TextSize,
-) -> Option<RangeInfo<Markup>> {
+) -> Option<Vec<IncludeDirective>> {
     let includes = include_directives_at(db, file_id, offset).ok()?;
+    (!includes.is_empty()).then_some(includes)
+}
+
+fn render_include_hover(db: &RootDb, includes: Vec<IncludeDirective>) -> Option<RangeInfo<Markup>> {
     let range = includes.first()?.range;
     let mut markup = Markup::new();
     markup.print("Include");

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -40,7 +40,7 @@ pub mod rename;
 pub mod selection_ranges;
 pub mod semantic_tokens;
 pub mod signature_help;
-pub(crate) mod source_tokens;
+pub(crate) mod source_targets;
 #[cfg(test)]
 mod test_utils;
 #[cfg(test)]

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use nohash_hasher::IntMap;
 use search::{ReferencesCtx, SearchScope};
 use syntax::{
-    SyntaxTokenWithParent, TokenKind,
+    SyntaxNode, SyntaxTokenWithParent, TokenKind,
     has_text_range::HasTextRange,
     token::{TokenKindExt, pair_token},
 };
@@ -23,9 +23,20 @@ use crate::{
     db::root_db::RootDb,
     definitions::{Definition, DefinitionClass},
     navigation_target::{NavTarget, ToNav},
+    source_targets::{SourceTarget, source_target_at_offset},
 };
 
 pub(crate) mod search;
+
+enum ReferencesTarget<'tree> {
+    Preproc(PreprocReferencesTarget),
+    Source(SourceTarget<'tree>),
+}
+
+enum PreprocReferencesTarget {
+    MacroParams(Vec<MacroParamDefinition>),
+    Macros(Vec<MacroDefinition>),
+}
 
 bitflags::bitflags! {
     #[derive(Copy, Clone, Default, PartialEq, Eq, Hash, Debug)]
@@ -94,26 +105,55 @@ pub(crate) fn references(
     FilePosition { file_id, offset }: FilePosition,
     config: ReferencesConfig,
 ) -> Option<Vec<References>> {
-    if let Some(macro_refs) = handle_preproc_macro(db, file_id, offset, &config) {
-        return Some(macro_refs);
-    }
-
     let sema = Semantics::new(db);
-    let hir_file_id = file_id.into();
     let parsed_file = sema.parse_file(file_id);
-    let root = parsed_file.root()?;
-    let tokens = crate::source_targets::source_target_at_offset(
-        db,
-        file_id,
-        root,
-        offset,
-        token_precedence,
-    )?
-    .resolved()?
-    .into_tokens();
+    let target = dispatch_references_target(db, file_id, offset, parsed_file.root())?;
+    render_references_target(db, file_id, &sema, target, config)
+}
+
+fn dispatch_references_target<'tree>(
+    db: &RootDb,
+    file_id: FileId,
+    offset: TextSize,
+    root: Option<SyntaxNode<'tree>>,
+) -> Option<ReferencesTarget<'tree>> {
+    if let Some(target) = dispatch_preproc_references_target(db, file_id, offset) {
+        return Some(ReferencesTarget::Preproc(target));
+    }
+    let root = root?;
+    let target =
+        source_target_at_offset(db, file_id, root, offset, token_precedence)?.resolved()?;
+    Some(ReferencesTarget::Source(target))
+}
+
+fn render_references_target(
+    db: &RootDb,
+    file_id: FileId,
+    sema: &Semantics<RootDb>,
+    target: ReferencesTarget<'_>,
+    config: ReferencesConfig,
+) -> Option<Vec<References>> {
+    match target {
+        ReferencesTarget::Preproc(target) => {
+            render_preproc_references_target(db, file_id, target, &config)
+        }
+        ReferencesTarget::Source(target) => {
+            render_source_references_target(sema, file_id, target, config)
+        }
+    }
+}
+
+fn render_source_references_target(
+    sema: &Semantics<RootDb>,
+    file_id: FileId,
+    target: SourceTarget<'_>,
+    config: ReferencesConfig,
+) -> Option<Vec<References>> {
+    let hir_file_id = file_id.into();
+    let tokens = target.into_tokens();
     let references = tokens
         .into_iter()
-        .filter_map(|token| references_for_token(&sema, hir_file_id, token, config.clone()))
+        .filter_map(|token| references_for_token(sema, hir_file_id, token, config.clone()))
         .flatten()
         .collect_vec();
     (!references.is_empty()).then_some(references)
@@ -135,14 +175,13 @@ fn references_for_token(
     })
 }
 
-fn handle_preproc_macro(
+fn dispatch_preproc_references_target(
     db: &RootDb,
     file_id: FileId,
     offset: TextSize,
-    config: &ReferencesConfig,
-) -> Option<Vec<References>> {
-    if let Some(param_refs) = handle_preproc_macro_param(db, file_id, offset, config) {
-        return Some(param_refs);
+) -> Option<PreprocReferencesTarget> {
+    if let Some(target) = dispatch_preproc_macro_param_references_target(db, file_id, offset) {
+        return Some(target);
     }
 
     let definitions = if let Some(definition) = macro_definition_at(db, file_id, offset).ok()? {
@@ -154,18 +193,14 @@ fn handle_preproc_macro(
         return None;
     }
 
-    definitions
-        .into_iter()
-        .map(|definition| macro_references_for_definition(db, file_id, definition, config))
-        .collect()
+    Some(PreprocReferencesTarget::Macros(definitions))
 }
 
-fn handle_preproc_macro_param(
+fn dispatch_preproc_macro_param_references_target(
     db: &RootDb,
     file_id: FileId,
     offset: TextSize,
-    config: &ReferencesConfig,
-) -> Option<Vec<References>> {
+) -> Option<PreprocReferencesTarget> {
     let definitions =
         if let Some(definition) = macro_param_definition_at(db, file_id, offset).ok()? {
             vec![definition]
@@ -176,10 +211,27 @@ fn handle_preproc_macro_param(
         return None;
     }
 
-    definitions
-        .into_iter()
-        .map(|definition| macro_param_references_for_definition(db, file_id, definition, config))
-        .collect()
+    Some(PreprocReferencesTarget::MacroParams(definitions))
+}
+
+fn render_preproc_references_target(
+    db: &RootDb,
+    file_id: FileId,
+    target: PreprocReferencesTarget,
+    config: &ReferencesConfig,
+) -> Option<Vec<References>> {
+    match target {
+        PreprocReferencesTarget::MacroParams(definitions) => definitions
+            .into_iter()
+            .map(|definition| {
+                macro_param_references_for_definition(db, file_id, definition, config)
+            })
+            .collect(),
+        PreprocReferencesTarget::Macros(definitions) => definitions
+            .into_iter()
+            .map(|definition| macro_references_for_definition(db, file_id, definition, config))
+            .collect(),
+    }
 }
 
 fn macro_param_references_for_definition(

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -102,7 +102,7 @@ pub(crate) fn references(
     let hir_file_id = file_id.into();
     let parsed_file = sema.parse_file(file_id);
     let root = parsed_file.root()?;
-    let tokens = crate::source_tokens::source_token_resolution_at_offset(
+    let tokens = crate::source_targets::source_target_at_offset(
         db,
         file_id,
         root,

--- a/crates/ide/src/references/search.rs
+++ b/crates/ide/src/references/search.rs
@@ -27,7 +27,7 @@ use crate::{
     ScopeVisibility,
     db::root_db::RootDb,
     definitions::{Definition, DefinitionClass},
-    source_tokens::SourceTokenRequestCache,
+    source_targets::SourceTargetRequestCache,
 };
 
 /// A search scope is a set of files and ranges within those files that should
@@ -205,7 +205,7 @@ impl<'a, 'b> ReferencesCtx<'a, 'b> {
             self.def.origins().into_iter().filter_map(|def| def.name_range(db)).collect();
 
         let finder = &Finder::new(&name);
-        let mut source_token_cache = SourceTokenRequestCache::default();
+        let mut source_target_cache = SourceTargetRequestCache::default();
         for (text, file_id, range) in self.scope_files() {
             self.sema.db.unwind_if_cancelled();
 
@@ -221,7 +221,7 @@ impl<'a, 'b> ReferencesCtx<'a, 'b> {
                         file_id,
                         &def_ranges,
                         offset,
-                        &mut source_token_cache,
+                        &mut source_target_cache,
                     )
                 })
                 .filter(|tp| self.classify_and_filter(sema, file_id.into(), tp))
@@ -274,21 +274,21 @@ impl<'a, 'b> ReferencesCtx<'a, 'b> {
         file_id: FileId,
         names: &[InFile<TextRange>],
         offset: TextSize,
-        source_token_cache: &mut SourceTokenRequestCache,
+        source_target_cache: &mut SourceTargetRequestCache,
     ) -> Vec<SyntaxTokenWithParent<'tree>> {
-        let Some(selection) = crate::source_tokens::source_token_resolution_at_offset_with_cache(
+        let Some(target) = crate::source_targets::source_target_at_offset_with_cache(
             db,
             file_id,
             node,
             offset,
             super::token_precedence,
-            source_token_cache,
+            source_target_cache,
         )
         .and_then(|resolution| resolution.resolved()) else {
             return Vec::new();
         };
 
-        selection
+        target
             .into_tokens()
             .into_iter()
             .filter(|tok| tok.kind().name_like())

--- a/crates/ide/src/source_targets.rs
+++ b/crates/ide/src/source_targets.rs
@@ -1,7 +1,8 @@
 use hir::{
     base_db::source_db::{SourceDb, SourcePreprocQueryError},
     preproc::{
-        EmittedTokenProvenance, MacroDefinitionId, MacroExpansionProvenance, MappedPreprocSource,
+        EmittedTokenProvenance, MacroArgumentTokenIdentity, MacroBodyTokenIdentity,
+        MacroDefinitionId, MacroExpansionProvenance, MacroTokenIdentity, MappedPreprocSource,
         PreprocError, TokenProvenance, macro_expansion_provenances_at,
     },
 };
@@ -16,30 +17,30 @@ use vfs::FileId;
 use crate::db::root_db::RootDb;
 
 #[derive(Debug, Clone)]
-pub(crate) enum SourceTokenResolution<'tree> {
-    Resolved(SourceTokenSelection<'tree>),
-    Blocked(SourceTokenBlock),
+pub(crate) enum SourceTargetResolution<'tree> {
+    Resolved(SourceTarget<'tree>),
+    Blocked(SourceTargetBlock),
 }
 
-impl<'tree> SourceTokenResolution<'tree> {
-    pub(crate) fn resolved(self) -> Option<SourceTokenSelection<'tree>> {
+impl<'tree> SourceTargetResolution<'tree> {
+    pub(crate) fn resolved(self) -> Option<SourceTarget<'tree>> {
         match self {
             Self::Resolved(selection) => Some(selection),
-            Self::Blocked(SourceTokenBlock { .. }) => None,
+            Self::Blocked(SourceTargetBlock { .. }) => None,
         }
     }
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct SourceTokenSelection<'tree> {
-    pub origin: SourceTokenOrigin,
+pub(crate) struct SourceTarget<'tree> {
+    pub origin: SourceTargetOrigin,
     pub range: TextRange,
     pub tokens: Vec<SyntaxTokenWithParent<'tree>>,
 }
 
-impl<'tree> SourceTokenSelection<'tree> {
+impl<'tree> SourceTarget<'tree> {
     fn normal_syntax(range: TextRange, tokens: Vec<SyntaxTokenWithParent<'tree>>) -> Self {
-        Self { origin: SourceTokenOrigin::NormalSyntax, range, tokens }
+        Self { origin: SourceTargetOrigin::NormalSyntax, range, tokens }
     }
 
     fn preproc(
@@ -47,14 +48,14 @@ impl<'tree> SourceTokenSelection<'tree> {
         hits: Vec<PreprocTokenHit>,
         tokens: Vec<SyntaxTokenWithParent<'tree>>,
     ) -> Self {
-        Self { origin: SourceTokenOrigin::Preproc { hits }, range, tokens }
+        Self { origin: SourceTargetOrigin::Preproc { hits }, range, tokens }
     }
 
     pub(crate) fn into_parts(self) -> (TextRange, Vec<SyntaxTokenWithParent<'tree>>) {
         let Self { origin, range, tokens } = self;
         match origin {
-            SourceTokenOrigin::NormalSyntax => (range, tokens),
-            SourceTokenOrigin::Preproc { hits } => {
+            SourceTargetOrigin::NormalSyntax => (range, tokens),
+            SourceTargetOrigin::Preproc { hits } => {
                 let _hit_count = hits.len();
                 (range, tokens)
             }
@@ -67,54 +68,54 @@ impl<'tree> SourceTokenSelection<'tree> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum SourceTokenOrigin {
+pub(crate) enum SourceTargetOrigin {
     NormalSyntax,
     Preproc { hits: Vec<PreprocTokenHit> },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum SourceTokenDomain {
+pub(crate) enum SourceTargetDomain {
     Preproc,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct SourceTokenBlock {
-    pub domain: SourceTokenDomain,
+pub(crate) struct SourceTargetBlock {
+    pub domain: SourceTargetDomain,
     pub range: TextRange,
-    pub reason: SourceTokenBlockReason,
+    pub reason: SourceTargetBlockReason,
 }
 
-impl SourceTokenBlock {
+impl SourceTargetBlock {
     fn preproc_unavailable(range: TextRange) -> Self {
         Self {
-            domain: SourceTokenDomain::Preproc,
+            domain: SourceTargetDomain::Preproc,
             range,
-            reason: SourceTokenBlockReason::Unavailable,
+            reason: SourceTargetBlockReason::Unavailable,
         }
     }
 
     fn preproc_ambiguous(range: TextRange, hits: Vec<PreprocTokenHit>) -> Self {
         Self {
-            domain: SourceTokenDomain::Preproc,
+            domain: SourceTargetDomain::Preproc,
             range,
-            reason: SourceTokenBlockReason::Ambiguous { hits },
+            reason: SourceTargetBlockReason::Ambiguous { hits },
         }
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum SourceTokenBlockReason {
+pub(crate) enum SourceTargetBlockReason {
     Unavailable,
     Ambiguous { hits: Vec<PreprocTokenHit> },
 }
 
 #[derive(Debug, Default)]
-pub(crate) struct SourceTokenRequestCache {
+pub(crate) struct SourceTargetRequestCache {
     provenance_by_offset:
         FxHashMap<(FileId, TextSize), Result<Vec<MacroExpansionProvenance>, PreprocError>>,
 }
 
-impl SourceTokenRequestCache {
+impl SourceTargetRequestCache {
     fn macro_expansion_provenances_at(
         &mut self,
         db: &RootDb,
@@ -146,7 +147,7 @@ pub(crate) struct PreprocTokenHit {
     pub display_range: TextRange,
     pub source_range: TextRange,
     pub provenance: PreprocTokenProvenance,
-    target: PreprocSemanticTarget,
+    target: PreprocSourceTarget,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -156,12 +157,14 @@ pub(crate) enum PreprocTokenProvenance {
         range: TextRange,
     },
     MacroBody {
+        identity: MacroBodyTokenIdentity,
         call: usize,
         definition_id: MacroDefinitionId,
         source: MappedPreprocSource,
         range: TextRange,
     },
     MacroArgument {
+        identity: MacroArgumentTokenIdentity,
         call: usize,
         argument_index: usize,
         source: MappedPreprocSource,
@@ -170,116 +173,116 @@ pub(crate) enum PreprocTokenProvenance {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum PreprocSemanticTarget {
+enum PreprocSourceTarget {
     SourceToken { source: MappedPreprocSource, range: TextRange },
     MacroBody { definition_id: MacroDefinitionId, source: MappedPreprocSource, range: TextRange },
 }
 
-pub(crate) fn source_token_resolution_at_offset<'tree, F>(
+pub(crate) fn source_target_at_offset<'tree, F>(
     db: &RootDb,
     file_id: FileId,
     root: SyntaxNode<'tree>,
     offset: TextSize,
     precedence: F,
-) -> Option<SourceTokenResolution<'tree>>
+) -> Option<SourceTargetResolution<'tree>>
 where
     F: Fn(TokenKind) -> usize,
 {
-    let mut cache = SourceTokenRequestCache::default();
-    source_token_resolution_at_offset_with_cache(db, file_id, root, offset, precedence, &mut cache)
+    let mut cache = SourceTargetRequestCache::default();
+    source_target_at_offset_with_cache(db, file_id, root, offset, precedence, &mut cache)
 }
 
-pub(crate) fn source_token_resolution_at_offset_with_cache<'tree, F>(
+pub(crate) fn source_target_at_offset_with_cache<'tree, F>(
     db: &RootDb,
     file_id: FileId,
     root: SyntaxNode<'tree>,
     offset: TextSize,
     precedence: F,
-    cache: &mut SourceTokenRequestCache,
-) -> Option<SourceTokenResolution<'tree>>
+    cache: &mut SourceTargetRequestCache,
+) -> Option<SourceTargetResolution<'tree>>
 where
     F: Fn(TokenKind) -> usize,
 {
-    match preproc_source_token_at_offset(db, file_id, root, offset, &precedence, cache) {
-        SourceTokenProviderResult::NotApplicable => {
-            normal_syntax_source_token_at_offset(root, offset, &precedence).into_resolution()
+    match preproc_source_target_at_offset(db, file_id, root, offset, &precedence, cache) {
+        SourceTargetProviderResult::NotApplicable => {
+            normal_syntax_source_target_at_offset(root, offset, &precedence).into_resolution()
         }
         result => result.into_resolution(),
     }
 }
 
-fn normal_syntax_source_token_at_offset<'tree>(
+fn normal_syntax_source_target_at_offset<'tree>(
     root: SyntaxNode<'tree>,
     offset: TextSize,
     precedence: &impl Fn(TokenKind) -> usize,
-) -> SourceTokenProviderResult<'tree> {
+) -> SourceTargetProviderResult<'tree> {
     let Some(token) = root.token_at_offset(offset).pick_bext_token(precedence) else {
-        return SourceTokenProviderResult::NotApplicable;
+        return SourceTargetProviderResult::NotApplicable;
     };
     let Some(range) = token.text_range() else {
-        return SourceTokenProviderResult::NotApplicable;
+        return SourceTargetProviderResult::NotApplicable;
     };
-    SourceTokenProviderResult::Resolved(SourceTokenSelection::normal_syntax(range, vec![token]))
+    SourceTargetProviderResult::Resolved(SourceTarget::normal_syntax(range, vec![token]))
 }
 
-enum SourceTokenProviderResult<'tree> {
-    Resolved(SourceTokenSelection<'tree>),
-    Blocked(SourceTokenBlock),
+enum SourceTargetProviderResult<'tree> {
+    Resolved(SourceTarget<'tree>),
+    Blocked(SourceTargetBlock),
     NotApplicable,
 }
 
-impl<'tree> SourceTokenProviderResult<'tree> {
-    fn into_resolution(self) -> Option<SourceTokenResolution<'tree>> {
+impl<'tree> SourceTargetProviderResult<'tree> {
+    fn into_resolution(self) -> Option<SourceTargetResolution<'tree>> {
         match self {
-            Self::Resolved(selection) => Some(SourceTokenResolution::Resolved(selection)),
-            Self::Blocked(block) => Some(SourceTokenResolution::Blocked(block)),
+            Self::Resolved(selection) => Some(SourceTargetResolution::Resolved(selection)),
+            Self::Blocked(block) => Some(SourceTargetResolution::Blocked(block)),
             Self::NotApplicable => None,
         }
     }
 }
 
-fn preproc_source_token_at_offset<'tree>(
+fn preproc_source_target_at_offset<'tree>(
     db: &RootDb,
     file_id: FileId,
     root: SyntaxNode<'tree>,
     offset: TextSize,
     precedence: &impl Fn(TokenKind) -> usize,
-    cache: &mut SourceTokenRequestCache,
-) -> SourceTokenProviderResult<'tree> {
+    cache: &mut SourceTargetRequestCache,
+) -> SourceTargetProviderResult<'tree> {
     if !source_macro_invocation_may_cover_offset(db.file_text(file_id).as_ref(), offset) {
-        return SourceTokenProviderResult::NotApplicable;
+        return SourceTargetProviderResult::NotApplicable;
     }
 
     let provenances = match cache.macro_expansion_provenances_at(db, file_id, offset) {
         Ok(provenances) => provenances,
         Err(PreprocError::SourceQuery(SourcePreprocQueryError::UnsupportedFileKind(_))) => {
-            return SourceTokenProviderResult::NotApplicable;
+            return SourceTargetProviderResult::NotApplicable;
         }
         Err(_) => {
-            return SourceTokenProviderResult::Blocked(SourceTokenBlock::preproc_unavailable(
+            return SourceTargetProviderResult::Blocked(SourceTargetBlock::preproc_unavailable(
                 TextRange::empty(offset),
             ));
         }
     };
     if provenances.is_empty() {
-        return SourceTokenProviderResult::NotApplicable;
+        return SourceTargetProviderResult::NotApplicable;
     }
 
     match preproc_hits_at_offset(&provenances, file_id, offset) {
         PreprocHitLookup::Available { range, hits } => {
             let Some(tokens) = syntax_tokens_for_preproc_hit(root, offset, precedence, &hits)
             else {
-                return SourceTokenProviderResult::Blocked(SourceTokenBlock::preproc_unavailable(
-                    range,
-                ));
+                return SourceTargetProviderResult::Blocked(
+                    SourceTargetBlock::preproc_unavailable(range),
+                );
             };
-            SourceTokenProviderResult::Resolved(SourceTokenSelection::preproc(range, hits, tokens))
+            SourceTargetProviderResult::Resolved(SourceTarget::preproc(range, hits, tokens))
         }
         PreprocHitLookup::Unavailable { range } => {
-            SourceTokenProviderResult::Blocked(SourceTokenBlock::preproc_unavailable(range))
+            SourceTargetProviderResult::Blocked(SourceTargetBlock::preproc_unavailable(range))
         }
         PreprocHitLookup::Ambiguous { range, hits } => {
-            SourceTokenProviderResult::Blocked(SourceTokenBlock::preproc_ambiguous(range, hits))
+            SourceTargetProviderResult::Blocked(SourceTargetBlock::preproc_ambiguous(range, hits))
         }
     }
 }
@@ -337,35 +340,37 @@ fn preproc_hit_for_token(
             source.clone(),
             *range,
             PreprocTokenProvenance::SourceToken { source: source.clone(), range: *range },
-            PreprocSemanticTarget::SourceToken { source: source.clone(), range: *range },
+            PreprocSourceTarget::SourceToken { source: source.clone(), range: *range },
             expansion.expansion.call.id.raw(),
         ),
-        TokenProvenance::MacroBody { call, definition_id, source, range, .. } => (
+        TokenProvenance::MacroBody { identity, call, definition_id, source, range } => (
             source.clone(),
             *range,
             PreprocTokenProvenance::MacroBody {
+                identity: *identity,
                 call: call.id.raw(),
                 definition_id: *definition_id,
                 source: source.clone(),
                 range: *range,
             },
-            PreprocSemanticTarget::MacroBody {
+            PreprocSourceTarget::MacroBody {
                 definition_id: *definition_id,
                 source: source.clone(),
                 range: *range,
             },
             call.id.raw(),
         ),
-        TokenProvenance::MacroArgument { call, argument_index, source, range, .. } => (
+        TokenProvenance::MacroArgument { identity, call, argument_index, source, range } => (
             source.clone(),
             *range,
             PreprocTokenProvenance::MacroArgument {
+                identity: *identity,
                 call: call.id.raw(),
                 argument_index: *argument_index,
                 source: source.clone(),
                 range: *range,
             },
-            PreprocSemanticTarget::SourceToken { source: source.clone(), range: *range },
+            PreprocSourceTarget::SourceToken { source: source.clone(), range: *range },
             call.id.raw(),
         ),
         TokenProvenance::Predefine { .. }
@@ -403,27 +408,44 @@ fn syntax_tokens_for_preproc_hit<'tree>(
     precedence: &impl Fn(TokenKind) -> usize,
     hits: &[PreprocTokenHit],
 ) -> Option<Vec<SyntaxTokenWithParent<'tree>>> {
+    let identities = hits.iter().filter_map(macro_token_identity_for_hit).collect::<Vec<_>>();
+    if !identities.is_empty() {
+        return syntax_tokens_for_macro_identities(root, &identities);
+    }
+
+    return normal_syntax_source_target_at_offset(root, offset, precedence)
+        .into_resolution()
+        .and_then(SourceTargetResolution::resolved)
+        .map(SourceTarget::into_tokens);
+}
+
+fn macro_token_identity_for_hit(hit: &PreprocTokenHit) -> Option<MacroTokenIdentity> {
+    match hit.provenance {
+        PreprocTokenProvenance::MacroBody { identity, .. } => {
+            Some(MacroTokenIdentity::Body(identity))
+        }
+        PreprocTokenProvenance::MacroArgument { identity, .. } => {
+            Some(MacroTokenIdentity::Argument(identity))
+        }
+        PreprocTokenProvenance::SourceToken { .. } => None,
+    }
+}
+
+fn syntax_tokens_for_macro_identities<'tree>(
+    root: SyntaxNode<'tree>,
+    identities: &[MacroTokenIdentity],
+) -> Option<Vec<SyntaxTokenWithParent<'tree>>> {
     let mut tokens = Vec::new();
-    let mut best_precedence = 0;
     for event in root.elem_preorder() {
         let WalkEvent::Enter(SyntaxElement::Token(token)) = event else {
             continue;
         };
-        let Some(token_range) = token.text_range() else {
+        let Some(identity) =
+            MacroTokenIdentity::from_syntax_provenance(token.preprocessor_trace_provenance())
+        else {
             continue;
         };
-        if !token_range.contains(offset)
-            || !hits.iter().any(|hit| hit.source_range.intersect(token_range).is_some())
-        {
-            continue;
-        }
-
-        let token_precedence = precedence(token.kind());
-        if token_precedence > best_precedence {
-            tokens.clear();
-            best_precedence = token_precedence;
-        }
-        if token_precedence == best_precedence && !tokens.contains(&token) {
+        if identities.contains(&identity) && !tokens.contains(&token) {
             tokens.push(token);
         }
     }
@@ -537,12 +559,14 @@ fn covering_range(ranges: &[TextRange]) -> Option<TextRange> {
 
 #[cfg(test)]
 mod tests {
-    use syntax::{SyntaxTree, token::TokenKindExt};
+    use syntax::{
+        PreprocessorTraceTokenProvenance, SyntaxTree, SyntaxTreeOptions, token::TokenKindExt,
+    };
 
     use super::*;
 
     #[test]
-    fn source_tokens_provenance_source_range_hit_test_is_half_open() {
+    fn source_targets_provenance_source_range_hit_test_is_half_open() {
         let file_id = FileId(0);
         let range = TextRange::new(5.into(), 10.into());
         let provenance = TokenProvenance::SourceToken {
@@ -565,7 +589,7 @@ mod tests {
     }
 
     #[test]
-    fn source_tokens_preproc_range_mismatch_still_selects_by_identity() {
+    fn source_targets_source_token_range_mismatch_uses_original_syntax_hit() {
         let (root, offset, parser_range) =
             root_and_offset("module m; wire payload_i; endmodule\n", "payload_i", 2);
         let file_id = FileId(0);
@@ -575,18 +599,18 @@ mod tests {
         );
         let hit = test_source_hit(file_id, provenance_range, 0);
 
-        let SourceTokenProviderResult::Resolved(selection) = preproc_provider_result_from_hits(
+        let SourceTargetProviderResult::Resolved(selection) = preproc_provider_result_from_hits(
             root,
             offset,
             &test_precedence,
             vec![hit],
             provenance_range,
         ) else {
-            panic!("preproc identity hit should select without exact parser range equality");
+            panic!("source-token hit should select by the original syntax token at the offset");
         };
 
         assert_eq!(selection.range, provenance_range);
-        let SourceTokenOrigin::Preproc { hits } = &selection.origin else {
+        let SourceTargetOrigin::Preproc { hits } = &selection.origin else {
             panic!("preproc provider should produce a preproc-origin selection");
         };
         assert_eq!(hits.len(), 1);
@@ -596,13 +620,80 @@ mod tests {
     }
 
     #[test]
-    fn source_tokens_preproc_owned_unresolved_does_not_use_normal_syntax_fallback() {
+    fn source_targets_macro_argument_selects_syntax_token_by_trace_identity() {
+        let source = r#"`define ID(x) x
+module m;
+  assign y = `ID(payload_i);
+endmodule
+"#;
+        let parsed = SyntaxTree::from_text_with_options_and_trace(
+            source,
+            "source",
+            "sample/rtl/top.sv",
+            &SyntaxTreeOptions::default(),
+        );
+        let root = parsed.tree.root().expect("test source should parse");
+        let token = root
+            .elem_preorder()
+            .filter_map(|event| match event {
+                WalkEvent::Enter(SyntaxElement::Token(token))
+                    if token.raw_text().as_bytes() == b"payload_i"
+                        && matches!(
+                            token.preprocessor_trace_provenance(),
+                            PreprocessorTraceTokenProvenance::MacroArgument { .. }
+                        ) =>
+                {
+                    Some(token)
+                }
+                _ => None,
+            })
+            .next()
+            .expect("expanded source should contain the macro argument token");
+        let PreprocessorTraceTokenProvenance::MacroArgument { identity, .. } =
+            token.preprocessor_trace_provenance()
+        else {
+            panic!("payload_i should have macro argument provenance");
+        };
+        let expected_identity: MacroArgumentTokenIdentity = identity.into();
+        let file_id = FileId(0);
+        let source_range = source_range(source, "payload_i");
+        let source = MappedPreprocSource::RealFile { file_id };
+        let hit = PreprocTokenHit {
+            expansion: 0,
+            call: 0,
+            emitted_token: 0,
+            display_range: source_range,
+            source_range,
+            provenance: PreprocTokenProvenance::MacroArgument {
+                identity: expected_identity,
+                call: 0,
+                argument_index: 0,
+                source: source.clone(),
+                range: source_range,
+            },
+            target: PreprocSourceTarget::SourceToken { source, range: source_range },
+        };
+
+        let tokens =
+            syntax_tokens_for_preproc_hit(root, source_range.start(), &test_precedence, &[hit])
+                .expect("macro argument identity should resolve to a parsed syntax token");
+
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(tokens[0].raw_text().as_bytes(), b"payload_i");
+        assert_eq!(
+            MacroTokenIdentity::from_syntax_provenance(tokens[0].preprocessor_trace_provenance()),
+            Some(MacroTokenIdentity::Argument(expected_identity))
+        );
+    }
+
+    #[test]
+    fn source_targets_preproc_owned_unresolved_does_not_use_normal_syntax_fallback() {
         let (root, offset, parser_range) =
             root_and_offset("module m; wire payload_i; endmodule\n", "payload_i", 0);
         assert!(
             matches!(
-                normal_syntax_source_token_at_offset(root, offset, &test_precedence),
-                SourceTokenProviderResult::Resolved(_)
+                normal_syntax_source_target_at_offset(root, offset, &test_precedence),
+                SourceTargetProviderResult::Resolved(_)
             ),
             "test setup must have an ordinary syntax token that fallback could have selected"
         );
@@ -616,38 +707,38 @@ mod tests {
         );
         assert!(matches!(
             lookup,
-            SourceTokenProviderResult::Blocked(SourceTokenBlock {
-                domain: SourceTokenDomain::Preproc,
-                reason: SourceTokenBlockReason::Unavailable,
+            SourceTargetProviderResult::Blocked(SourceTargetBlock {
+                domain: SourceTargetDomain::Preproc,
+                reason: SourceTargetBlockReason::Unavailable,
                 ..
             })
         ));
     }
 
     #[test]
-    fn source_tokens_normal_syntax_path_still_selects_non_preproc_offsets() {
+    fn source_targets_normal_syntax_path_still_selects_non_preproc_offsets() {
         let (root, offset, parser_range) =
             root_and_offset("module m; wire payload_i; endmodule\n", "payload_i", 0);
-        let SourceTokenProviderResult::Resolved(selection) =
-            normal_syntax_source_token_at_offset(root, offset, &test_precedence)
+        let SourceTargetProviderResult::Resolved(selection) =
+            normal_syntax_source_target_at_offset(root, offset, &test_precedence)
         else {
             panic!("normal syntax token expected");
         };
 
-        assert!(matches!(selection.origin, SourceTokenOrigin::NormalSyntax));
+        assert!(matches!(selection.origin, SourceTargetOrigin::NormalSyntax));
         assert_eq!(selection.range, parser_range);
         assert_eq!(selection.tokens.len(), 1);
     }
 
     #[test]
-    fn source_tokens_macro_provenance_gate_skips_plain_identifiers() {
+    fn source_targets_macro_provenance_gate_skips_plain_identifiers() {
         let text = "module m; wire payload_i; endmodule\n";
 
         assert!(!source_macro_invocation_may_cover_offset(text, offset(text, "payload_i")));
     }
 
     #[test]
-    fn source_tokens_macro_provenance_gate_keeps_macro_names_and_arguments() {
+    fn source_targets_macro_provenance_gate_keeps_macro_names_and_arguments() {
         let text = "module m; wire `MAKE_DECL(payload_i); endmodule\n";
 
         assert!(source_macro_invocation_may_cover_offset(text, offset(text, "`MAKE_DECL")));
@@ -655,14 +746,14 @@ mod tests {
     }
 
     #[test]
-    fn source_tokens_macro_provenance_gate_keeps_outer_arguments_after_nested_macros() {
+    fn source_targets_macro_provenance_gate_keeps_outer_arguments_after_nested_macros() {
         let text = "assign y = `OUTER(a, `INNER(b), payload_i);\n";
 
         assert!(source_macro_invocation_may_cover_offset(text, offset(text, "payload_i")));
     }
 
     #[test]
-    fn source_tokens_dedups_preproc_hits_for_same_semantic_target() {
+    fn source_targets_dedups_preproc_hits_for_same_semantic_target() {
         let (root, offset, parser_range) =
             root_and_offset("module m; wire payload_i; endmodule\n", "payload_i", 0);
         let file_id = FileId(0);
@@ -671,20 +762,20 @@ mod tests {
             test_source_hit(file_id, parser_range, 1),
         ];
 
-        let SourceTokenProviderResult::Resolved(selection) =
+        let SourceTargetProviderResult::Resolved(selection) =
             preproc_provider_result_from_hits(root, offset, &test_precedence, hits, parser_range)
         else {
             panic!("same semantic target should dedup to one available preproc hit");
         };
 
-        let SourceTokenOrigin::Preproc { hits } = selection.origin else {
+        let SourceTargetOrigin::Preproc { hits } = selection.origin else {
             panic!("preproc provider should produce a preproc-origin selection");
         };
         assert_eq!(hits.len(), 1);
     }
 
     #[test]
-    fn source_tokens_reports_ambiguous_preproc_hits_for_conflicting_targets() {
+    fn source_targets_reports_ambiguous_preproc_hits_for_conflicting_targets() {
         let (root, offset, parser_range) =
             root_and_offset("module m; wire payload_i; endmodule\n", "payload_i", 2);
         let file_id = FileId(0);
@@ -692,8 +783,8 @@ mod tests {
         let second = TextRange::new(parser_range.start() + TextSize::from(1), parser_range.end());
         let hits = vec![test_source_hit(file_id, first, 0), test_source_hit(file_id, second, 1)];
 
-        let SourceTokenProviderResult::Blocked(SourceTokenBlock {
-            reason: SourceTokenBlockReason::Ambiguous { hits },
+        let SourceTargetProviderResult::Blocked(SourceTargetBlock {
+            reason: SourceTargetBlockReason::Ambiguous { hits },
             ..
         }) = preproc_provider_result_from_hits(root, offset, &test_precedence, hits, parser_range)
         else {
@@ -704,8 +795,8 @@ mod tests {
     }
 
     #[test]
-    fn source_token_request_cache_reuses_provenance_lookup_for_repeated_reference_hits() {
-        let mut cache = SourceTokenRequestCache::default();
+    fn source_target_request_cache_reuses_provenance_lookup_for_repeated_reference_hits() {
+        let mut cache = SourceTargetRequestCache::default();
         let mut lookups = 0usize;
         let file_id = FileId(0);
         let offset = TextSize::from(12);
@@ -750,6 +841,11 @@ mod tests {
         TextSize::from(u32::try_from(text.find(needle).expect("needle should exist")).unwrap())
     }
 
+    fn source_range(text: &str, needle: &str) -> TextRange {
+        let start = text.find(needle).expect("needle should exist");
+        TextRange::new(TextSize::from(start as u32), TextSize::from((start + needle.len()) as u32))
+    }
+
     fn test_source_hit(file_id: FileId, range: TextRange, emitted_token: usize) -> PreprocTokenHit {
         let source = MappedPreprocSource::RealFile { file_id };
         PreprocTokenHit {
@@ -759,7 +855,7 @@ mod tests {
             display_range: range,
             source_range: range,
             provenance: PreprocTokenProvenance::SourceToken { source: source.clone(), range },
-            target: PreprocSemanticTarget::SourceToken { source, range },
+            target: PreprocSourceTarget::SourceToken { source, range },
         }
     }
 
@@ -769,7 +865,7 @@ mod tests {
         precedence: &impl Fn(TokenKind) -> usize,
         hits: Vec<PreprocTokenHit>,
         fallback_range: TextRange,
-    ) -> SourceTokenProviderResult<'tree> {
+    ) -> SourceTargetProviderResult<'tree> {
         let mut unique_hits = Vec::new();
         for hit in hits {
             if hit.source_range.contains(offset) {
@@ -777,7 +873,7 @@ mod tests {
             }
         }
         if unique_hits.is_empty() {
-            return SourceTokenProviderResult::Blocked(SourceTokenBlock::preproc_unavailable(
+            return SourceTargetProviderResult::Blocked(SourceTargetBlock::preproc_unavailable(
                 fallback_range,
             ));
         }
@@ -785,22 +881,18 @@ mod tests {
             covering_range(&unique_hits.iter().map(|hit| hit.source_range).collect::<Vec<_>>())
                 .unwrap_or(fallback_range);
         if unique_hits.len() > 1 {
-            return SourceTokenProviderResult::Blocked(SourceTokenBlock::preproc_ambiguous(
+            return SourceTargetProviderResult::Blocked(SourceTargetBlock::preproc_ambiguous(
                 range,
                 unique_hits,
             ));
         }
         let Some(tokens) = syntax_tokens_for_preproc_hit(root, offset, precedence, &unique_hits)
         else {
-            return SourceTokenProviderResult::Blocked(SourceTokenBlock::preproc_unavailable(
+            return SourceTargetProviderResult::Blocked(SourceTargetBlock::preproc_unavailable(
                 range,
             ));
         };
-        SourceTokenProviderResult::Resolved(SourceTokenSelection::preproc(
-            range,
-            unique_hits,
-            tokens,
-        ))
+        SourceTargetProviderResult::Resolved(SourceTarget::preproc(range, unique_hits, tokens))
     }
 
     fn preproc_hit_for_raw_provenance(

--- a/crates/ide/src/source_targets.rs
+++ b/crates/ide/src/source_targets.rs
@@ -413,10 +413,10 @@ fn syntax_tokens_for_preproc_hit<'tree>(
         return syntax_tokens_for_macro_identities(root, &identities);
     }
 
-    return normal_syntax_source_target_at_offset(root, offset, precedence)
+    normal_syntax_source_target_at_offset(root, offset, precedence)
         .into_resolution()
         .and_then(SourceTargetResolution::resolved)
-        .map(SourceTarget::into_tokens);
+        .map(SourceTarget::into_tokens)
 }
 
 fn macro_token_identity_for_hit(hit: &PreprocTokenHit) -> Option<MacroTokenIdentity> {

--- a/crates/ide/src/source_tokens.rs
+++ b/crates/ide/src/source_tokens.rs
@@ -340,7 +340,7 @@ fn preproc_hit_for_token(
             PreprocSemanticTarget::SourceToken { source: source.clone(), range: *range },
             expansion.expansion.call.id.raw(),
         ),
-        TokenProvenance::MacroBody { call, definition_id, source, range } => (
+        TokenProvenance::MacroBody { call, definition_id, source, range, .. } => (
             source.clone(),
             *range,
             PreprocTokenProvenance::MacroBody {
@@ -356,7 +356,7 @@ fn preproc_hit_for_token(
             },
             call.id.raw(),
         ),
-        TokenProvenance::MacroArgument { call, argument_index, source, range } => (
+        TokenProvenance::MacroArgument { call, argument_index, source, range, .. } => (
             source.clone(),
             *range,
             PreprocTokenProvenance::MacroArgument {

--- a/crates/ide/src/verilog_2005.rs
+++ b/crates/ide/src/verilog_2005.rs
@@ -1694,9 +1694,13 @@ fn preproc_macro_hover_expands_through_configured_predefine_argument() {
       name``_q <= (next_value); \
     end \
   end
-module top;
+module macro_hover_top(
+  input wire logic clk_i,
+  input wire logic rst_ni
+);
+  `DECL_PIPE(trace, `LANE_WIDTH);
   `/*marker:decl_call*/DECL_PIPE(sample, `LANE_WIDTH);
-  `/*marker:assign_call*/PIPE_ASSIGN(trace, sample_q ^ {{(`LANE_WIDTH-1){1'b0}}, 1'b1});
+  `/*marker:assign_call*/PIPE_ASSIGN(trace, /*marker:assign_arg*/sample_q ^ {{(`LANE_WIDTH-1){1'b0}}, 1'b1});
 endmodule
 "#,
     );
@@ -1774,6 +1778,22 @@ endmodule
             && assign_info.contains("trace_q <= (sample_q ^ {{(12-1){1'b0}}, 1'b1});")
             && !assign_info.contains("unavailable"),
         "PIPE_ASSIGN hover should show actual-argument expansion through configured predefine: {assign_info}"
+    );
+
+    let argument_hover = analysis
+        .hover(
+            position(top_file_id, &top_markers, "assign_arg"),
+            HoverConfig { format: HoverFormat::PlainText },
+        )
+        .unwrap()
+        .expect("PIPE_ASSIGN actual argument hover expected");
+    let argument_info = argument_hover.info.as_str();
+    assert!(
+        argument_info.contains("sample_q")
+            && !argument_info.contains("clk_i")
+            && !argument_info.contains("rst_ni")
+            && !argument_info.contains("trace_q"),
+        "actual argument hover should stay on sample_q only: {argument_info}"
     );
 }
 

--- a/crates/slang/bindings/rust/ffi.rs
+++ b/crates/slang/bindings/rust/ffi.rs
@@ -415,6 +415,12 @@ mod slang_ffi {
             context: &SyntaxNode,
         ) -> UniquePtr<SourceRange>;
 
+        #[namespace = "wrapper::syntax"]
+        fn SyntaxToken_preprocessorTraceProvenanceWithContext(
+            token: &SyntaxToken,
+            context: &SyntaxNode,
+        ) -> RawPreprocessorTraceEmittedToken;
+
         fn childNode(self: &SyntaxNode, idx: usize) -> *const SyntaxNode;
 
         #[namespace = "wrapper::syntax"]
@@ -684,6 +690,7 @@ impl_functions! {
     impl SyntaxToken {
         fn range(&self) -> UniquePtr<SourceRange> |> SyntaxToken_range;
         fn rangeWithContext(token: &SyntaxToken, context: &SyntaxNode) -> UniquePtr<SourceRange> |> SyntaxToken_rangeWithContext;
+        fn preprocessorTraceProvenanceWithContext(token: &SyntaxToken, context: &SyntaxNode) -> RawPreprocessorTraceEmittedToken |> SyntaxToken_preprocessorTraceProvenanceWithContext;
     }
 }
 

--- a/crates/slang/bindings/rust/ffi/wrapper.cc
+++ b/crates/slang/bindings/rust/ffi/wrapper.cc
@@ -1419,6 +1419,22 @@ std::unique_ptr<SourceRange> SyntaxToken_rangeWithContext(
   return mapRawSourceRangeWithContext(token.range(), context);
 }
 
+::RawPreprocessorTraceEmittedToken SyntaxToken_preprocessorTraceProvenanceWithContext(
+    const wrapper::parsing::Token& token,
+    const SyntaxNode& context) {
+  const auto* root = findRoot(context);
+  SyntaxTreeSourceInfo sourceInfo;
+  {
+    std::lock_guard lock(syntaxTreeSourceInfoMutex);
+    auto it = syntaxTreeSourceInfo.find(root);
+    if (it == syntaxTreeSourceInfo.end())
+      return empty_preprocessor_trace_emitted_token();
+    sourceInfo = it->second;
+  }
+
+  return to_rust_preprocessor_trace_emitted_token(token, *sourceInfo.sourceManager);
+}
+
 } // namespace syntax
 
 namespace ast {

--- a/crates/slang/bindings/rust/ffi/wrapper.h
+++ b/crates/slang/bindings/rust/ffi/wrapper.h
@@ -38,6 +38,7 @@ struct RawSyntaxTreeBufferIds;
 struct RawExpectedSyntax;
 struct RawLexedTokenAtOffset;
 struct RawPreprocessorTrace;
+struct RawPreprocessorTraceEmittedToken;
 
 namespace wrapper {
   using Diagnostic = ::slang::Diagnostic;
@@ -491,6 +492,10 @@ namespace wrapper {
         const SyntaxNode& context);
 
     std::unique_ptr<SourceRange> SyntaxToken_rangeWithContext(
+        const wrapper::parsing::Token& token,
+        const SyntaxNode& context);
+
+    ::RawPreprocessorTraceEmittedToken SyntaxToken_preprocessorTraceProvenanceWithContext(
         const wrapper::parsing::Token& token,
         const SyntaxNode& context);
 

--- a/crates/slang/bindings/rust/lib.rs
+++ b/crates/slang/bindings/rust/lib.rs
@@ -1816,6 +1816,16 @@ impl SyntaxTokenWithParent<'_> {
         let context = self.parent._ptr.as_ref().get_ref();
         SourceRange::from_unique_ptr(ffi::SyntaxToken::rangeWithContext(token, context))
     }
+
+    #[inline]
+    pub fn preprocessor_trace_provenance(&self) -> PreprocessorTraceTokenProvenance {
+        let token = self.tok._ptr.as_ref().get_ref();
+        let context = self.parent._ptr.as_ref().get_ref();
+        PreprocessorTraceEmittedToken::from_raw(
+            ffi::SyntaxToken::preprocessorTraceProvenanceWithContext(token, context),
+        )
+        .provenance
+    }
 }
 
 impl<'a> std::ops::Deref for SyntaxTokenWithParent<'a> {

--- a/crates/slang/bindings/rust/tests.rs
+++ b/crates/slang/bindings/rust/tests.rs
@@ -1221,6 +1221,56 @@ endmodule
 }
 
 #[test]
+fn syntax_token_reports_direct_macro_provenance_identity() {
+    let source = r#"`define ID(x) x
+module m;
+localparam int B = `ID(7);
+endmodule
+"#;
+    let parsed = SyntaxTree::from_text_with_options_and_trace(
+        source,
+        "source",
+        "sample/rtl/top.sv",
+        &SyntaxTreeOptions::default(),
+    );
+    let trace = parsed.preprocessor_trace.expect("trace should be collected");
+    let root = parsed.tree.root().expect("tree should have a root");
+    let tokens = root
+        .elem_preorder()
+        .filter_map(|event| match event {
+            WalkEvent::Enter(SyntaxElement::Token(token)) if token.raw_text().as_bytes() == b"7" => {
+                Some(token)
+            }
+            _ => None,
+        })
+        .collect_vec();
+    assert_eq!(tokens.len(), 1, "expanded source should contain exactly one parsed 7 token");
+    let token = tokens[0];
+
+    let PreprocessorTraceTokenProvenance::MacroArgument {
+        identity: token_identity,
+        ..
+    } = token.preprocessor_trace_provenance()
+    else {
+        panic!("parsed 7 token should expose direct macro argument provenance");
+    };
+    let emitted = trace
+        .emitted_tokens
+        .iter()
+        .find(|token| token.raw_text == "7")
+        .expect("trace should contain the emitted argument token");
+    let PreprocessorTraceTokenProvenance::MacroArgument {
+        identity: emitted_identity,
+        ..
+    } = &emitted.provenance
+    else {
+        panic!("emitted 7 token should have macro argument provenance: {emitted:?}");
+    };
+
+    assert_eq!(token_identity, *emitted_identity);
+}
+
+#[test]
 fn preprocessor_trace_reports_nested_macro_call_range_in_macro_body() {
     let source = r#"`define LEAF 3
 `define WRAP `LEAF

--- a/crates/slang/bindings/rust/tests.rs
+++ b/crates/slang/bindings/rust/tests.rs
@@ -1238,7 +1238,9 @@ endmodule
     let tokens = root
         .elem_preorder()
         .filter_map(|event| match event {
-            WalkEvent::Enter(SyntaxElement::Token(token)) if token.raw_text().as_bytes() == b"7" => {
+            WalkEvent::Enter(SyntaxElement::Token(token))
+                if token.raw_text().as_bytes() == b"7" =>
+            {
                 Some(token)
             }
             _ => None,
@@ -1247,10 +1249,8 @@ endmodule
     assert_eq!(tokens.len(), 1, "expanded source should contain exactly one parsed 7 token");
     let token = tokens[0];
 
-    let PreprocessorTraceTokenProvenance::MacroArgument {
-        identity: token_identity,
-        ..
-    } = token.preprocessor_trace_provenance()
+    let PreprocessorTraceTokenProvenance::MacroArgument { identity: token_identity, .. } =
+        token.preprocessor_trace_provenance()
     else {
         panic!("parsed 7 token should expose direct macro argument provenance");
     };
@@ -1259,10 +1259,8 @@ endmodule
         .iter()
         .find(|token| token.raw_text == "7")
         .expect("trace should contain the emitted argument token");
-    let PreprocessorTraceTokenProvenance::MacroArgument {
-        identity: emitted_identity,
-        ..
-    } = &emitted.provenance
+    let PreprocessorTraceTokenProvenance::MacroArgument { identity: emitted_identity, .. } =
+        &emitted.provenance
     else {
         panic!("emitted 7 token should have macro argument provenance: {emitted:?}");
     };


### PR DESCRIPTION
This change introduces a shared source-target dispatch path for IDE features that need to interpret the token at a user-visible source offset before rendering feature-specific results.

It also preserves direct macro token identity through the slang and HIR layers so macro body and argument tokens are selected by provenance identity instead of inferred from overlapping ranges.
