### PR TITLE
chore(release): prepare 1.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vide"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2024"
 authors = ["roifewu <roifewu@gmail.com>", "hongjr03 <hongjr03@gmail.com>"]
 repository = "https://github.com/pascal-lab/vide"

--- a/docs/src/content/docs/changelog/index.mdx
+++ b/docs/src/content/docs/changelog/index.mdx
@@ -9,6 +9,11 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard
+    title="1.2.2"
+    href="./v1-2-2/"
+    description="修复启动和重载期间的工作区就绪请求、补全触发边界、localparam 覆盖建模，加入 Zed 扩展支持，并整理来源/预处理内部模型。"
+  />
+  <LinkCard
     title="1.2.1"
     href="./v1-2-1/"
     description="修复配置预定义宏和嵌套宏实参场景下的宏展开悬停，并保留展开代码的换行缩进。"

--- a/docs/src/content/docs/changelog/v1-2-2/index.mdx
+++ b/docs/src/content/docs/changelog/v1-2-2/index.mdx
@@ -1,0 +1,41 @@
+---
+title: 1.2.2
+description: Vide 1.2.2 更新日志。
+---
+
+Vide 1.2.2 改进启动和重载期间的 LSP 行为、补全触发边界、来源感知导航，以及编辑器集成发布包。
+
+## 修复
+
+### LSP 启动和重载
+
+- 依赖完整工作区状态的请求现在会等待 workspace ready 后再执行，避免启动或重载期间的局部快照产生空的工作区符号或诊断结果。([#264](https://github.com/pascal-lab/vide/pull/264) by [@hongjr03](https://github.com/hongjr03))
+- 工作区扫描被重载取代时，现在会关闭旧的 progress，客户端不再保留过期进度提示。([#263](https://github.com/pascal-lab/vide/pull/263) by [@hongjr03](https://github.com/hongjr03))
+- `localparam` 不再被建模为可覆写的模块参数。([#218](https://github.com/pascal-lab/vide/pull/218) by [@hongjr03](https://github.com/hongjr03))
+
+### 编辑体验
+
+- 补全不再在换行、逗号或左括号等边界意外重新弹出，避免 Enter 和逗号被错误的补全弹窗吞掉。([#262](https://github.com/pascal-lab/vide/pull/262) by [@hongjr03](https://github.com/hongjr03))
+
+### 来源导航
+
+- 宏操作目标现在通过来源感知 identity 解析，改进宏和预处理生成代码中的导航与编辑动作。([#252](https://github.com/pascal-lab/vide/pull/252) by [@hongjr03](https://github.com/hongjr03))
+- IDE target dispatch 现在会在渲染 LSP 响应前分派 hover、definition、references 等来源目标。([#251](https://github.com/pascal-lab/vide/pull/251) by [@hongjr03](https://github.com/hongjr03))
+
+## 编辑器集成
+
+- 新增 Zed 扩展，注册 Verilog/SystemVerilog 语言支持，并从 GitHub Releases 下载匹配的 `vide` 二进制。([#249](https://github.com/pascal-lab/vide/pull/249) by [@hongjr03](https://github.com/hongjr03))
+
+## 维护
+
+- 预处理展开来源处理被整理为显式的 macro file 和 source identity 模型。([#258](https://github.com/pascal-lab/vide/pull/258), [#259](https://github.com/pascal-lab/vide/pull/259), [#260](https://github.com/pascal-lab/vide/pull/260) by [@hongjr03](https://github.com/hongjr03))
+- Global state、dispatch 和测试组织被拆分为更小的 LSP event loop 职责边界。([#255](https://github.com/pascal-lab/vide/pull/255), [#256](https://github.com/pascal-lab/vide/pull/256), [#257](https://github.com/pascal-lab/vide/pull/257) by [@hongjr03](https://github.com/hongjr03))
+- CI 发布包流程不再发布 Alpine arm64 development package。([#247](https://github.com/pascal-lab/vide/pull/247) by [@hongjr03](https://github.com/hongjr03))
+
+## 贡献者
+
+感谢本次发布的所有贡献者：
+
+- [@hongjr03](https://github.com/hongjr03)
+
+**完整更新列表**: [v1.2.1...v1.2.2](https://github.com/pascal-lab/vide/compare/v1.2.1...v1.2.2)

--- a/docs/src/content/docs/en/changelog/index.mdx
+++ b/docs/src/content/docs/en/changelog/index.mdx
@@ -9,6 +9,11 @@ Browse Vide changes by version.
 
 <CardGrid>
   <LinkCard
+    title="1.2.2"
+    href="./v1-2-2/"
+    description="Startup and reload readiness fixes, completion trigger fixes, localparam override modeling, Zed extension support, and source/preprocessor cleanup."
+  />
+  <LinkCard
     title="1.2.1"
     href="./v1-2-1/"
     description="Fixes macro expansion hover through configured predefines and nested macro arguments, with line breaks and indentation preserved in expansion output."

--- a/docs/src/content/docs/en/changelog/v1-2-2/index.mdx
+++ b/docs/src/content/docs/en/changelog/v1-2-2/index.mdx
@@ -1,0 +1,41 @@
+---
+title: 1.2.2
+description: Vide 1.2.2 release notes.
+---
+
+Vide 1.2.2 improves startup and reload behavior, completion trigger handling, source-aware navigation, and editor integration packaging.
+
+## Fixes
+
+### LSP Startup and Reload
+
+- Workspace-scoped requests now wait for workspace readiness before running, preventing partial startup or reload snapshots from producing empty workspace symbol or diagnostic results. ([#264](https://github.com/pascal-lab/vide/pull/264) by [@hongjr03](https://github.com/hongjr03))
+- Workspace scan progress is now closed when superseded by a reload, so clients no longer keep stale progress notifications open. ([#263](https://github.com/pascal-lab/vide/pull/263) by [@hongjr03](https://github.com/hongjr03))
+- Localparams are no longer treated as overridable module parameters. ([#218](https://github.com/pascal-lab/vide/pull/218) by [@hongjr03](https://github.com/hongjr03))
+
+### Editing
+
+- Completion no longer reopens on newline, comma, or open-parenthesis boundaries that should commit a line break or punctuation input. This keeps Enter and comma from being swallowed by unintended completion popups. ([#262](https://github.com/pascal-lab/vide/pull/262) by [@hongjr03](https://github.com/hongjr03))
+
+### Source Navigation
+
+- Macro operation targets now resolve through source-aware identities, improving navigation and edit actions across macro and preprocessor-generated code. ([#252](https://github.com/pascal-lab/vide/pull/252) by [@hongjr03](https://github.com/hongjr03))
+- IDE target dispatch now routes hover, definition, references, and related source targets before rendering LSP responses. ([#251](https://github.com/pascal-lab/vide/pull/251) by [@hongjr03](https://github.com/hongjr03))
+
+## Editor Integrations
+
+- Added a Zed extension that registers Verilog/SystemVerilog language support and downloads the matching `vide` binary from GitHub Releases. ([#249](https://github.com/pascal-lab/vide/pull/249) by [@hongjr03](https://github.com/hongjr03))
+
+## Maintenance
+
+- Preprocessor expansion source handling was reorganized around explicit macro files and source identities. ([#258](https://github.com/pascal-lab/vide/pull/258), [#259](https://github.com/pascal-lab/vide/pull/259), [#260](https://github.com/pascal-lab/vide/pull/260) by [@hongjr03](https://github.com/hongjr03))
+- Global state, dispatch, and test organization were split into smaller responsibilities for the LSP event loop. ([#255](https://github.com/pascal-lab/vide/pull/255), [#256](https://github.com/pascal-lab/vide/pull/256), [#257](https://github.com/pascal-lab/vide/pull/257) by [@hongjr03](https://github.com/hongjr03))
+- CI release packaging no longer publishes the Alpine arm64 development package. ([#247](https://github.com/pascal-lab/vide/pull/247) by [@hongjr03](https://github.com/hongjr03))
+
+## Contributors
+
+Thanks to everyone who contributed to this release:
+
+- [@hongjr03](https://github.com/hongjr03)
+
+**Full Changelog**: [v1.2.1...v1.2.2](https://github.com/pascal-lab/vide/compare/v1.2.1...v1.2.2)

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vide-ide",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vide-ide",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vide-ide",
   "displayName": "Vide - Verilog/SystemVerilog Coding IDE",
   "description": "%extension.description%",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "publisher": "pascal-lab",
   "license": "MIT",
   "icon": "media/icon.png",


### PR DESCRIPTION
## Summary
- bump the Rust and VS Code extension versions to 1.2.2
- add Chinese and English changelog pages for 1.2.2
- add 1.2.2 to the changelog indexes

## Validation
- `git diff --check`
- `node docs/scripts/release-body-from-changelog.mjs --tag v1.2.2 --output /tmp/vide-release-body-1.2.2.md`
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `npm --prefix docs run build`
- `npm --prefix editors/vscode run package:vsix:debug`
