### PR TITLE
fix: use platform-owned Qihe defaults

### DIFF
--- a/docs/src/content/docs/en/user-guide/features/qihe.mdx
+++ b/docs/src/content/docs/en/user-guide/features/qihe.mdx
@@ -139,11 +139,11 @@ The arguments come from:
 
 If `vide.qihe.compileArgs` already contains `--mode`, `--mode=...`, or `-m ...`, Vide does not add `--mode sv` again.
 
-Common defaults are shown below. On Windows, if `vide.qihe.command` is not explicitly configured, Vide uses `qihe.bat`:
+Common defaults are shown below. `vide.qihe.command` defaults to `null`, which means Vide uses the platform default command: `qihe.bat` on Windows and `qihe` elsewhere.
 
 ```json
 {
-  "vide.qihe.command": "qihe",
+  "vide.qihe.command": null,
   "vide.qihe.autoConfigureArgsFromManifest": true,
   "vide.qihe.compileArgs": [],
   "vide.qihe.runArgs": ["-g", "std"]
@@ -203,6 +203,6 @@ If Qihe analysis fails, open the `Vide Qihe` output channel first and check:
 
 If the error is related to include paths, macro definitions, or top modules, fix [Project Configuration](../../project-configuration/) first.
 
-If the error is related to the Qihe command path, first set `vide.qihe.command` to the absolute path of the `qihe` executable. On Windows, if the default shell resolves the batch entry point, set it to the absolute path of `qihe.bat`.
+If the error is related to the Qihe command path, first confirm whether `vide.qihe.command` is still `null`. When you need to override the platform default, set it to the absolute path of the Qihe entry point. On Windows, if the default shell resolves the batch entry point, use the absolute path of `qihe.bat`.
 
 If the problem comes from Qihe's own compile or run process, file an issue in the [Qihe project](https://qihe.pascal-lab.net/).

--- a/docs/src/content/docs/user-guide/features/qihe.mdx
+++ b/docs/src/content/docs/user-guide/features/qihe.mdx
@@ -137,11 +137,11 @@ qihe run <qihe-run-args> [--options ./qihe-options.toml] -i <tmp.qh> [-c storage
 
 如果 `vide.qihe.compileArgs` 已经包含 `--mode`、`--mode=...` 或 `-m ...`，Vide 不会再自动追加 `--mode sv`。
 
-常用默认值如下。在 Windows 上，如果没有显式配置 `vide.qihe.command`，Vide 会使用 `qihe.bat`：
+常用默认值如下。`vide.qihe.command` 的默认值是 `null`，表示使用平台默认命令：Windows 为 `qihe.bat`，其他平台为 `qihe`。
 
 ```json
 {
-  "vide.qihe.command": "qihe",
+  "vide.qihe.command": null,
   "vide.qihe.autoConfigureArgsFromManifest": true,
   "vide.qihe.compileArgs": [],
   "vide.qihe.runArgs": ["-g", "std"]
@@ -201,6 +201,6 @@ qihe run <qihe-run-args> [--options ./qihe-options.toml] -i <tmp.qh> [-c storage
 
 如果报错与 include 路径、宏定义或 top module 有关，先检查并修正 [项目配置](../../project-configuration/)。
 
-如果报错与骑河命令路径有关，优先把 `vide.qihe.command` 设置为 `qihe` 可执行文件的绝对路径。在 Windows 上，如果默认 Shell 解析的是批处理入口，请把它设置为 `qihe.bat` 的绝对路径。
+如果报错与骑河命令路径有关，先确认 `vide.qihe.command` 是否仍为 `null`。需要覆盖平台默认时，把它设置为 Qihe 入口的绝对路径；在 Windows 上，如果默认 Shell 解析的是批处理入口，请使用 `qihe.bat` 的绝对路径。
 
 如果问题来自骑河自身的编译或运行过程，请前往[骑河项目](https://qihe.pascal-lab.net/)提交 issue。

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -135,8 +135,11 @@
           "description": "%configuration.server.additionalArgs.description%"
         },
         "vide.qihe.command": {
-          "type": "string",
-          "default": "qihe",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
           "description": "%configuration.qihe.command.description%"
         },
         "vide.qihe.autoConfigureArgsFromManifest": {

--- a/editors/vscode/src/generated/configuration.ts
+++ b/editors/vscode/src/generated/configuration.ts
@@ -18,7 +18,7 @@ export const USER_CONFIG_SETTINGS = [
 		docsGroup: "Qihe",
 		descriptionKey: "configuration.qihe.command.description",
 		markdownDescriptionKey: null,
-		defaultValue: "qihe",
+		defaultValue: null,
 	},
 	{
 		path: ["qihe","autoConfigureArgsFromManifest"],

--- a/editors/vscode/src/initializationOptions.ts
+++ b/editors/vscode/src/initializationOptions.ts
@@ -1,5 +1,5 @@
 import { USER_CONFIG_SETTINGS } from './generated/configuration';
-import { resolvedQiheCommand, type ConfigurationReader } from './qiheCommand';
+import type { ConfigurationReader } from './qiheCommand';
 
 function setting<T>(config: ConfigurationReader, section: string, fallback: T): T {
   return config.get<T>(section) ?? fallback;
@@ -7,15 +7,11 @@ function setting<T>(config: ConfigurationReader, section: string, fallback: T): 
 
 export function serverInitializationOptions(
   config: ConfigurationReader,
-  platform: NodeJS.Platform = process.platform,
 ): Record<string, unknown> {
   const options: Record<string, unknown> = {};
 
   for (const configSetting of USER_CONFIG_SETTINGS) {
-    const value =
-      configSetting.vscodeSection === 'qihe.command'
-        ? resolvedQiheCommand(config, platform)
-        : setting(config, configSetting.vscodeSection, configSetting.defaultValue);
+    const value = setting(config, configSetting.vscodeSection, configSetting.defaultValue);
 
     assignNestedValue(options, configSetting.path, value);
   }

--- a/editors/vscode/src/qiheCommand.ts
+++ b/editors/vscode/src/qiheCommand.ts
@@ -1,69 +1,19 @@
-import { USER_CONFIG_SETTINGS } from './generated/configuration';
-
 export type ConfigurationReader = {
   get<T>(section: string): T | undefined;
-  inspect?<T>(section: string): ConfigurationInspection<T> | undefined;
 };
-
-type ConfigurationInspection<T> = {
-  defaultValue?: T;
-  globalValue?: T;
-  workspaceValue?: T;
-  workspaceFolderValue?: T;
-  defaultLanguageValue?: T;
-  globalLanguageValue?: T;
-  workspaceLanguageValue?: T;
-  workspaceFolderLanguageValue?: T;
-};
-
-function setting<T>(config: ConfigurationReader, section: string, fallback: T): T {
-  return config.get<T>(section) ?? fallback;
-}
 
 function defaultQiheCommand(platform: NodeJS.Platform): string {
   return platform === 'win32' ? 'qihe.bat' : 'qihe';
 }
 
-function hasConfiguredValue<T>(inspection: ConfigurationInspection<T> | undefined): boolean {
-  return (
-    inspection?.globalValue !== undefined ||
-    inspection?.workspaceValue !== undefined ||
-    inspection?.workspaceFolderValue !== undefined ||
-    inspection?.globalLanguageValue !== undefined ||
-    inspection?.workspaceLanguageValue !== undefined ||
-    inspection?.workspaceFolderLanguageValue !== undefined
-  );
-}
-
-function qiheCommandSetting(
-  config: ConfigurationReader,
-  section: string,
-  fallback: unknown,
-  platform: NodeJS.Platform,
-): string {
-  const command = setting(config, section, fallback);
-  if (typeof command !== 'string') {
-    return defaultQiheCommand(platform);
-  }
-
-  if (hasConfiguredValue(config.inspect?.<string>(section))) {
-    return command;
-  }
-
-  return command === fallback ? defaultQiheCommand(platform) : command;
+function configuredQiheCommand(config: ConfigurationReader): string | null {
+  const command = config.get<string | null>('qihe.command');
+  return typeof command === 'string' && command.trim().length > 0 ? command.trim() : null;
 }
 
 export function resolvedQiheCommand(
   config: ConfigurationReader,
   platform: NodeJS.Platform = process.platform,
 ): string {
-  const qiheCommandConfig = USER_CONFIG_SETTINGS.find(
-    (configSetting) => configSetting.vscodeSection === 'qihe.command',
-  );
-  return qiheCommandSetting(
-    config,
-    'qihe.command',
-    qiheCommandConfig?.defaultValue ?? 'qihe',
-    platform,
-  );
+  return configuredQiheCommand(config) ?? defaultQiheCommand(platform);
 }

--- a/editors/vscode/test/configuration.test.ts
+++ b/editors/vscode/test/configuration.test.ts
@@ -123,6 +123,16 @@ test('does not expose the old videLsp settings namespace', () => {
   assert.deepEqual(oldSettings, []);
 });
 
+test('contributes Qihe command as a platform default marker', () => {
+  const property = readConfigurationProperties()['vide.qihe.command'] as {
+    type?: unknown;
+    default?: unknown;
+  };
+
+  assert.deepEqual(property.type, ['string', 'null']);
+  assert.equal(property.default, null);
+});
+
 test('localizes package contribution strings for English and Simplified Chinese', () => {
   const packageJson = readPackageJson();
   const placeholderKeys = [...collectNlsPlaceholders(packageJson)].sort();

--- a/editors/vscode/test/initializationOptions.test.ts
+++ b/editors/vscode/test/initializationOptions.test.ts
@@ -5,6 +5,7 @@ import {
   diagnosticsProfilingInitializationOptions,
   serverInitializationOptions,
 } from '../src/initializationOptions';
+import { USER_CONFIG_SETTINGS } from '../src/generated/configuration';
 import { resolvedQiheCommand } from '../src/qiheCommand';
 
 class TestConfiguration {
@@ -12,23 +13,6 @@ class TestConfiguration {
 
   get<T>(section: string): T | undefined {
     return this.values[section] as T | undefined;
-  }
-}
-
-class TestVscodeConfiguration extends TestConfiguration {
-  inspect<T>(section: string): { defaultValue?: T; globalValue?: T } | undefined {
-    return {
-      defaultValue: this.get<T>(section),
-    };
-  }
-}
-
-class TestConfiguredVscodeConfiguration extends TestConfiguration {
-  inspect<T>(section: string): { defaultValue?: T; globalValue?: T } | undefined {
-    return {
-      defaultValue: (section === 'qihe.command' ? 'qihe' : undefined) as T | undefined,
-      globalValue: this.get<T>(section),
-    };
   }
 }
 
@@ -65,30 +49,43 @@ test('server initialization options include user configuration for startup', () 
   });
 });
 
-test('server initialization options treat the VS Code Qihe default as platform-owned', () => {
+test('server initialization options pass the Qihe platform default marker to the server', () => {
   const options = serverInitializationOptions(
-    new TestVscodeConfiguration({
-      'qihe.command': 'qihe',
+    new TestConfiguration({
+      'qihe.command': null,
     }),
-    'win32',
   );
 
   assert.deepEqual(options.qihe, {
-    command: 'qihe.bat',
+    command: null,
     autoConfigureArgsFromManifest: true,
     compileArgs: [],
     runArgs: ['-g', 'std'],
   });
 });
 
+test('generated Qihe command setting uses the platform default marker', () => {
+  const setting = USER_CONFIG_SETTINGS.find(
+    (configSetting) => configSetting.vscodeSection === 'qihe.command',
+  );
+
+  assert.equal(setting?.defaultValue, null);
+});
+
+test('resolved Qihe command uses the platform default for unset extension commands', () => {
+  assert.equal(resolvedQiheCommand(new TestConfiguration({}), 'win32'), 'qihe.bat');
+  assert.equal(resolvedQiheCommand(new TestConfiguration({ 'qihe.command': null }), 'win32'), 'qihe.bat');
+  assert.equal(resolvedQiheCommand(new TestConfiguration({}), 'linux'), 'qihe');
+});
+
 test('resolved Qihe command keeps explicit user configuration', () => {
   assert.equal(
-    resolvedQiheCommand(new TestConfiguredVscodeConfiguration({ 'qihe.command': 'qihe' }), 'win32'),
+    resolvedQiheCommand(new TestConfiguration({ 'qihe.command': 'qihe' }), 'win32'),
     'qihe',
   );
   assert.equal(
     resolvedQiheCommand(
-      new TestConfiguredVscodeConfiguration({ 'qihe.command': 'custom-qihe' }),
+      new TestConfiguration({ 'qihe.command': 'custom-qihe' }),
       'win32',
     ),
     'custom-qihe',

--- a/packages/vide-extension-shared/src/config/initialization-options.ts
+++ b/packages/vide-extension-shared/src/config/initialization-options.ts
@@ -106,7 +106,7 @@ export function videInitializationOptions(
       },
     },
     qihe: {
-      command: setting(config, "qihe.command", "qihe"),
+      command: setting<string | null>(config, "qihe.command", null),
       autoConfigureArgsFromManifest: setting(
         config,
         "qihe.autoConfigureArgsFromManifest",

--- a/schemas/v1/user-config.schema.json
+++ b/schemas/v1/user-config.schema.json
@@ -142,7 +142,7 @@
     "qihe": {
       "$ref": "#/$defs/QiheUserConfig",
       "default": {
-        "command": "qihe",
+        "command": null,
         "autoConfigureArgsFromManifest": true,
         "compileArgs": [],
         "runArgs": [
@@ -685,9 +685,12 @@
       "type": "object",
       "properties": {
         "command": {
-          "description": "Command used to invoke Qihe.",
-          "type": "string",
-          "default": "qihe"
+          "description": "Command used to invoke Qihe. Use null to resolve the platform default.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
         },
         "autoConfigureArgsFromManifest": {
           "description": "Automatically add Qihe compile mode and forwarded slang options from the Vide project manifest.",

--- a/src/config/user_config.rs
+++ b/src/config/user_config.rs
@@ -23,6 +23,9 @@ use utils::paths::Utf8PathBuf;
 
 use super::Config;
 
+#[cfg(windows)]
+const DEFAULT_QIHE_COMMAND: &str = "qihe.bat";
+#[cfg(not(windows))]
 const DEFAULT_QIHE_COMMAND: &str = "qihe";
 const DEFAULT_QIHE_RUN_ARGS: &[&str] = &["-g", "std"];
 const DEFAULT_SLANG_WIDTH_WARNINGS: &[&str] =
@@ -577,9 +580,12 @@ pub(crate) struct SignatureHelpParamsUserConfig {
 pub(crate) struct QiheUserConfig {
     #[cfg_attr(
         feature = "user-config-schema",
-        schemars(description = "Command used to invoke Qihe.", default = "default_qihe_command")
+        schemars(
+            description = "Command used to invoke Qihe. Use null to resolve the platform default.",
+            default = "default_qihe_command_setting"
+        )
     )]
-    pub(crate) command: String,
+    pub(crate) command: Option<String>,
     #[serde(rename = "autoConfigureArgsFromManifest")]
     #[cfg_attr(
         feature = "user-config-schema",
@@ -612,7 +618,7 @@ pub(crate) struct QiheUserConfig {
 impl Default for QiheUserConfig {
     fn default() -> Self {
         Self {
-            command: DEFAULT_QIHE_COMMAND.to_owned(),
+            command: None,
             auto_configure_args_from_manifest: true,
             compile_args: Vec::new(),
             run_args: DEFAULT_QIHE_RUN_ARGS.iter().map(|arg| (*arg).to_owned()).collect(),
@@ -656,8 +662,8 @@ fn default_indent_width() -> usize {
 }
 
 #[cfg(feature = "user-config-schema")]
-fn default_qihe_command() -> String {
-    DEFAULT_QIHE_COMMAND.to_owned()
+fn default_qihe_command_setting() -> Option<String> {
+    None
 }
 
 #[cfg(feature = "user-config-schema")]
@@ -712,7 +718,6 @@ enum ConfigSettingDefault {
 #[derive(Clone, Copy)]
 enum ConfigSettingSchema {
     Boolean,
-    String,
     StringOrNull,
     StringArray,
     Integer { minimum: usize },
@@ -770,9 +775,6 @@ impl ConfigSettingMeta {
             ConfigSettingSchema::Boolean => {
                 property.insert("type".to_owned(), serde_json::json!("boolean"));
             }
-            ConfigSettingSchema::String => {
-                property.insert("type".to_owned(), serde_json::json!("string"));
-            }
             ConfigSettingSchema::StringOrNull => {
                 property.insert("type".to_owned(), serde_json::json!(["string", "null"]));
             }
@@ -820,6 +822,17 @@ impl ConfigSettingMeta {
     }
 }
 
+fn default_qihe_command_for_platform() -> &'static str {
+    DEFAULT_QIHE_COMMAND
+}
+
+fn resolve_qihe_command(command: Option<&str>) -> String {
+    match command.map(str::trim).filter(|cmd| !cmd.is_empty()) {
+        Some(command) => command.to_owned(),
+        None => default_qihe_command_for_platform().to_owned(),
+    }
+}
+
 #[cfg(feature = "user-config-schema")]
 const FILES_WATCHER_ENUM_DESCRIPTIONS: &[(&str, &str)] = &[
     ("client", "configuration.files.watcher.enum.client"),
@@ -841,8 +854,8 @@ const USER_CONFIG_SETTINGS: &[ConfigSettingMeta] = &[
         markdown_description_key: None,
         enum_descriptions: &[],
         exposed_in_vscode: true,
-        default: ConfigSettingDefault::String(DEFAULT_QIHE_COMMAND),
-        schema: ConfigSettingSchema::String,
+        default: ConfigSettingDefault::Null,
+        schema: ConfigSettingSchema::StringOrNull,
     },
     ConfigSettingMeta {
         path: &["qihe", "autoConfigureArgsFromManifest"],
@@ -1408,7 +1421,7 @@ fn apply_user_config_fields(
     field!(&["qihe", "autoConfigureArgsFromManifest"], bool, |cfg, value| {
         cfg.qihe.auto_configure_args_from_manifest = value
     });
-    field!(&["qihe", "command"], String, |cfg, value| cfg.qihe.command = value);
+    field!(&["qihe", "command"], Option<String>, |cfg, value| cfg.qihe.command = value);
     field!(&["qihe", "compileArgs"], Vec<String>, |cfg, value| { cfg.qihe.compile_args = value });
     field!(&["qihe", "runArgs"], Vec<String>, |cfg, value| cfg.qihe.run_args = value);
     field!(&["references", "includeDeclaration"], bool, |cfg, value| {
@@ -1466,10 +1479,7 @@ impl UserConfig {
     }
 
     pub(crate) fn qihe(&self) -> QiheConfig {
-        let command = Some(self.qihe.command.trim())
-            .filter(|cmd| !cmd.is_empty())
-            .unwrap_or(DEFAULT_QIHE_COMMAND)
-            .to_string();
+        let command = resolve_qihe_command(self.qihe.command.as_deref());
 
         let run_args =
             Some(&self.qihe.run_args).filter(|args| !args.is_empty()).cloned().unwrap_or_else(
@@ -1604,6 +1614,31 @@ fn check_default() {
         user_cfg.diagnostics_config().slang.warnings,
         ["width-expand", "width-trunc", "port-width-expand", "port-width-trunc"]
     );
+}
+
+#[cfg(test)]
+fn test_expected_qihe_command_for_current_platform() -> &'static str {
+    default_qihe_command_for_platform()
+}
+
+#[test]
+fn qihe_default_command_matches_current_platform() {
+    let mut errors = vec![];
+    let user_cfg = UserConfig::from_json(serde_json::Value::Null, &mut errors);
+    assert!(errors.is_empty(), "{errors:?}");
+
+    assert_eq!(user_cfg.qihe().command, test_expected_qihe_command_for_current_platform());
+}
+
+#[cfg(feature = "user-config-schema")]
+#[test]
+fn generated_qihe_command_setting_uses_platform_default_marker() {
+    let properties = generated_vscode_package_properties();
+    let setting =
+        properties.get("vide.qihe.command").expect("qihe command setting should be generated");
+
+    assert_eq!(setting.get("type"), Some(&serde_json::json!(["string", "null"])));
+    assert_eq!(setting.get("default"), Some(&serde_json::Value::Null));
 }
 
 #[test]

--- a/src/global_state/qihe.rs
+++ b/src/global_state/qihe.rs
@@ -651,6 +651,7 @@ fn resolve_qihe_run_plan(
         .clone()
         .or(options_storage_root)
         .unwrap_or_else(|| workspace.join("storage"));
+    fs::create_dir_all(&workspace)?;
     fs::create_dir_all(&storage_root)?;
     Ok(QiheRunPlan {
         ir_path: workspace.join("input.qh"),
@@ -1747,6 +1748,7 @@ mod tests {
             run_plan.options_path,
             Some(PathBuf::from(root.path().join("qihe-options.toml")))
         );
+        assert!(run_plan.ir_path.parent().is_some_and(|path| path.is_dir()));
         assert!(run_plan.append_options_arg);
         assert!(!run_plan.append_storage_root_arg);
     }


### PR DESCRIPTION
## Summary
- fix a regression of #96 where Windows could still advertise or persist `qihe` as the Qihe command default even though the executable entrypoint is `qihe.bat`
- model `vide.qihe.command` as `null`/unset in config metadata, schema, package defaults, generated settings, and docs
- pass the Qihe command default marker through server initialization; resolve platform defaults at the Qihe execution boundary
- create the Qihe temp workspace before compiling to `input.qh`, so options-provided storage roots do not break compile output

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo xtask check-config-artifacts`
- `cargo test -p vide --features user-config-schema`
- `npm --prefix editors/vscode run test`
- `npm --prefix docs run build`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Qihe CLI compile smoke with an existing generated temp output directory
