### PR TITLE
fix(ide): preserve macro hover rendering

### DIFF
--- a/crates/hir/src/preproc/helpers/mapping/definitions.rs
+++ b/crates/hir/src/preproc/helpers/mapping/definitions.rs
@@ -37,15 +37,38 @@ pub(crate) fn map_macro_definition(
         })
         .transpose()?;
     let file_id = require_file_backed_source(&source)?;
+    let source_range = definition_source_range(mapped, file_id, directive_range, definition);
     Ok(MacroDefinition {
         id: definition.id.into(),
         file_id,
         name: definition.name.clone(),
         params,
         body_tokens: definition.body_tokens.iter().map(|token| token.raw.clone()).collect(),
+        source_range,
         directive_range,
         name_range,
     })
+}
+
+fn definition_source_range(
+    mapped: &MappedSourcePreprocModel,
+    file_id: FileId,
+    directive_range: TextRange,
+    definition: &SourceMacroDefinition,
+) -> TextRange {
+    let mut source_range = directive_range;
+    for token_range in definition.body_tokens.iter().filter_map(|token| token.range) {
+        let Ok((token_source, token_range)) = map_source_mapping_range(mapped, token_range) else {
+            continue;
+        };
+        let Ok(token_file_id) = require_file_backed_source(&token_source) else {
+            continue;
+        };
+        if token_file_id == file_id && token_range.end() > source_range.end() {
+            source_range = TextRange::new(source_range.start(), token_range.end());
+        }
+    }
+    source_range
 }
 
 pub(in crate::preproc) fn map_macro_param_definition(

--- a/crates/hir/src/preproc/predefines.rs
+++ b/crates/hir/src/preproc/predefines.rs
@@ -105,6 +105,7 @@ fn configured_predefine_definition(
         name: predefine_name,
         params: None,
         body_tokens: Vec::new(),
+        source_range: source.range,
         directive_range: source.range,
         name_range: source.range,
     })

