### PR TITLE
chore(release): prepare 1.2.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vide"
-version = "1.2.2"
+version = "1.2.3"
 edition = "2024"
 authors = ["roifewu <roifewu@gmail.com>", "hongjr03 <hongjr03@gmail.com>"]
 repository = "https://github.com/pascal-lab/vide"

--- a/docs/src/content/docs/changelog/index.mdx
+++ b/docs/src/content/docs/changelog/index.mdx
@@ -9,6 +9,11 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard
+    title="1.2.3"
+    href="./v1-2-3/"
+    description="修正 Qihe 命令默认值由语言服务器统一提供，并让更新日志侧边栏自动包含所有版本。"
+  />
+  <LinkCard
     title="1.2.2"
     href="./v1-2-2/"
     description="修复启动和重载期间的工作区就绪请求、补全触发边界、localparam 覆盖建模，加入 Zed 扩展支持，并整理来源/预处理内部模型。"

--- a/docs/src/content/docs/changelog/v1-2-3/index.mdx
+++ b/docs/src/content/docs/changelog/v1-2-3/index.mdx
@@ -1,0 +1,24 @@
+---
+title: 1.2.3
+description: Vide 1.2.3 更新日志。
+---
+
+Vide 1.2.3 修正 Qihe 命令默认值的归属，并让更新日志导航自动跟随版本页面。
+
+## 修复
+
+### Qihe 配置
+
+- `vide.qihe.command` 现在默认保持为 `null`，由语言服务器按平台选择实际命令：Windows 使用 `qihe.bat`，其他平台使用 `qihe`。VS Code 扩展不再维护一份重复默认值，避免扩展设置、schema 和语言服务器行为不一致。([#267](https://github.com/pascal-lab/vide/pull/267) by [@hongjr03](https://github.com/hongjr03))
+
+## 文档
+
+- 更新日志侧边栏现在从版本页面目录自动生成，新增版本页面后会自动显示在侧边栏中，不再需要手动同步 Astro 配置。([#268](https://github.com/pascal-lab/vide/pull/268) by [@hongjr03](https://github.com/hongjr03))
+
+## 贡献者
+
+感谢本次发布的所有贡献者：
+
+- [@hongjr03](https://github.com/hongjr03)
+
+**完整更新列表**: [v1.2.2...v1.2.3](https://github.com/pascal-lab/vide/compare/v1.2.2...v1.2.3)

--- a/docs/src/content/docs/en/changelog/index.mdx
+++ b/docs/src/content/docs/en/changelog/index.mdx
@@ -9,6 +9,11 @@ Browse Vide changes by version.
 
 <CardGrid>
   <LinkCard
+    title="1.2.3"
+    href="./v1-2-3/"
+    description="Uses language-server-owned Qihe command defaults and automatically includes every changelog version in the sidebar."
+  />
+  <LinkCard
     title="1.2.2"
     href="./v1-2-2/"
     description="Startup and reload readiness fixes, completion trigger fixes, localparam override modeling, Zed extension support, and source/preprocessor cleanup."

--- a/docs/src/content/docs/en/changelog/v1-2-3/index.mdx
+++ b/docs/src/content/docs/en/changelog/v1-2-3/index.mdx
@@ -1,0 +1,24 @@
+---
+title: 1.2.3
+description: Vide 1.2.3 release notes.
+---
+
+Vide 1.2.3 fixes Qihe command default ownership and keeps changelog navigation in sync with version pages.
+
+## Fixes
+
+### Qihe Configuration
+
+- `vide.qihe.command` now defaults to `null`, letting the language server choose the actual platform command: `qihe.bat` on Windows and `qihe` elsewhere. The VS Code extension no longer carries a duplicate default, avoiding drift between extension settings, schema data, and language server behavior. ([#267](https://github.com/pascal-lab/vide/pull/267) by [@hongjr03](https://github.com/hongjr03))
+
+## Documentation
+
+- The changelog sidebar is now generated from the version page directories, so new version pages appear automatically without a matching manual Astro config edit. ([#268](https://github.com/pascal-lab/vide/pull/268) by [@hongjr03](https://github.com/hongjr03))
+
+## Contributors
+
+Thanks to everyone who contributed to this release:
+
+- [@hongjr03](https://github.com/hongjr03)
+
+**Full Changelog**: [v1.2.2...v1.2.3](https://github.com/pascal-lab/vide/compare/v1.2.2...v1.2.3)

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vide-ide",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vide-ide",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vide-ide",
   "displayName": "Vide - Verilog/SystemVerilog Coding IDE",
   "description": "%extension.description%",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "publisher": "pascal-lab",
   "license": "MIT",
   "icon": "media/icon.png",


### PR DESCRIPTION
## Summary
- bump the Rust and VS Code extension versions to 1.2.3
- add Chinese and English changelog pages for 1.2.3
- add 1.2.3 to the changelog indexes

## Validation
- `git diff --check`
- `node docs/scripts/release-body-from-changelog.mjs --tag v1.2.3 --output /tmp/vide-release-body-1.2.3.md`
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `npm --prefix docs run build`
- `npm --prefix editors/vscode run package:vsix:debug`
