### PR TITLE
fix(ide): select macro tokens by emitted identity

### DIFF
--- a/crates/hir/src/hir_def/macro_file.rs
+++ b/crates/hir/src/hir_def/macro_file.rs
@@ -1,6 +1,6 @@
 use ::preproc::source::{
-    SourceEmittedTokenId, SourceEmittedTokenRange, SourceMacroCall, SourceMacroCallId,
-    SourceMacroExpansion, SourceMacroExpansionDefinition, SourcePreprocModel,
+    SourceEmittedTokenRange, SourceMacroCall, SourceMacroCallId, SourceMacroExpansion,
+    SourceMacroExpansionDefinition, SourcePreprocModel,
 };
 use smol_str::SmolStr;
 use syntax::{SyntaxTree, preproc::MacroCallId as TraceMacroCallId};
@@ -18,6 +18,7 @@ mod source_map;
 #[cfg(test)]
 mod tests;
 
+pub use ::preproc::source::SourceEmittedTokenId;
 pub use source_map::{ExpansionSourceHit, ExpansionSourceMap, Origin};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]

--- a/crates/hir/src/hir_def/macro_file/source_map.rs
+++ b/crates/hir/src/hir_def/macro_file/source_map.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
 
-use ::preproc::source::{PreprocSourceId, SourceEmittedTokenRange, SourceRange};
+use ::preproc::source::{
+    PreprocSourceId, SourceEmittedTokenId, SourceEmittedTokenRange, SourceRange,
+};
 use smol_str::{SmolStr, ToSmolStr};
 use syntax::{
     SourceBufferRange,
@@ -31,6 +33,7 @@ pub struct ExpansionSourceMap {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct OriginSlot {
+    emitted_token: SourceEmittedTokenId,
     origin: Origin,
     source: Option<OriginSource>,
 }
@@ -43,6 +46,7 @@ struct OriginSource {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExpansionSourceHit {
+    pub emitted_token: SourceEmittedTokenId,
     pub expanded_token_index: usize,
     pub range: TextRange,
     pub origin: Origin,
@@ -81,6 +85,7 @@ impl ExpansionSourceMap {
                 let slot = slot.as_ref()?;
                 let source = slot.source?;
                 (source.file == file && source.range.contains(offset)).then(|| ExpansionSourceHit {
+                    emitted_token: slot.emitted_token,
                     expanded_token_index,
                     range: source.range,
                     origin: slot.origin.clone(),
@@ -102,10 +107,12 @@ impl ExpansionSourceMap {
         let operation_sources = OperationSourceResolver::new(trace);
         let origins = (emitted_range.start.raw()..end)
             .map(|raw| {
+                let emitted_token = SourceEmittedTokenId::new(raw);
                 trace.emitted_tokens.get(raw).and_then(|token| {
                     origin_slot_from_token_origin(
                         db,
                         model_file,
+                        emitted_token,
                         &token.origin,
                         source_map,
                         Some(&operation_sources),
@@ -126,8 +133,16 @@ impl ExpansionSourceMap {
         Self {
             origins: origins
                 .into_iter()
+                .enumerate()
                 .map(|origin| {
-                    origin_slot_from_token_origin(db, model_file, origin, source_map, None)
+                    origin_slot_from_token_origin(
+                        db,
+                        model_file,
+                        SourceEmittedTokenId::new(origin.0),
+                        origin.1,
+                        source_map,
+                        None,
+                    )
                 })
                 .collect(),
         }
@@ -217,6 +232,7 @@ impl Origin {
 fn origin_slot_from_token_origin(
     db: &dyn HirDb,
     model_file: FileId,
+    emitted_token: SourceEmittedTokenId,
     origin: &TokenOrigin,
     source_map: &PreprocSourceMap,
     operation_sources: Option<&OperationSourceResolver<'_>>,
@@ -243,7 +259,7 @@ fn origin_slot_from_token_origin(
         }
         TokenOrigin::Builtin { .. } | TokenOrigin::Unavailable => None,
     };
-    Some(OriginSlot { origin: mapped_origin, source })
+    Some(OriginSlot { emitted_token, origin: mapped_origin, source })
 }
 
 fn macro_call_id(db: &dyn HirDb, model_file: FileId, trace_call: TraceMacroCallId) -> MacroCallId {

--- a/crates/hir/src/hir_def/macro_file/tests.rs
+++ b/crates/hir/src/hir_def/macro_file/tests.rs
@@ -182,6 +182,7 @@ fn expansion_source_map_maps_trace_origins_and_missing_slots() {
     assert_eq!(
         source_map.source_hits(TOP, TextSize::from(21)),
         vec![ExpansionSourceHit {
+            emitted_token: SourceEmittedTokenId::new(1),
             expanded_token_index: 1,
             range: text_range(20, 24),
             origin: Origin::MacroBody {
@@ -194,6 +195,7 @@ fn expansion_source_map_maps_trace_origins_and_missing_slots() {
     assert_eq!(
         source_map.source_hits(TOP, TextSize::from(51)),
         vec![ExpansionSourceHit {
+            emitted_token: SourceEmittedTokenId::new(2),
             expanded_token_index: 2,
             range: text_range(50, 54),
             origin: Origin::MacroArg {

--- a/crates/ide/src/source_targets.rs
+++ b/crates/ide/src/source_targets.rs
@@ -1,4 +1,4 @@
-use hir::hir_def::macro_file::{MacroFileId, Origin, macro_files_at_offset};
+use hir::hir_def::macro_file::{MacroFileId, Origin, SourceEmittedTokenId, macro_files_at_offset};
 use rustc_hash::FxHashMap;
 use syntax::{
     SyntaxNode, SyntaxNodeExt, SyntaxTokenWithParent, TokenKind, has_text_range::HasTextRange,
@@ -15,9 +15,7 @@ mod preproc;
 use macro_gate::source_macro_invocation_may_cover_offset;
 use preproc::preproc_source_target_at_offset;
 #[cfg(test)]
-use preproc::{
-    origin_from_token_origin_raw, push_unique_preproc_hit, syntax_tokens_for_preproc_hit,
-};
+use preproc::{push_unique_preproc_hit, syntax_tokens_for_preproc_hit};
 
 #[derive(Debug, Clone)]
 pub(crate) enum SourceTargetResolution<'tree> {
@@ -145,7 +143,7 @@ impl SourceTargetRequestCache {
 pub(crate) struct PreprocTokenHit {
     pub expansion: usize,
     pub call: usize,
-    pub emitted_token: usize,
+    pub emitted_token: SourceEmittedTokenId,
     pub display_range: TextRange,
     pub source_range: TextRange,
     pub origin: Origin,

--- a/crates/ide/src/source_targets/preproc.rs
+++ b/crates/ide/src/source_targets/preproc.rs
@@ -1,13 +1,9 @@
 use hir::{
     base_db::source_db::SourceDb,
     db::HirDb,
-    hir_def::macro_file::{ExpansionSourceHit, MacroCallId, MacroCallLoc, MacroFileId, Origin},
+    hir_def::macro_file::{ExpansionSourceHit, MacroFileId, Origin, SourceEmittedTokenId},
 };
-use smol_str::ToSmolStr;
-use syntax::{
-    SourceBufferRange, SyntaxElement, SyntaxNode, SyntaxTokenWithParent, TokenKind, WalkEvent,
-    preproc::{MacroCallId as TraceMacroCallId, TokenOrigin},
-};
+use syntax::{SyntaxElement, SyntaxNode, SyntaxTokenWithParent, TokenKind, WalkEvent};
 use utils::line_index::{TextRange, TextSize};
 use vfs::FileId;
 
@@ -37,8 +33,7 @@ pub(super) fn preproc_source_target_at_offset<'tree>(
 
     match preproc_hits_at_offset(db, &macro_files, file_id, offset) {
         PreprocHitLookup::Available { range, hits } => {
-            let Some(tokens) =
-                syntax_tokens_for_preproc_hit(db, file_id, root, offset, precedence, &hits)
+            let Some(tokens) = syntax_tokens_for_preproc_hit(root, offset, precedence, &hits)
             else {
                 return SourceTargetProviderResult::Blocked(
                     SourceTargetBlock::preproc_unavailable(range),
@@ -86,7 +81,7 @@ fn preproc_hits_at_offset(
         .unwrap_or_else(|| TextRange::empty(offset));
     match hits.len() {
         0 => unreachable!(),
-        1 => PreprocHitLookup::Available { range, hits },
+        _ if hits_have_one_origin(&hits) => PreprocHitLookup::Available { range, hits },
         _ => PreprocHitLookup::Ambiguous { range, hits },
     }
 }
@@ -100,7 +95,7 @@ fn preproc_hit_for_source_hit(
     Some(PreprocTokenHit {
         expansion,
         call,
-        emitted_token: source_hit.expanded_token_index,
+        emitted_token: source_hit.emitted_token,
         display_range: source_hit.range,
         source_range: source_hit.range,
         origin: source_hit.origin,
@@ -120,23 +115,28 @@ fn origin_call(db: &dyn HirDb, origin: &Origin) -> Option<usize> {
 }
 
 pub(super) fn push_unique_preproc_hit(hits: &mut Vec<PreprocTokenHit>, hit: PreprocTokenHit) {
-    if hits.iter().any(|existing| existing.origin == hit.origin) {
+    if hits.contains(&hit) {
         return;
     }
     hits.push(hit);
 }
 
+fn hits_have_one_origin(hits: &[PreprocTokenHit]) -> bool {
+    let Some(first) = hits.first() else {
+        return false;
+    };
+    hits.iter().all(|hit| hit.origin == first.origin)
+}
+
 pub(super) fn syntax_tokens_for_preproc_hit<'tree>(
-    db: &dyn HirDb,
-    model_file: FileId,
     root: SyntaxNode<'tree>,
     offset: TextSize,
     precedence: &impl Fn(TokenKind) -> usize,
     hits: &[PreprocTokenHit],
 ) -> Option<Vec<SyntaxTokenWithParent<'tree>>> {
-    let origins = hits.iter().filter_map(macro_origin_for_hit).collect::<Vec<_>>();
-    if !origins.is_empty() {
-        return syntax_tokens_for_macro_origins(db, model_file, root, &origins);
+    let emitted_tokens = hits.iter().filter_map(macro_emitted_token_for_hit).collect::<Vec<_>>();
+    if !emitted_tokens.is_empty() {
+        return syntax_tokens_for_macro_emitted_tokens(root, &emitted_tokens);
     }
 
     normal_syntax_source_target_at_offset(root, offset, precedence)
@@ -145,88 +145,35 @@ pub(super) fn syntax_tokens_for_preproc_hit<'tree>(
         .map(SourceTarget::into_tokens)
 }
 
-fn macro_origin_for_hit(hit: &PreprocTokenHit) -> Option<&Origin> {
-    (!matches!(hit.origin, Origin::File { .. })).then_some(&hit.origin)
+fn macro_emitted_token_for_hit(hit: &PreprocTokenHit) -> Option<SourceEmittedTokenId> {
+    (!matches!(hit.origin, Origin::File { .. })).then_some(hit.emitted_token)
 }
 
-fn syntax_tokens_for_macro_origins<'tree>(
-    db: &dyn HirDb,
-    model_file: FileId,
+fn syntax_tokens_for_macro_emitted_tokens<'tree>(
     root: SyntaxNode<'tree>,
-    origins: &[&Origin],
+    emitted_tokens: &[SourceEmittedTokenId],
 ) -> Option<Vec<SyntaxTokenWithParent<'tree>>> {
     let mut tokens = Vec::new();
     for event in root.elem_preorder() {
         let WalkEvent::Enter(SyntaxElement::Token(token)) = event else {
             continue;
         };
-        let Some(token_origin) =
-            origin_from_token_origin_raw(db, model_file, &token.preprocessor_trace_origin())
-        else {
+        let Some(token_id) = syntax_token_emitted_token_id(&token) else {
             continue;
         };
-        if matches!(token_origin, Origin::File { .. }) {
-            continue;
-        }
-        if origins.iter().any(|origin| **origin == token_origin) && !tokens.contains(&token) {
+        if emitted_tokens.contains(&token_id) && !tokens.contains(&token) {
             tokens.push(token);
         }
     }
     (!tokens.is_empty()).then_some(tokens)
 }
 
-/// Map a syntax-tree `TokenOrigin` to a hir `Origin` using raw buffer offsets,
-/// without consulting a `PreprocSourceMap`.
-///
-/// This is the inverse used to compare an emitted token against an `Origin`
-/// produced earlier by [`Origin::from_token_origin`] when both sides share the
-/// same buffer (the common case for single-file expansions). When the call
-/// site has a `PreprocSourceMap` available, prefer
-/// [`Origin::from_token_origin`] instead.
-pub(super) fn origin_from_token_origin_raw(
-    db: &dyn HirDb,
-    model_file: FileId,
-    origin: &TokenOrigin,
-) -> Option<Origin> {
-    Some(match origin {
-        TokenOrigin::Source { token_range } => {
-            Origin::File { file: model_file, range: source_buffer_text_range(token_range)? }
-        }
-        TokenOrigin::MacroBody { call_id, definition_id, body_token_range, .. } => {
-            Origin::MacroBody {
-                call: macro_call_id(db, model_file, *call_id),
-                def: *definition_id,
-                body_range: source_buffer_text_range(body_token_range)?,
-            }
-        }
-        TokenOrigin::MacroArgument { call_id, argument_index, argument_token_range, .. } => {
-            Origin::MacroArg {
-                call: macro_call_id(db, model_file, *call_id),
-                arg_index: usize::try_from(*argument_index).ok()?,
-                arg_range: source_buffer_text_range(argument_token_range)?,
-            }
-        }
-        TokenOrigin::TokenPaste { call_id, .. } => {
-            Origin::TokenPaste { call: macro_call_id(db, model_file, *call_id) }
-        }
-        TokenOrigin::Stringify { call_id, .. } => {
-            Origin::Stringify { call: macro_call_id(db, model_file, *call_id) }
-        }
-        TokenOrigin::Builtin { name, call_id, .. } if !name.is_empty() => Origin::Builtin {
-            call: macro_call_id(db, model_file, *call_id),
-            name: name.to_smolstr(),
-        },
-        TokenOrigin::Builtin { .. } | TokenOrigin::Unavailable => return None,
-    })
-}
-
-fn macro_call_id(db: &dyn HirDb, model_file: FileId, trace_call: TraceMacroCallId) -> MacroCallId {
-    db.intern_macro_call(MacroCallLoc { model_file, trace_call })
-}
-
-fn source_buffer_text_range(range: &SourceBufferRange) -> Option<TextRange> {
-    Some(TextRange::new(
-        TextSize::from(u32::try_from(range.range.start).ok()?),
-        TextSize::from(u32::try_from(range.range.end).ok()?),
-    ))
+fn syntax_token_emitted_token_id(
+    token: &SyntaxTokenWithParent<'_>,
+) -> Option<SourceEmittedTokenId> {
+    token
+        .preprocessor_trace_emitted_token()
+        .emitted_token_index
+        .and_then(|index| usize::try_from(index).ok())
+        .map(SourceEmittedTokenId::new)
 }

--- a/crates/ide/src/source_targets/tests.rs
+++ b/crates/ide/src/source_targets/tests.rs
@@ -1,3 +1,4 @@
+use hir::{db::InternDb, hir_def::macro_file::SourceEmittedTokenId};
 use syntax::{
     SyntaxElement, SyntaxNode, SyntaxTree, SyntaxTreeOptions, WalkEvent, preproc::TokenOrigin,
     token::TokenKindExt,
@@ -39,14 +40,9 @@ fn source_targets_source_token_range_mismatch_uses_original_syntax_hit() {
     );
     let hit = test_source_hit(file_id, origin_range, 0);
 
-    let SourceTargetProviderResult::Resolved(selection) = preproc_provider_result_from_hits(
-        root,
-        offset,
-        &test_precedence,
-        vec![hit],
-        origin_range,
-        file_id,
-    ) else {
+    let SourceTargetProviderResult::Resolved(selection) =
+        preproc_provider_result_from_hits(root, offset, &test_precedence, vec![hit], origin_range)
+    else {
         panic!("source-token hit should select by the original syntax token at the offset");
     };
 
@@ -92,35 +88,100 @@ endmodule
         })
         .next()
         .expect("expanded source should contain the macro argument token");
+    let emitted_token = token.preprocessor_trace_emitted_token();
     let expected_origin =
-        origin_from_token_origin_raw(&db, model_file, &token.preprocessor_trace_origin())
-            .expect("payload_i should have macro argument origin");
+        macro_arg_origin_from_token_origin(&db, model_file, &emitted_token.origin);
+    let emitted_token = SourceEmittedTokenId::new(
+        usize::try_from(
+            emitted_token
+                .emitted_token_index
+                .expect("syntax token should carry trace emitted-token identity"),
+        )
+        .unwrap(),
+    );
     let source_range = source_range(source, "payload_i");
     let hit = PreprocTokenHit {
         expansion: 0,
         call: 0,
-        emitted_token: 0,
+        emitted_token,
         display_range: source_range,
         source_range,
         origin: expected_origin.clone(),
     };
 
-    let tokens = syntax_tokens_for_preproc_hit(
-        &db,
-        model_file,
-        root,
-        source_range.start(),
-        &test_precedence,
-        &[hit],
-    )
-    .expect("macro argument origin should resolve to a parsed syntax token");
+    let tokens =
+        syntax_tokens_for_preproc_hit(root, source_range.start(), &test_precedence, &[hit])
+            .expect("macro argument origin should resolve to a parsed syntax token");
 
     assert_eq!(tokens.len(), 1);
     assert_eq!(tokens[0].raw_text().as_bytes(), b"payload_i");
     assert_eq!(
-        origin_from_token_origin_raw(&db, model_file, &tokens[0].preprocessor_trace_origin()),
-        Some(expected_origin)
+        tokens[0].preprocessor_trace_emitted_token().emitted_token_index,
+        Some(u32::try_from(emitted_token.raw()).unwrap())
     );
+}
+
+#[test]
+fn source_targets_macro_argument_selects_only_the_hit_emitted_token() {
+    let db = RootDb::new(None);
+    let model_file = FileId(0);
+    let source = r#"`define DUP(x) x x
+module m;
+  assign y = `DUP(payload_i);
+endmodule
+"#;
+    let parsed = SyntaxTree::from_text_with_options_and_trace(
+        source,
+        "source",
+        "sample/rtl/top.sv",
+        &SyntaxTreeOptions::default(),
+    );
+    let root = parsed.tree.root().expect("test source should parse");
+    let trace = parsed.preprocessor_trace.expect("trace should be collected");
+    let emitted_payloads = trace
+        .emitted_tokens
+        .iter()
+        .enumerate()
+        .filter(|(_, token)| {
+            token.raw_text == "payload_i"
+                && matches!(token.origin, TokenOrigin::MacroArgument { .. })
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(emitted_payloads.len(), 2, "DUP should emit the argument twice");
+    let (second_emitted_token, second_emitted_payload) = emitted_payloads[1];
+    let expected_origin =
+        macro_arg_origin_from_token_origin(&db, model_file, &second_emitted_payload.origin);
+    let expected_tokens = root
+        .elem_preorder()
+        .filter_map(|event| match event {
+            WalkEvent::Enter(SyntaxElement::Token(token))
+                if token.raw_text().as_bytes() == b"payload_i"
+                    && matches!(
+                        token.preprocessor_trace_origin(),
+                        TokenOrigin::MacroArgument { .. }
+                    ) =>
+            {
+                Some(token)
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(expected_tokens.len(), 2, "expanded syntax should contain both argument copies");
+    let source_range = source_range(source, "payload_i");
+    let hit = PreprocTokenHit {
+        expansion: 0,
+        call: 0,
+        emitted_token: SourceEmittedTokenId::new(second_emitted_token),
+        display_range: source_range,
+        source_range,
+        origin: expected_origin,
+    };
+
+    let tokens =
+        syntax_tokens_for_preproc_hit(root, source_range.start(), &test_precedence, &[hit])
+            .expect("macro argument emitted token should resolve to a parsed syntax token");
+
+    assert_eq!(tokens, vec![expected_tokens[1]]);
 }
 
 #[test]
@@ -135,14 +196,8 @@ fn source_targets_preproc_owned_unresolved_does_not_use_normal_syntax_fallback()
         "test setup must have an ordinary syntax token that fallback could have selected"
     );
 
-    let lookup = preproc_provider_result_from_hits(
-        root,
-        offset,
-        &test_precedence,
-        Vec::new(),
-        parser_range,
-        FileId(0),
-    );
+    let lookup =
+        preproc_provider_result_from_hits(root, offset, &test_precedence, Vec::new(), parser_range);
     assert!(matches!(
         lookup,
         SourceTargetProviderResult::Blocked(SourceTargetBlock {
@@ -169,28 +224,23 @@ fn source_targets_normal_syntax_path_still_selects_non_preproc_offsets() {
 }
 
 #[test]
-fn source_targets_dedups_preproc_hits_for_same_semantic_target() {
+fn source_targets_same_origin_hits_are_available_without_dropping_emitted_tokens() {
     let (root, offset, parser_range) =
         root_and_offset("module m; wire payload_i; endmodule\n", "payload_i", 0);
     let file_id = FileId(0);
     let hits =
         vec![test_source_hit(file_id, parser_range, 0), test_source_hit(file_id, parser_range, 1)];
 
-    let SourceTargetProviderResult::Resolved(selection) = preproc_provider_result_from_hits(
-        root,
-        offset,
-        &test_precedence,
-        hits,
-        parser_range,
-        file_id,
-    ) else {
-        panic!("same semantic target should dedup to one available preproc hit");
+    let SourceTargetProviderResult::Resolved(selection) =
+        preproc_provider_result_from_hits(root, offset, &test_precedence, hits, parser_range)
+    else {
+        panic!("same-origin hits should remain available");
     };
 
     let SourceTargetOrigin::Preproc { hits } = selection.origin else {
         panic!("preproc provider should produce a preproc-origin selection");
     };
-    assert_eq!(hits.len(), 1);
+    assert_eq!(hits.len(), 2);
 }
 
 #[test]
@@ -205,14 +255,7 @@ fn source_targets_reports_ambiguous_preproc_hits_for_conflicting_targets() {
     let SourceTargetProviderResult::Blocked(SourceTargetBlock {
         reason: SourceTargetBlockReason::Ambiguous { hits },
         ..
-    }) = preproc_provider_result_from_hits(
-        root,
-        offset,
-        &test_precedence,
-        hits,
-        parser_range,
-        file_id,
-    )
+    }) = preproc_provider_result_from_hits(root, offset, &test_precedence, hits, parser_range)
     else {
         panic!("conflicting preproc targets should be ambiguous");
     };
@@ -247,10 +290,32 @@ fn test_source_hit(file_id: FileId, range: TextRange, emitted_token: usize) -> P
     PreprocTokenHit {
         expansion: 0,
         call: 0,
-        emitted_token,
+        emitted_token: SourceEmittedTokenId::new(emitted_token),
         display_range: range,
         source_range: range,
         origin,
+    }
+}
+
+fn macro_arg_origin_from_token_origin(
+    db: &RootDb,
+    model_file: FileId,
+    origin: &TokenOrigin,
+) -> Origin {
+    let TokenOrigin::MacroArgument { call_id, argument_index, argument_token_range, .. } = origin
+    else {
+        panic!("macro argument origin expected");
+    };
+    Origin::MacroArg {
+        call: db.intern_macro_call(hir::hir_def::macro_file::MacroCallLoc {
+            model_file,
+            trace_call: *call_id,
+        }),
+        arg_index: usize::try_from(*argument_index).unwrap(),
+        arg_range: TextRange::new(
+            TextSize::from(u32::try_from(argument_token_range.range.start).unwrap()),
+            TextSize::from(u32::try_from(argument_token_range.range.end).unwrap()),
+        ),
     }
 }
 
@@ -260,7 +325,6 @@ fn preproc_provider_result_from_hits<'tree>(
     precedence: &impl Fn(TokenKind) -> usize,
     hits: Vec<PreprocTokenHit>,
     fallback_range: TextRange,
-    model_file: FileId,
 ) -> SourceTargetProviderResult<'tree> {
     let mut unique_hits = Vec::new();
     for hit in hits {
@@ -275,16 +339,16 @@ fn preproc_provider_result_from_hits<'tree>(
     }
     let range = covering_range(&unique_hits.iter().map(|hit| hit.source_range).collect::<Vec<_>>())
         .unwrap_or(fallback_range);
-    if unique_hits.len() > 1 {
+    let has_conflicting_origin = unique_hits
+        .first()
+        .is_some_and(|first| unique_hits.iter().any(|hit| hit.origin != first.origin));
+    if has_conflicting_origin {
         return SourceTargetProviderResult::Blocked(SourceTargetBlock::preproc_ambiguous(
             range,
             unique_hits,
         ));
     }
-    let db = RootDb::new(None);
-    let Some(tokens) =
-        syntax_tokens_for_preproc_hit(&db, model_file, root, offset, precedence, &unique_hits)
-    else {
+    let Some(tokens) = syntax_tokens_for_preproc_hit(root, offset, precedence, &unique_hits) else {
         return SourceTargetProviderResult::Blocked(SourceTargetBlock::preproc_unavailable(range));
     };
     SourceTargetProviderResult::Resolved(SourceTarget::preproc(range, unique_hits, tokens))

--- a/crates/preproc/src/source/model/tests/definition_trace.rs
+++ b/crates/preproc/src/source/model/tests/definition_trace.rs
@@ -90,6 +90,7 @@ fn source_model_uses_direct_trace_definition_when_body_ranges_collide() {
         ],
         include_edges: Vec::new(),
         emitted_tokens: vec![syntax::EmittedToken {
+            emitted_token_index: None,
             raw_text: "2".to_owned(),
             value_text: "2".to_owned(),
             display_text: "2".to_owned(),

--- a/crates/slang/bindings/rust/ffi.rs
+++ b/crates/slang/bindings/rust/ffi.rs
@@ -132,6 +132,8 @@ mod slang_ffi {
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct RawPreprocessorTraceEmittedToken {
+        emitted_token_index: u32,
+        has_emitted_token_index: bool,
         raw_text: String,
         value_text: String,
         display_text: String,

--- a/crates/slang/bindings/rust/ffi/wrapper.cc
+++ b/crates/slang/bindings/rust/ffi/wrapper.cc
@@ -8,7 +8,9 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <limits>
 #include <mutex>
+#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -62,6 +64,7 @@ rust::Vec<rust::String> diagnostic_args(const Diagnostic& diag) {
 
 struct SyntaxTreeSourceInfo {
   const slang::SourceManager* sourceManager;
+  const slang::parsing::PreprocessorTraceSnapshot* preprocessorTrace;
   slang::SourceLocation rootLocation;
 };
 
@@ -174,6 +177,8 @@ constexpr uint8_t TRACE_TOKEN_ORIGIN_STRINGIFICATION = 6;
 
 ::RawPreprocessorTraceEmittedToken empty_preprocessor_trace_emitted_token() {
   ::RawPreprocessorTraceEmittedToken token;
+  token.emitted_token_index = 0;
+  token.has_emitted_token_index = false;
   token.raw_text = rust::String();
   token.value_text = rust::String();
   token.display_text = rust::String();
@@ -507,10 +512,16 @@ template<typename TTokens>
 
 ::RawPreprocessorTraceEmittedToken to_rust_preprocessor_trace_emitted_token(
     slang::parsing::Token token,
-    const slang::SourceManager& sourceManager) {
+    const slang::SourceManager& sourceManager,
+    std::optional<size_t> emittedTokenIndex = std::nullopt) {
   auto result = empty_preprocessor_trace_emitted_token();
   if (!token)
     return result;
+
+  if (emittedTokenIndex && *emittedTokenIndex <= std::numeric_limits<uint32_t>::max()) {
+    result.emitted_token_index = static_cast<uint32_t>(*emittedTokenIndex);
+    result.has_emitted_token_index = true;
+  }
 
   result.raw_text = rust::String(std::string(token.rawText()));
   result.value_text = rust::String(std::string(token.valueText()));
@@ -881,6 +892,20 @@ std::unordered_set<uint32_t> predefine_buffer_ids(
   return bufferIds;
 }
 
+std::optional<size_t> emitted_token_index_for(
+    const slang::parsing::PreprocessorTraceSnapshot* trace,
+    slang::parsing::Token token) {
+  if (!trace || !token)
+    return std::nullopt;
+
+  for (size_t index = 0; index < trace->emittedTokens.size(); index++) {
+    if (trace->emittedTokens[index] == token)
+      return index;
+  }
+
+  return std::nullopt;
+}
+
 ::RawPreprocessorTrace to_rust_preprocessor_trace_snapshot(
     const slang::parsing::PreprocessorTraceSnapshot& trace,
     const slang::SourceManager& sourceManager) {
@@ -917,9 +942,11 @@ std::unordered_set<uint32_t> predefine_buffer_ids(
     }
   }
 
-  for (auto token : trace.emittedTokens)
+  for (size_t index = 0; index < trace.emittedTokens.size(); index++) {
+    auto token = trace.emittedTokens[index];
     result.emitted_tokens.emplace_back(
-        to_rust_preprocessor_trace_emitted_token(token, sourceManager));
+        to_rust_preprocessor_trace_emitted_token(token, sourceManager, index));
+  }
 
   for (auto buffer : sourceManager.getAllBuffers()) {
     auto includedFrom = sourceManager.getIncludedFrom(buffer);
@@ -1127,7 +1154,8 @@ SyntaxTree::SyntaxTree(std::shared_ptr<::slang::syntax::SyntaxTree> tree,
   std::lock_guard lock(syntaxTreeSourceInfoMutex);
   syntaxTreeSourceInfo.emplace(
       &root,
-      SyntaxTreeSourceInfo{&innerTree->sourceManager(), rootLocation});
+      SyntaxTreeSourceInfo{
+          &innerTree->sourceManager(), innerTree->getPreprocessorTrace(), rootLocation});
 }
 
 SyntaxTree::~SyntaxTree() {
@@ -1432,7 +1460,9 @@ std::unique_ptr<SourceRange> SyntaxToken_rangeWithContext(
     sourceInfo = it->second;
   }
 
-  return to_rust_preprocessor_trace_emitted_token(token, *sourceInfo.sourceManager);
+  return to_rust_preprocessor_trace_emitted_token(
+      token, *sourceInfo.sourceManager,
+      emitted_token_index_for(sourceInfo.preprocessorTrace, token));
 }
 
 } // namespace syntax

--- a/crates/slang/bindings/rust/preproc.rs
+++ b/crates/slang/bindings/rust/preproc.rs
@@ -52,6 +52,7 @@ pub struct Event {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EmittedToken {
+    pub emitted_token_index: Option<u32>,
     pub raw_text: String,
     pub value_text: String,
     pub display_text: String,

--- a/crates/slang/bindings/rust/preproc/origin/raw.rs
+++ b/crates/slang/bindings/rust/preproc/origin/raw.rs
@@ -35,6 +35,8 @@ impl EmittedToken {
     #[inline]
     pub(crate) fn from_raw(raw: ffi::RawPreprocessorTraceEmittedToken) -> Self {
         let ffi::RawPreprocessorTraceEmittedToken {
+            emitted_token_index,
+            has_emitted_token_index,
             raw_text,
             value_text,
             display_text,
@@ -61,6 +63,7 @@ impl EmittedToken {
             argument_token_range,
         } = raw;
         Self {
+            emitted_token_index: has_emitted_token_index.then_some(emitted_token_index),
             raw_text,
             value_text,
             display_text,

--- a/crates/slang/bindings/rust/syntax_tree.rs
+++ b/crates/slang/bindings/rust/syntax_tree.rs
@@ -643,11 +643,15 @@ impl SyntaxTokenWithParent<'_> {
     }
 
     #[inline]
-    pub fn preprocessor_trace_origin(&self) -> TokenOrigin {
+    pub fn preprocessor_trace_emitted_token(&self) -> EmittedToken {
         let token = self.tok._ptr.as_ref().get_ref();
         let context = self.parent._ptr.as_ref().get_ref();
         EmittedToken::from_raw(ffi::SyntaxToken::preprocessorTraceOriginWithContext(token, context))
-            .origin
+    }
+
+    #[inline]
+    pub fn preprocessor_trace_origin(&self) -> TokenOrigin {
+        self.preprocessor_trace_emitted_token().origin
     }
 }
 

--- a/crates/slang/bindings/rust/tests.rs
+++ b/crates/slang/bindings/rust/tests.rs
@@ -1253,13 +1253,18 @@ endmodule
     assert_eq!(tokens.len(), 1, "expanded source should contain exactly one parsed 7 token");
     let token = tokens[0];
 
-    let token_origin = token.preprocessor_trace_origin();
+    let token_emitted = token.preprocessor_trace_emitted_token();
+    let token_origin = token_emitted.origin.clone();
     assert!(matches!(token_origin, TokenOrigin::MacroArgument { .. }));
-    let emitted = trace
+    let (emitted_index, emitted) = trace
         .emitted_tokens
         .iter()
-        .find(|token| token.raw_text == "7")
+        .enumerate()
+        .find(|(_, token)| token.raw_text == "7")
         .expect("trace should contain the emitted argument token");
+    let emitted_index = u32::try_from(emitted_index).unwrap();
+    assert_eq!(emitted.emitted_token_index, Some(emitted_index));
+    assert_eq!(token_emitted.emitted_token_index, Some(emitted_index));
     assert_eq!(token_origin, emitted.origin.clone());
 }
 


### PR DESCRIPTION
﻿## Summary

This change makes macro-expanded IDE source targeting select syntax tokens by exact emitted-token identity instead of reconstructing HIR origins from raw syntax-token provenance.

## Details

- Carries `SourceEmittedTokenId` through `ExpansionSourceMap` and `ExpansionSourceHit` while preserving the existing expanded-token index semantics.
- Exposes emitted-token identity from the slang trace binding for both trace emitted tokens and parsed syntax tokens.
- Updates IDE source-target resolution to match macro syntax tokens by emitted-token identity, and keeps same-origin multiple emitted tokens available without treating them as ambiguous.
- Adds regression coverage for a macro argument emitted more than once.

## Validation

- `cargo test -p ide source_targets -- --nocapture`
- `cargo test -p hir macro_file -- --nocapture`
- `cargo test -p slang syntax_token_reports_direct_macro_origin_identity -- --nocapture`
- `cargo test -p preproc source_model_uses_direct_trace_definition_when_body_ranges_collide -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p slang -p preproc -p hir -p ide --all-targets -- -D warnings`