--- a/crates/hir/src/preproc/types/macro_model.rs
+++ b/crates/hir/src/preproc/types/macro_model.rs
@@ -7,6 +7,7 @@ pub struct MacroDefinition {
     pub name: SmolStr,
     pub params: Option<Vec<MacroDefinitionParam>>,
     pub body_tokens: Vec<SmolStr>,
+    pub source_range: TextRange,
     pub directive_range: TextRange,
     pub name_range: TextRange,
 }

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -7,6 +7,7 @@ use syntax::{
 use utils::{
     get::GetRef,
     line_index::{TextRange, TextSize},
+    uniq_vec::UniqVec,
 };
 use vfs::FileId;
 
@@ -154,7 +155,12 @@ fn hover_for_token(
 }
 
 fn merge_hover_results(markups: Vec<Markup>) -> Option<Markup> {
-    let mut iter = markups.into_iter();
+    let mut unique = UniqVec::<Markup, Markup>::default();
+    for markup in markups {
+        unique.push_unique(markup);
+    }
+
+    let mut iter = unique.into_vec().into_iter();
     let mut res = iter.next()?;
     for markup in iter {
         res.horizontal_line();

--- a/crates/ide/src/hover/macro_hover/markup.rs
+++ b/crates/ide/src/hover/macro_hover/markup.rs
@@ -8,6 +8,7 @@ use hir::{
 };
 use vfs::FileId;
 
+use super::expansion::macro_expansion_hover_text;
 use crate::{db::root_db::RootDb, markup::Markup};
 
 struct MacroSourceLink {
@@ -50,13 +51,31 @@ fn macro_signature(definition: &MacroDefinition) -> String {
     signature
 }
 
-fn macro_definition_line(definition: &MacroDefinition) -> String {
+fn macro_definition_line(db: &RootDb, definition: &MacroDefinition) -> String {
+    source_macro_definition_text(db, definition)
+        .unwrap_or_else(|| fallback_macro_definition_line(definition))
+}
+
+fn source_macro_definition_text(db: &RootDb, definition: &MacroDefinition) -> Option<String> {
+    let source = db.file_text(definition.file_id);
+    let start = usize::from(definition.source_range.start());
+    let end = usize::from(definition.source_range.end());
+    let raw = source.get(start..end)?;
+    raw.trim_start().starts_with("`define").then(|| macro_expansion_hover_text(raw))
+}
+
+fn fallback_macro_definition_line(definition: &MacroDefinition) -> String {
     let mut line = String::from("`define ");
-    line.push_str(&macro_signature(definition));
-    let body = macro_definition_body_text(definition);
-    if !body.is_empty() {
-        line.push(' ');
-        line.push_str(&body);
+    line.push_str(definition.name.as_str());
+    if let Some(params) = &definition.params {
+        line.push('(');
+        for (index, param) in params.iter().enumerate() {
+            if index > 0 {
+                line.push_str(", ");
+            }
+            line.push_str(param.name.as_deref().unwrap_or("<unnamed>"));
+        }
+        line.push(')');
     }
     line
 }
@@ -194,7 +213,7 @@ fn render_macro_definition_display(
     anchor_file_id: FileId,
     definition: &MacroDefinition,
 ) {
-    markup.push_with_code_fence(&macro_definition_line(definition));
+    markup.push_with_code_fence(&macro_definition_line(db, definition));
     render_macro_expansion_separator(markup);
     render_macro_source_link(db, markup, definition, anchor_file_id);
 }
@@ -243,8 +262,4 @@ fn markdown_link_label(label: &str) -> String {
 
 fn markdown_link_destination(destination: &str) -> String {
     destination.replace('>', "%3E")
-}
-
-fn macro_definition_body_text(definition: &MacroDefinition) -> String {
-    definition.body_tokens.iter().map(|token| token.as_str()).collect::<Vec<_>>().join(" ")
 }

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -34,6 +34,8 @@ pub mod goto_declaration;
 pub mod goto_definition;
 pub mod hover;
 pub mod inlay_hint;
+#[cfg(test)]
+mod macro_hover_tests;
 pub mod range;
 pub mod references;
 pub mod rename;

--- a/crates/ide/src/macro_hover_tests.rs
+++ b/crates/ide/src/macro_hover_tests.rs
@@ -1,0 +1,202 @@
+use std::collections::HashMap;
+
+use hir::base_db::{
+    change::Change,
+    project::{CompilationProfile, CompilationProfileId, PreprocessConfig, ProjectConfig},
+    source_root::{SourceRoot, SourceRootId},
+};
+use triomphe::Arc;
+use utils::{lines::LineEnding, test_support::TestDir, text_edit::TextSize};
+use vfs::{ChangeKind, ChangedFile, FileId, FileSet, VfsPath};
+
+use crate::{
+    FilePosition,
+    analysis_host::AnalysisHost,
+    hover::{HoverConfig, HoverFormat},
+    test_utils::normalize_fixture_text,
+};
+
+struct PipelineMacroFixture {
+    _dir: TestDir,
+    host: AnalysisHost,
+    top_file_id: FileId,
+    header_file_id: FileId,
+    top_markers: HashMap<String, TextSize>,
+    header_markers: HashMap<String, TextSize>,
+}
+
+fn setup_pipeline_macro_fixture(predefines: Vec<&'static str>) -> PipelineMacroFixture {
+    let dir = TestDir::new("pipeline-macro-hover");
+    let rtl_dir = dir.path().join("rtl");
+    let include_dir = dir.path().join("include");
+    std::fs::create_dir_all(&rtl_dir).unwrap();
+    std::fs::create_dir_all(&include_dir).unwrap();
+
+    let top_path = rtl_dir.join("02_macro_hover_top.sv");
+    let header_path = include_dir.join("pipeline_macros.svh");
+    let marked_header_text = normalize_fixture_text(
+        r#"
+`ifndef PIPELINE_MACROS_SVH
+`define PIPELINE_MACROS_SVH
+
+`define DECL_PIPE(name, width) logic [(width)-1:0] name``_q
+`define P/*marker:pipe_assign_def*/IPE_ASSIGN(name, next_value) \
+  always_ff @(posedge clk_i or negedge rst_ni) begin \
+    if (!rst_ni) begin \
+      name``_q <= '0; \
+    end else begin \
+      name``_q <= (next_value); \
+    end \
+  end
+
+`endif
+"#,
+    );
+    let marked_top_text = normalize_fixture_text(
+        r#"
+`include "pipeline_macros.svh"
+
+module macro_hover_top (
+  input  logic                  clk_i,
+  input  logic                  rst_ni,
+  input  logic [`LANE_WIDTH-1:0] sample_i,
+  output logic [`LANE_WIDTH-1:0] sample_o
+);
+  `DECL_PIPE(sample, `LANE_WIDTH);
+  `DECL_PIPE(trace,  `LANE_WIDTH);
+
+  `PIPE_ASSIGN(/*marker:trace_arg*/trace, sample_q ^ {{(`LANE_WIDTH-1){1'b0}}, 1'b1});
+
+  assign sample_o = trace_q;
+endmodule
+"#,
+    );
+    let (header_text, header_markers) = strip_markers(marked_header_text);
+    let (top_text, top_markers) = strip_markers(marked_top_text);
+    std::fs::write(&top_path, &top_text).unwrap();
+    std::fs::write(&header_path, &header_text).unwrap();
+
+    let top_file_id = FileId(0);
+    let header_file_id = FileId(1);
+    let mut file_set = FileSet::default();
+    file_set.insert(top_file_id, VfsPath::from(top_path));
+    file_set.insert(header_file_id, VfsPath::from(header_path));
+
+    let mut change = Change::new();
+    change.set_roots(vec![SourceRoot::new_local_with_source_files(
+        file_set,
+        vec![top_file_id, header_file_id],
+    )]);
+    change.set_project_config(Arc::new(ProjectConfig::new(
+        vec![Some(CompilationProfileId(0))],
+        vec![CompilationProfile {
+            source_roots: vec![SourceRootId(0)],
+            top_modules: Vec::new(),
+            preprocess: PreprocessConfig::with_predefine_strings(predefines, vec![include_dir]),
+        }],
+    )));
+    change.add_changed_file(ChangedFile {
+        file_id: top_file_id,
+        change_kind: ChangeKind::Create(Arc::from(top_text.as_str()), LineEnding::Unix),
+    });
+    change.add_changed_file(ChangedFile {
+        file_id: header_file_id,
+        change_kind: ChangeKind::Create(Arc::from(header_text.as_str()), LineEnding::Unix),
+    });
+
+    let mut host = AnalysisHost::default();
+    host.apply_change(change);
+    PipelineMacroFixture {
+        _dir: dir,
+        host,
+        top_file_id,
+        header_file_id,
+        top_markers,
+        header_markers,
+    }
+}
+
+fn strip_markers(mut text: String) -> (String, HashMap<String, TextSize>) {
+    let mut markers = HashMap::new();
+    let mut cursor = 0;
+    let prefix = "/*marker:";
+
+    while let Some(rel_start) = text[cursor..].find(prefix) {
+        let start = cursor + rel_start;
+        let name_start = start + prefix.len();
+        let rel_end = text[name_start..].find("*/").expect("unterminated marker in fixture");
+        let name_end = name_start + rel_end;
+        let name = text[name_start..name_end].to_string();
+        let end = name_end + 2;
+        text.replace_range(start..end, "");
+        markers.insert(name, TextSize::from(start as u32));
+        cursor = start;
+    }
+
+    (text, markers)
+}
+
+fn position(file_id: FileId, markers: &HashMap<String, TextSize>, name: &str) -> FilePosition {
+    FilePosition {
+        file_id,
+        offset: *markers.get(name).unwrap_or_else(|| panic!("missing marker {name:?}")),
+    }
+}
+
+#[test]
+fn macro_definition_hover_preserves_multiline_source_layout() {
+    let fixture = setup_pipeline_macro_fixture(Vec::new());
+    let analysis = fixture.host.make_analysis();
+
+    let hover = analysis
+        .hover(
+            position(fixture.header_file_id, &fixture.header_markers, "pipe_assign_def"),
+            HoverConfig { format: HoverFormat::PlainText },
+        )
+        .unwrap()
+        .expect("PIPE_ASSIGN macro definition hover expected");
+    let info = hover.info.as_str();
+    let expected_definition = "`define PIPE_ASSIGN(name, next_value) \\
+  always_ff @(posedge clk_i or negedge rst_ni) begin \\
+    if (!rst_ni) begin \\
+      name``_q <= '0; \\
+    end else begin \\
+      name``_q <= (next_value); \\
+    end \\
+  end";
+
+    assert!(
+        info.contains(expected_definition),
+        "macro definition hover should preserve source line breaks and indentation: {info}"
+    );
+    assert!(
+        !info.contains("always_ff @ ( posedge clk_i or negedge rst_ni )"),
+        "macro definition hover should not reconstruct source by token joining: {info}"
+    );
+}
+
+#[test]
+fn macro_argument_hover_deduplicates_pasted_symbol_result() {
+    let fixture = setup_pipeline_macro_fixture(vec!["LANE_WIDTH=12"]);
+    let analysis = fixture.host.make_analysis();
+
+    let hover = analysis
+        .hover(
+            position(fixture.top_file_id, &fixture.top_markers, "trace_arg"),
+            HoverConfig { format: HoverFormat::PlainText },
+        )
+        .unwrap()
+        .expect("PIPE_ASSIGN trace argument hover expected");
+    let info = hover.info.as_str();
+    let trace_definition = "logic [12 - 1:0] trace_q";
+
+    assert!(
+        info.contains(trace_definition),
+        "trace argument hover should resolve to the pasted trace_q definition: {info}"
+    );
+    assert_eq!(
+        info.matches(trace_definition).count(),
+        1,
+        "trace argument hover should show the pasted trace_q definition once: {info}"
+    );
+}

--- a/crates/ide/src/verilog_2005.rs
+++ b/crates/ide/src/verilog_2005.rs
@@ -1892,7 +1892,7 @@ endmodule
         .unwrap()
         .expect("macro definition hover expected");
     assert!(
-        hover.info.as_str().contains("`define `LOCAL_WIDTH 8"),
+        hover.info.as_str().contains("`define LOCAL_WIDTH 8"),
         "hover should show macro definition"
     );
     assert!(hover.info.as_str().contains("from [feature.v]"), "hover should show macro source");


### PR DESCRIPTION
## Summary
- Preserve macro definition hover layout by rendering from the mapped source range instead of token-joining body tokens.
- Deduplicate identical hover markup blocks when macro argument source mapping returns equivalent symbols.
- Add focused pipeline macro hover regressions for the 1.2.2 demo cases.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p ide`
- `cargo test -p hir`
- `cargo test --workspace`
