### PR TITLE
fix(lsp): gate workspace-scoped requests until ready

### DIFF
--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -98,7 +98,6 @@ pub(crate) struct AnalysisState {
 
 pub(crate) struct DiagnosticsState {
     pub(crate) published_diagnostics: FxHashMap<DiagnosticPublishKey, Vec<lsp_types::Diagnostic>>,
-    pub(crate) pending_diagnostic_requests: Vec<Request>,
     // didOpen/didClose can change the URI set for a file without changing its
     // text. Keep those target changes explicit so push diagnostics converge at
     // the normal change-processing boundary.
@@ -120,7 +119,7 @@ pub(crate) struct WorkspaceState {
     pub(crate) vfs_loader: Handle<Box<dyn vfs::loader::Handle>, Receiver<vfs::loader::Message>>,
     pub(crate) vfs: Arc<RwLock<(Vfs, IntMap<FileId, LineEnding>)>>,
     pub(crate) workspace_vfs: WorkspaceVfsReadiness,
-    pub(crate) pending_workspace_symbol_requests: Vec<Request>,
+    pub(crate) pending_workspace_readiness_requests: Vec<Request>,
 
     pub(crate) workspaces: Arc<Vec<Workspace>>,
     pub(crate) fetch_workspaces_task:
@@ -173,7 +172,6 @@ impl GlobalState {
             },
             diagnostics: DiagnosticsState {
                 published_diagnostics: FxHashMap::default(),
-                pending_diagnostic_requests: Vec::new(),
                 pending_document_diagnostic_targets: FxHashSet::default(),
                 diagnostics_revision: 0,
                 diagnostic_target_revision: 0,
@@ -183,7 +181,7 @@ impl GlobalState {
                 vfs_loader,
                 vfs: Arc::new(RwLock::new((Vfs::default(), IntMap::default()))),
                 workspace_vfs: WorkspaceVfsReadiness::default(),
-                pending_workspace_symbol_requests: Vec::new(),
+                pending_workspace_readiness_requests: Vec::new(),
                 workspaces: Arc::from(vec![]),
                 fetch_workspaces_task: ExclTask::default(),
                 registered_client_file_watcher_globs: None,

--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -120,6 +120,7 @@ pub(crate) struct WorkspaceState {
     pub(crate) vfs_loader: Handle<Box<dyn vfs::loader::Handle>, Receiver<vfs::loader::Message>>,
     pub(crate) vfs: Arc<RwLock<(Vfs, IntMap<FileId, LineEnding>)>>,
     pub(crate) workspace_vfs: WorkspaceVfsReadiness,
+    pub(crate) pending_workspace_symbol_requests: Vec<Request>,
 
     pub(crate) workspaces: Arc<Vec<Workspace>>,
     pub(crate) fetch_workspaces_task:
@@ -182,6 +183,7 @@ impl GlobalState {
                 vfs_loader,
                 vfs: Arc::new(RwLock::new((Vfs::default(), IntMap::default()))),
                 workspace_vfs: WorkspaceVfsReadiness::default(),
+                pending_workspace_symbol_requests: Vec::new(),
                 workspaces: Arc::from(vec![]),
                 fetch_workspaces_task: ExclTask::default(),
                 registered_client_file_watcher_globs: None,

--- a/src/global_state/dispatch/request.rs
+++ b/src/global_state/dispatch/request.rs
@@ -1,5 +1,7 @@
 use lsp_server::Request;
-use lsp_types::request::{Request as _, WorkspaceSymbolRequest};
+use lsp_types::request::{
+    DocumentDiagnosticRequest, Request as _, WorkspaceDiagnosticRequest, WorkspaceSymbolRequest,
+};
 
 use crate::{
     global_state::{GlobalState, dispatcher::ReqDispatcher, handlers},
@@ -8,17 +10,13 @@ use crate::{
 
 impl GlobalState {
     pub(in crate::global_state) fn handle_request(&mut self, req: Request) {
-        if !self.is_workspace_ready() {
+        if !self.is_workspace_ready() && Self::is_workspace_readiness_request(&req) {
             if Self::is_pull_diagnostic_request(&req) {
                 self.workspace.workspace_vfs.defer_diagnostics_until_ready();
-                self.diagnostics.pending_diagnostic_requests.push(req);
-                return;
             }
 
-            if Self::is_workspace_symbol_request(&req) {
-                self.workspace.pending_workspace_symbol_requests.push(req);
-                return;
-            }
+            self.workspace.pending_workspace_readiness_requests.push(req);
+            return;
         }
 
         let mut dispatcher = ReqDispatcher { req: Some(req), global_state: self };
@@ -86,12 +84,16 @@ impl GlobalState {
     fn is_pull_diagnostic_request(req: &Request) -> bool {
         matches!(
             req.method.as_str(),
-            lsp_types::request::DocumentDiagnosticRequest::METHOD
-                | lsp_types::request::WorkspaceDiagnosticRequest::METHOD
+            DocumentDiagnosticRequest::METHOD | WorkspaceDiagnosticRequest::METHOD
         )
     }
 
-    fn is_workspace_symbol_request(req: &Request) -> bool {
-        req.method == WorkspaceSymbolRequest::METHOD
+    fn is_workspace_readiness_request(req: &Request) -> bool {
+        matches!(
+            req.method.as_str(),
+            DocumentDiagnosticRequest::METHOD
+                | WorkspaceDiagnosticRequest::METHOD
+                | WorkspaceSymbolRequest::METHOD
+        )
     }
 }

--- a/src/global_state/dispatch/request.rs
+++ b/src/global_state/dispatch/request.rs
@@ -1,5 +1,5 @@
 use lsp_server::Request;
-use lsp_types::request::Request as _;
+use lsp_types::request::{Request as _, WorkspaceSymbolRequest};
 
 use crate::{
     global_state::{GlobalState, dispatcher::ReqDispatcher, handlers},
@@ -8,10 +8,17 @@ use crate::{
 
 impl GlobalState {
     pub(in crate::global_state) fn handle_request(&mut self, req: Request) {
-        if Self::is_pull_diagnostic_request(&req) && !self.is_workspace_ready() {
-            self.workspace.workspace_vfs.defer_diagnostics_until_ready();
-            self.diagnostics.pending_diagnostic_requests.push(req);
-            return;
+        if !self.is_workspace_ready() {
+            if Self::is_pull_diagnostic_request(&req) {
+                self.workspace.workspace_vfs.defer_diagnostics_until_ready();
+                self.diagnostics.pending_diagnostic_requests.push(req);
+                return;
+            }
+
+            if Self::is_workspace_symbol_request(&req) {
+                self.workspace.pending_workspace_symbol_requests.push(req);
+                return;
+            }
         }
 
         let mut dispatcher = ReqDispatcher { req: Some(req), global_state: self };
@@ -82,5 +89,9 @@ impl GlobalState {
             lsp_types::request::DocumentDiagnosticRequest::METHOD
                 | lsp_types::request::WorkspaceDiagnosticRequest::METHOD
         )
+    }
+
+    fn is_workspace_symbol_request(req: &Request) -> bool {
+        req.method == WorkspaceSymbolRequest::METHOD
     }
 }

--- a/src/global_state/event_loop.rs
+++ b/src/global_state/event_loop.rs
@@ -173,11 +173,10 @@ impl GlobalState {
         let state_changed = self.process_changes();
         if self.workspace.workspace_vfs.take_deferred_diagnostics_if_ready() {
             self.invalidate_diagnostics(DiagnosticInvalidation::WorkspaceChanged);
-            self.drain_pending_diagnostic_requests();
         }
 
         if self.is_workspace_ready() {
-            self.drain_pending_workspace_symbol_requests();
+            self.drain_pending_workspace_readiness_requests();
 
             let client_refresh = !was_workspace_ready || state_changed;
 

--- a/src/global_state/event_loop.rs
+++ b/src/global_state/event_loop.rs
@@ -177,6 +177,8 @@ impl GlobalState {
         }
 
         if self.is_workspace_ready() {
+            self.drain_pending_workspace_symbol_requests();
+
             let client_refresh = !was_workspace_ready || state_changed;
 
             if client_refresh && self.config_state.config.cli_code_lens_refresh_support() {

--- a/src/global_state/main_loop.rs
+++ b/src/global_state/main_loop.rs
@@ -52,18 +52,9 @@ impl GlobalState {
         handler(self, res)
     }
 
-    pub(in crate::global_state) fn drain_pending_diagnostic_requests(&mut self) {
-        let pending_requests = std::mem::take(&mut self.diagnostics.pending_diagnostic_requests);
-        for req in pending_requests {
-            if !self.is_completed(&req) {
-                self.handle_request(req);
-            }
-        }
-    }
-
-    pub(in crate::global_state) fn drain_pending_workspace_symbol_requests(&mut self) {
+    pub(in crate::global_state) fn drain_pending_workspace_readiness_requests(&mut self) {
         let pending_requests =
-            std::mem::take(&mut self.workspace.pending_workspace_symbol_requests);
+            std::mem::take(&mut self.workspace.pending_workspace_readiness_requests);
         for req in pending_requests {
             if !self.is_completed(&req) {
                 self.handle_request(req);
@@ -409,7 +400,7 @@ mod tests {
         state.register_request(Instant::now(), &req);
         state.handle_request(req);
 
-        assert_eq!(state.diagnostics.pending_diagnostic_requests.len(), 1);
+        assert_eq!(state.workspace.pending_workspace_readiness_requests.len(), 1);
         assert!(state.tasks.task_pool.receiver.recv_timeout(Duration::from_millis(50)).is_err());
 
         state
@@ -420,7 +411,7 @@ mod tests {
             }))
             .unwrap();
 
-        assert!(state.diagnostics.pending_diagnostic_requests.is_empty());
+        assert!(state.workspace.pending_workspace_readiness_requests.is_empty());
         let task = state.tasks.task_pool.receiver.recv_timeout(Duration::from_secs(1)).unwrap();
         let Task::Response(response) = task else {
             panic!("expected parked diagnostic request to resume as response task, got {task:?}");
@@ -448,7 +439,7 @@ mod tests {
         state.register_request(Instant::now(), &req);
         state.handle_request(req);
 
-        assert_eq!(state.workspace.pending_workspace_symbol_requests.len(), 1);
+        assert_eq!(state.workspace.pending_workspace_readiness_requests.len(), 1);
         assert!(state.tasks.task_pool.receiver.try_recv().is_err());
 
         state
@@ -459,7 +450,7 @@ mod tests {
             }))
             .unwrap();
 
-        assert!(state.workspace.pending_workspace_symbol_requests.is_empty());
+        assert!(state.workspace.pending_workspace_readiness_requests.is_empty());
         let task = state.tasks.task_pool.receiver.recv_timeout(Duration::from_secs(1)).unwrap();
         let Task::Response(response) = task else {
             panic!(

--- a/src/global_state/main_loop.rs
+++ b/src/global_state/main_loop.rs
@@ -60,6 +60,16 @@ impl GlobalState {
             }
         }
     }
+
+    pub(in crate::global_state) fn drain_pending_workspace_symbol_requests(&mut self) {
+        let pending_requests =
+            std::mem::take(&mut self.workspace.pending_workspace_symbol_requests);
+        for req in pending_requests {
+            if !self.is_completed(&req) {
+                self.handle_request(req);
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -70,7 +80,9 @@ mod tests {
     use lsp_types::{
         ClientCapabilities, Diagnostic, DiagnosticSeverity, Position, ProgressParams,
         ProgressParamsValue, PublishDiagnosticsParams, Range, WindowClientCapabilities,
-        WorkDoneProgress, notification::Notification as _, request::Request as _,
+        WorkDoneProgress, WorkDoneProgressParams, WorkspaceSymbolParams,
+        notification::Notification as _,
+        request::{Request as _, WorkspaceSymbolRequest},
     };
     use project_model::{ProjectModel, project_manifest::ProjectManifest};
     use rustc_hash::FxHashSet;
@@ -412,6 +424,47 @@ mod tests {
         let task = state.tasks.task_pool.receiver.recv_timeout(Duration::from_secs(1)).unwrap();
         let Task::Response(response) = task else {
             panic!("expected parked diagnostic request to resume as response task, got {task:?}");
+        };
+        assert_eq!(response.response.id, request_id);
+    }
+
+    #[test]
+    fn workspace_symbol_requests_are_parked_until_workspace_ready() {
+        let root = TestDir::new("workspace-symbol-readiness-queue");
+        let root_path = root.path().to_path_buf();
+        let mut state = test_state(root_path);
+        let config_version = state.workspace.workspace_vfs.begin_vfs_load(1).config_version;
+        let request_id = lsp_server::RequestId::from(8);
+        let req = Request::new(
+            request_id.clone(),
+            WorkspaceSymbolRequest::METHOD.to_owned(),
+            WorkspaceSymbolParams {
+                query: "top shared".to_owned(),
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: Default::default(),
+            },
+        );
+
+        state.register_request(Instant::now(), &req);
+        state.handle_request(req);
+
+        assert_eq!(state.workspace.pending_workspace_symbol_requests.len(), 1);
+        assert!(state.tasks.task_pool.receiver.try_recv().is_err());
+
+        state
+            .handle_event(Event::Vfs(vfs_loader::Message::Progress {
+                n_total: 1,
+                n_done: 1,
+                config_version,
+            }))
+            .unwrap();
+
+        assert!(state.workspace.pending_workspace_symbol_requests.is_empty());
+        let task = state.tasks.task_pool.receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+        let Task::Response(response) = task else {
+            panic!(
+                "expected parked workspace symbol request to resume as response task, got {task:?}"
+            );
         };
         assert_eq!(response.response.id, request_id);
     }


### PR DESCRIPTION
## Summary
- gate workspace-scoped requests that depend on a complete workspace snapshot until the workspace VFS is ready
- reuse one pending readiness queue for pull diagnostics and workspace symbol requests
- keep document-local requests on the normal path so edit-time requests stay responsive

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo test -p vide --lib
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
