### PR TITLE
fix(lsp): close superseded workspace scan progress

### DIFF
--- a/src/global_state/event_loop.rs
+++ b/src/global_state/event_loop.rs
@@ -365,6 +365,8 @@ impl GlobalState {
                     assert_eq!(progress.n_done, progress.n_total);
                     Progress::End
                 };
+                let starts_client_progress = state == Progress::Begin;
+                let finishes_client_progress = state == Progress::End;
 
                 self.report_progress(
                     self.config_state.config.i18n.text(keys::PROGRESS_ROOTS_SCANNING),
@@ -373,6 +375,14 @@ impl GlobalState {
                     Some(Progress::fraction(progress.n_done, progress.n_total)),
                     None,
                 );
+                if self.config_state.config.cli_work_done_progress() {
+                    if starts_client_progress {
+                        self.workspace.workspace_vfs.note_vfs_client_progress_started();
+                    }
+                    if finishes_client_progress {
+                        self.workspace.workspace_vfs.note_vfs_client_progress_finished();
+                    }
+                }
             }
             vfs_loader::Message::Loaded { files, config_version } => {
                 always!(

--- a/src/global_state/main_loop.rs
+++ b/src/global_state/main_loop.rs
@@ -329,8 +329,10 @@ mod tests {
         let root_path = root.path().to_path_buf();
         let file_path = root_path.join("stale.sv");
         let mut state = test_state(root_path);
-        state.workspace.workspace_vfs.begin_vfs_load(1);
-        state.workspace.workspace_vfs.begin_vfs_load(1);
+        let stale_load = state.workspace.workspace_vfs.begin_vfs_load(1);
+        let current_load = state.workspace.workspace_vfs.begin_vfs_load(1);
+        assert!(!stale_load.superseded_client_progress_active);
+        assert!(!current_load.superseded_client_progress_active);
 
         state.process_vfs_msg(vfs_loader::Message::Loaded {
             files: vec![(
@@ -361,7 +363,7 @@ mod tests {
             },
         );
 
-        let config_version = state.workspace.workspace_vfs.begin_vfs_load(0);
+        let config_version = state.workspace.workspace_vfs.begin_vfs_load(0).config_version;
         assert!(!state.workspace.workspace_vfs.is_ready());
 
         state.process_vfs_msg(vfs_loader::Message::Progress {
@@ -379,7 +381,7 @@ mod tests {
         let root = TestDir::new("diagnostic-request-readiness-queue");
         let root_path = root.path().to_path_buf();
         let mut state = test_state(root_path);
-        let config_version = state.workspace.workspace_vfs.begin_vfs_load(1);
+        let config_version = state.workspace.workspace_vfs.begin_vfs_load(1).config_version;
         let request_id = lsp_server::RequestId::from(7);
         let req = Request::new(
             request_id.clone(),
@@ -484,8 +486,8 @@ mod tests {
                 ..ClientCapabilities::default()
             },
         );
-        let stale_config = state.workspace.workspace_vfs.begin_vfs_load(4);
-        let current_config = state.workspace.workspace_vfs.begin_vfs_load(4);
+        let stale_config = state.workspace.workspace_vfs.begin_vfs_load(4).config_version;
+        let current_config = state.workspace.workspace_vfs.begin_vfs_load(4).config_version;
 
         state.process_vfs_msg(vfs_loader::Message::Progress {
             n_total: 4,
@@ -533,6 +535,40 @@ mod tests {
     }
 
     #[test]
+    fn superseded_vfs_load_ends_reported_progress() {
+        let root = TestDir::new("superseded-vfs-load-progress");
+        let root_path = root.path().to_path_buf();
+        let (mut state, client) = test_state_with_caps(
+            root_path.clone(),
+            ClientCapabilities {
+                window: Some(WindowClientCapabilities {
+                    work_done_progress: Some(true),
+                    ..WindowClientCapabilities::default()
+                }),
+                ..ClientCapabilities::default()
+            },
+        );
+        let stale_config = state.workspace.workspace_vfs.begin_vfs_load(4).config_version;
+        state.process_vfs_msg(vfs_loader::Message::Progress {
+            n_total: 4,
+            n_done: 0,
+            config_version: stale_config,
+        });
+        assert!(matches!(recv_work_done_progress(&client), WorkDoneProgress::Begin(_)));
+
+        state.request_workspace_reload("test reload");
+        let request = state.workspace.fetch_workspaces_task.should_start().unwrap();
+        state
+            .workspace
+            .fetch_workspaces_task
+            .complete(Some((Arc::new(workspace_model(root_path)), Vec::new())));
+        state.switch_workspaces("test switch".to_owned(), request.generation);
+
+        assert!(matches!(recv_work_done_progress(&client), WorkDoneProgress::End(_)));
+        assert_eq!(state.workspace.workspace_vfs.current_vfs_config_version(), stale_config + 1);
+    }
+
+    #[test]
     fn out_of_order_vfs_progress_does_not_regress_readiness_or_report() {
         let root = TestDir::new("out-of-order-vfs-progress");
         let root_path = root.path().to_path_buf();
@@ -546,7 +582,7 @@ mod tests {
                 ..ClientCapabilities::default()
             },
         );
-        let config_version = state.workspace.workspace_vfs.begin_vfs_load(2);
+        let config_version = state.workspace.workspace_vfs.begin_vfs_load(2).config_version;
 
         state.process_vfs_msg(vfs_loader::Message::Progress {
             n_total: 2,

--- a/src/global_state/reload.rs
+++ b/src/global_state/reload.rs
@@ -14,8 +14,9 @@ use crate::{
     config::{Config, FilesWatcher},
     global_state::{
         DEFAULT_REQ_HANDLER, GlobalState, WorkspaceFetchCause, WorkspaceGeneration,
-        process_changes::DiagnosticInvalidation,
+        process_changes::DiagnosticInvalidation, respond::Progress,
     },
+    i18n::keys,
 };
 
 const CLIENT_FILE_WATCHER_REGISTRATION_ID: &str = "workspace/didChangeWatchedFiles";
@@ -176,12 +177,21 @@ impl GlobalState {
         };
 
         let to_load_len = to_load.len();
-        let vfs_config_version = self.workspace.workspace_vfs.begin_vfs_load(to_load_len);
+        let vfs_load = self.workspace.workspace_vfs.begin_vfs_load(to_load_len);
+        if vfs_load.superseded_client_progress_active {
+            self.report_progress(
+                self.config_state.config.i18n.text(keys::PROGRESS_ROOTS_SCANNING),
+                Progress::End,
+                None,
+                None,
+                None,
+            );
+        }
 
         self.workspace.vfs_loader.handle.set_config(vfs::loader::Config {
             to_load,
             to_watch,
-            version: vfs_config_version,
+            version: vfs_load.config_version,
         });
 
         self.config_state.source_root_config = source_root_config;

--- a/src/global_state/workspace_state.rs
+++ b/src/global_state/workspace_state.rs
@@ -33,6 +33,13 @@ impl VfsProgress {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[must_use = "callers must close any superseded vfs progress before forwarding the new config"]
+pub(crate) struct BeginVfsLoad {
+    pub(crate) config_version: u32,
+    pub(crate) superseded_client_progress_active: bool,
+}
+
 #[derive(Debug)]
 pub(crate) struct WorkspaceVfsReadiness {
     requested_workspace_generation: WorkspaceGeneration,
@@ -42,6 +49,7 @@ pub(crate) struct WorkspaceVfsReadiness {
     vfs_config_version: u32,
     vfs_progress: VfsProgress,
     vfs_ready: bool,
+    vfs_client_progress_active: bool,
     diagnostic_readiness_revision: u64,
     diagnostics_deferred_until_ready: bool,
 }
@@ -56,6 +64,7 @@ impl Default for WorkspaceVfsReadiness {
             vfs_config_version: 0,
             vfs_progress: VfsProgress::default(),
             vfs_ready: true,
+            vfs_client_progress_active: false,
             diagnostic_readiness_revision: 0,
             diagnostics_deferred_until_ready: false,
         }
@@ -118,12 +127,14 @@ impl WorkspaceVfsReadiness {
         false
     }
 
-    pub(crate) fn begin_vfs_load(&mut self, n_total: usize) -> u32 {
+    pub(crate) fn begin_vfs_load(&mut self, n_total: usize) -> BeginVfsLoad {
+        let superseded_client_progress_active = self.vfs_client_progress_active;
         self.vfs_config_version += 1;
         self.vfs_progress =
             VfsProgress { config_version: self.vfs_config_version, n_done: 0, n_total };
         self.vfs_ready = false;
-        self.vfs_config_version
+        self.vfs_client_progress_active = false;
+        BeginVfsLoad { config_version: self.vfs_config_version, superseded_client_progress_active }
     }
 
     pub(crate) fn accept_vfs_progress(
@@ -142,6 +153,14 @@ impl WorkspaceVfsReadiness {
         self.vfs_progress = VfsProgress { config_version, n_done, n_total };
         self.vfs_ready = !self.vfs_progress.in_progress();
         Some(self.vfs_progress)
+    }
+
+    pub(crate) fn note_vfs_client_progress_started(&mut self) {
+        self.vfs_client_progress_active = true;
+    }
+
+    pub(crate) fn note_vfs_client_progress_finished(&mut self) {
+        self.vfs_client_progress_active = false;
     }
 
     pub(crate) fn accepts_vfs_loaded(&self, config_version: u32) -> bool {


### PR DESCRIPTION
## Summary

This change closes any active `Scanning Workspace Files` work-done progress before a workspace reload starts a replacement VFS scan. It keeps the stable progress token model and prevents the client status indicator from being left open when the previous VFS generation is superseded.

## Root cause

`begin_vfs_load` advanced the VFS config version and reset progress state immediately. If the previous generation had already sent `WorkDoneProgress::Begin`, later progress from that older config version was rejected as stale, including the eventual `End`. The client could then keep showing the scan progress indefinitely.

## Changes

- Track whether the current VFS generation has an active client-side work-done progress.
- Return superseded progress state from `begin_vfs_load` so `switch_workspaces` can close it before forwarding the new loader config.
- Add a regression test that starts VFS scan progress, supersedes it via workspace switching, and asserts the client receives `WorkDoneProgress::End`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p vide --lib`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`