### PR TITLE
fix(ide): unify hover layout

### DIFF
--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -1,7 +1,11 @@
-use hir::{container::InContainer, file::HirFileId, hir_def::expr::Expr, semantics::Semantics};
+use hir::{
+    base_db::source_db::SourceDb, container::InContainer, file::HirFileId, hir_def::expr::Expr,
+    semantics::Semantics,
+};
 use syntax::{
     SyntaxNode, SyntaxTokenWithParent, TokenKind,
     ast::{self, AstNode},
+    has_text_range::HasTextRange,
     token::TokenKindExt,
 };
 use utils::{
@@ -22,7 +26,7 @@ use crate::{
             with_expanded_macro_hover,
         },
     },
-    markup::Markup,
+    markup::{Markup, inline_code},
     render,
     source_targets::{SourceTarget, source_target_at_offset},
 };
@@ -174,6 +178,7 @@ fn handle_definition(
     file_id: HirFileId,
     tp: SyntaxTokenWithParent,
 ) -> Option<Markup> {
+    let token_text = token_text(sema.db, file_id, &tp);
     let def = DefinitionClass::resolve(sema, file_id, tp)?;
     let mut res = Markup::new();
 
@@ -182,22 +187,42 @@ fn handle_definition(
             res.merge(render::render_definition(sema, def));
         }
         DefinitionClass::PortConnShorthand { port, local } => {
-            res.new_subsection("Port");
+            res.title("Port connection shorthand");
+            res.section("Port");
             res.merge(render::render_definition(sema, port));
-            res.horizontal_line();
-            res.new_subsection("Local");
+            res.section("Local");
             res.merge(render::render_definition(sema, local));
         }
         DefinitionClass::Ambiguous(definitions) => {
-            res.print("Ambiguous reference");
-            for definition in definitions {
-                res.horizontal_line();
+            let token_text = token_text.unwrap_or_else(|| "reference".to_string());
+            res.title(&format!("Module reference {}", inline_code(&token_text)));
+            res.push_with_code_fence(&token_text);
+            res.section("Facts");
+            res.fact("Status", "ambiguous");
+            res.fact("Candidates", &definitions.len().to_string());
+            res.section("Candidates");
+            for (idx, definition) in definitions.into_iter().enumerate() {
+                if idx > 0 && !res.as_str().ends_with('\n') {
+                    res.print("\n");
+                }
                 res.merge(render::render_definition_location(sema, definition));
             }
         }
     }
 
     Some(res)
+}
+
+fn token_text(
+    db: &RootDb,
+    file_id: HirFileId,
+    token: &SyntaxTokenWithParent<'_>,
+) -> Option<String> {
+    let range = token.text_range()?;
+    let source = db.file_text(file_id.file_id());
+    let start = usize::from(range.start());
+    let end = usize::from(range.end());
+    source.get(start..end).map(ToString::to_string)
 }
 
 #[cfg(test)]

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -180,32 +180,35 @@ fn handle_definition(
 ) -> Option<Markup> {
     let token_text = token_text(sema.db, file_id, &tp);
     let def = DefinitionClass::resolve(sema, file_id, tp)?;
+    let anchor_file_id = file_id.file_id();
     let mut res = Markup::new();
 
     match def {
         DefinitionClass::Definition(def) => {
-            res.merge(render::render_definition(sema, def));
+            res.merge(render::render_definition(sema, def, anchor_file_id));
         }
         DefinitionClass::PortConnShorthand { port, local } => {
             res.title("Port connection shorthand");
             res.section("Port");
-            res.merge(render::render_definition(sema, port));
+            res.merge(render::render_definition(sema, port, anchor_file_id));
             res.section("Local");
-            res.merge(render::render_definition(sema, local));
+            res.merge(render::render_definition(sema, local, anchor_file_id));
         }
         DefinitionClass::Ambiguous(definitions) => {
             let token_text = token_text.unwrap_or_else(|| "reference".to_string());
+            let candidate_count = definitions.len();
             res.title(&format!("Module reference {}", inline_code(&token_text)));
             res.push_with_code_fence(&token_text);
-            res.section("Facts");
-            res.fact("Status", "ambiguous");
-            res.fact("Candidates", &definitions.len().to_string());
+            res.metadata_line(&format!(
+                "ambiguous reference, {candidate_count} candidate{}",
+                if candidate_count == 1 { "" } else { "s" }
+            ));
             res.section("Candidates");
             for (idx, definition) in definitions.into_iter().enumerate() {
                 if idx > 0 && !res.as_str().ends_with('\n') {
                     res.print("\n");
                 }
-                res.merge(render::render_definition_location(sema, definition));
+                res.merge(render::render_definition_location(sema, definition, anchor_file_id));
             }
         }
     }

--- a/crates/ide/src/hover/include.rs
+++ b/crates/ide/src/hover/include.rs
@@ -1,11 +1,13 @@
-use hir::{
-    base_db::source_db::SourceDb,
-    preproc::{IncludeDirective, IncludeTarget, include_directives_at},
-};
+use hir::preproc::{IncludeDirective, IncludeTarget, include_directives_at};
 use utils::line_index::TextSize;
 use vfs::FileId;
 
-use crate::{RangeInfo, db::root_db::RootDb, markup::Markup};
+use crate::{
+    RangeInfo,
+    db::root_db::RootDb,
+    markup::{Markup, inline_code},
+    render,
+};
 
 pub(super) fn dispatch_include_hover_target(
     db: &RootDb,
@@ -22,21 +24,23 @@ pub(super) fn render_include_hover(
 ) -> Option<RangeInfo<Markup>> {
     let range = includes.first()?.range;
     let mut markup = Markup::new();
-    markup.print("Include");
-    for include in includes {
-        markup.newline();
+    for (idx, include) in includes.into_iter().enumerate() {
+        if idx > 0 {
+            markup.horizontal_line();
+        }
         match include.target {
             IncludeTarget::Literal { path, resolved_file } => {
-                markup.push_with_backticks(path.as_str());
-                if let Some(target_file_id) = resolved_file
-                    && let Some(path) = db.file_path(target_file_id)
-                {
-                    markup.newline();
-                    markup.print(&path.to_string());
-                }
+                markup.title(&format!("Include {}", inline_code(path.as_str())));
+                markup.push_with_code_fence(&format!("`include \"{}\"", path.as_str()));
+                markup.section("Facts");
+                let resolved = resolved_file
+                    .and_then(|target_file_id| render::source_file_link(db, target_file_id))
+                    .unwrap_or_else(|| "unresolved".to_string());
+                markup.fact("Resolves to", &resolved);
             }
             IncludeTarget::Token { raw } => {
-                markup.push_with_backticks(raw.as_str());
+                markup.title(&format!("Include {}", inline_code(raw.as_str())));
+                markup.push_with_code_fence(&format!("`include {}", raw.as_str()));
             }
         }
     }

--- a/crates/ide/src/hover/include.rs
+++ b/crates/ide/src/hover/include.rs
@@ -32,11 +32,12 @@ pub(super) fn render_include_hover(
             IncludeTarget::Literal { path, resolved_file } => {
                 markup.title(&format!("Include {}", inline_code(path.as_str())));
                 markup.push_with_code_fence(&format!("`include \"{}\"", path.as_str()));
-                markup.section("Facts");
                 let resolved = resolved_file
-                    .and_then(|target_file_id| render::source_file_link(db, target_file_id))
+                    .and_then(|target_file_id| {
+                        render::source_file_link(db, target_file_id, include.file_id)
+                    })
                     .unwrap_or_else(|| "unresolved".to_string());
-                markup.fact("Resolves to", &resolved);
+                markup.metadata_line(&format!("resolves to {resolved}"));
             }
             IncludeTarget::Token { raw } => {
                 markup.title(&format!("Include {}", inline_code(raw.as_str())));

--- a/crates/ide/src/hover/macro_hover.rs
+++ b/crates/ide/src/hover/macro_hover.rs
@@ -11,8 +11,6 @@ use crate::{RangeInfo, db::root_db::RootDb, markup::Markup};
 mod expansion;
 mod markup;
 
-const MACRO_EXPANSION_SEPARATOR: &str = "--------------------";
-
 #[cfg(test)]
 pub(super) use expansion::macro_expansion_hover_text;
 pub(super) use expansion::with_expanded_macro_hover;

--- a/crates/ide/src/hover/macro_hover/expansion.rs
+++ b/crates/ide/src/hover/macro_hover/expansion.rs
@@ -6,10 +6,7 @@ use hir::{
 use utils::line_index::{TextRange, TextSize};
 use vfs::FileId;
 
-use super::markup::{
-    render_macro_expansion_header, render_macro_expansion_separator,
-    render_macro_expansion_source_link,
-};
+use super::markup::{macro_expansion_source_fact, render_macro_expansion_header};
 use crate::{RangeInfo, db::root_db::RootDb, markup::Markup};
 
 pub(in crate::hover) fn with_expanded_macro_hover(
@@ -97,20 +94,19 @@ fn expanded_macro_markup(db: &RootDb, expansions: &[ExpandedMacro]) -> Markup {
 
 fn render_expanded_macro(db: &RootDb, markup: &mut Markup, expansion: &ExpandedMacro) {
     if !markup.is_empty() {
-        markup.newline();
+        markup.horizontal_line();
     }
     render_macro_expansion_header(markup, &expansion.metadata.definition);
-    render_macro_expansion_separator(markup);
-    markup.print("Expands to");
-    markup.newline();
-    markup.push_with_code_fence(&macro_expansion_hover_text(expansion.text.as_str()));
-    render_macro_expansion_separator(markup);
-    render_macro_expansion_source_link(
+    markup.section("Facts");
+    let source = macro_expansion_source_fact(
         db,
-        markup,
         &expansion.metadata.definition,
         expansion.metadata.call_file_id,
-    );
+    )
+    .unwrap_or_else(|| "unavailable".to_string());
+    markup.fact("Source", &source);
+    markup.section("Expansion");
+    markup.push_with_code_fence(&macro_expansion_hover_text(expansion.text.as_str()));
 }
 
 pub(in crate::hover) fn macro_expansion_hover_text(text: &str) -> String {

--- a/crates/ide/src/hover/macro_hover/expansion.rs
+++ b/crates/ide/src/hover/macro_hover/expansion.rs
@@ -97,14 +97,13 @@ fn render_expanded_macro(db: &RootDb, markup: &mut Markup, expansion: &ExpandedM
         markup.horizontal_line();
     }
     render_macro_expansion_header(markup, &expansion.metadata.definition);
-    markup.section("Facts");
     let source = macro_expansion_source_fact(
         db,
         &expansion.metadata.definition,
         expansion.metadata.call_file_id,
     )
     .unwrap_or_else(|| "unavailable".to_string());
-    markup.fact("Source", &source);
+    markup.metadata_line(&format!("from {source}"));
     markup.section("Expansion");
     markup.push_with_code_fence(&macro_expansion_hover_text(expansion.text.as_str()));
 }

--- a/crates/ide/src/hover/macro_hover/markup.rs
+++ b/crates/ide/src/hover/macro_hover/markup.rs
@@ -1,8 +1,5 @@
 use hir::{
-    base_db::{
-        source_db::{SourceDb, SourceRootDb},
-        source_root::SourceRootRole,
-    },
+    base_db::source_db::SourceDb,
     hir_def::macro_file::MacroExpansionDefinition,
     preproc::{MacroDefinition, MacroParamDefinition},
 };
@@ -10,17 +7,10 @@ use vfs::FileId;
 
 use super::expansion::macro_expansion_hover_text;
 use crate::{
-    db::{line_index_db::LineIndexDb, root_db::RootDb},
-    markup::{
-        Markup, display_hover_path, display_project_path, file_link_target, inline_code,
-        markdown_link,
-    },
+    db::root_db::RootDb,
+    markup::{Markup, inline_code},
+    render,
 };
-
-struct MacroSourceLink {
-    label: String,
-    target: String,
-}
 
 pub(super) fn render_macro_expansion_header(
     markup: &mut Markup,
@@ -92,61 +82,6 @@ fn fallback_macro_definition_line(definition: &MacroDefinition) -> String {
     line
 }
 
-fn macro_file_source_link(
-    db: &RootDb,
-    file_id: FileId,
-    anchor_file_id: FileId,
-) -> Option<MacroSourceLink> {
-    let source_root = db.source_root(db.source_root_id(file_id));
-    let label = if matches!(source_root.role(), SourceRootRole::Local)
-        && let Some(label) = local_source_root_path_label(db, file_id, anchor_file_id)
-    {
-        label
-    } else {
-        source_root
-            .path_for_file(&file_id)
-            .map(|path| display_hover_path(path.to_string()))
-            .or_else(|| db.file_path(file_id).map(|path| display_hover_path(path.to_string())))?
-    };
-    let target = db
-        .file_path(file_id)
-        .map(|path| file_link_target(&path.to_string()))
-        .unwrap_or_else(|| label.clone());
-    Some(MacroSourceLink { label, target })
-}
-
-fn local_source_root_path_label(
-    db: &RootDb,
-    file_id: FileId,
-    anchor_file_id: FileId,
-) -> Option<String> {
-    let source_root = db.source_root(db.source_root_id(file_id));
-    let source_path = source_root.path_for_file(&file_id)?;
-    let Some(target_path) = source_path.as_abs_path() else {
-        return Some(display_project_path(source_path.to_string()));
-    };
-
-    let anchor_source_root = db.source_root(db.source_root_id(anchor_file_id));
-    let anchor_path = anchor_source_root.path_for_file(&anchor_file_id)?.as_abs_path()?;
-    let mut common_dir = anchor_path.parent()?.to_path_buf();
-    while !target_path.starts_with(common_dir.as_path()) {
-        if !common_dir.pop() {
-            return None;
-        }
-    }
-    if !has_normal_path_component(common_dir.as_path()) {
-        return None;
-    }
-
-    target_path
-        .strip_prefix(common_dir.as_path())
-        .map(|path| display_project_path(path.as_ref().display().to_string()))
-}
-
-fn has_normal_path_component(path: &utils::paths::AbsPath) -> bool {
-    path.components().any(|component| matches!(component, utils::paths::Utf8Component::Normal(_)))
-}
-
 pub(super) fn macro_param_definition_markup(definition: &MacroParamDefinition) -> Markup {
     macro_param_definitions_markup(std::slice::from_ref(definition))
 }
@@ -156,8 +91,10 @@ pub(super) fn macro_param_definitions_markup(definitions: &[MacroParamDefinition
     if definitions.len() == 1 {
         let definition = &definitions[0];
         markup.title(&format!("Macro parameter {}", inline_code(definition.name.as_str())));
-        markup.section("Facts");
-        markup.fact("Macro", &inline_code(definition.macro_definition.name.as_str()));
+        markup.metadata_line(&format!(
+            "in macro {}",
+            inline_code(definition.macro_definition.name.as_str())
+        ));
         return markup;
     }
 
@@ -218,10 +155,9 @@ fn render_macro_definition_display(
 ) {
     markup.title(&macro_title(definition.name.as_str()));
     markup.push_with_code_fence(&macro_definition_line(db, definition));
-    markup.section("Facts");
     let source = macro_definition_source_fact(db, definition, anchor_file_id)
         .unwrap_or_else(|| "unavailable".to_string());
-    markup.fact("Source", &source);
+    markup.metadata_line(&format!("from {source}"));
 }
 
 fn macro_definition_source_fact(
@@ -241,7 +177,7 @@ pub(super) fn macro_expansion_source_fact(
         MacroExpansionDefinition::Source(definition) => {
             macro_definition_source_fact(db, definition, anchor_file_id)
         }
-        MacroExpansionDefinition::Builtin { .. } => Some("Builtin".to_string()),
+        MacroExpansionDefinition::Builtin { .. } => Some("builtin".to_string()),
     }
 }
 
@@ -251,7 +187,5 @@ fn macro_file_source_fact(
     offset: utils::line_index::TextSize,
     anchor_file_id: FileId,
 ) -> Option<String> {
-    let source = macro_file_source_link(db, file_id, anchor_file_id)?;
-    let line = db.line_index(file_id).try_line_col(offset)?.line + 1;
-    Some(format!("{} line {line}", markdown_link(&source.label, &source.target)))
+    render::source_line_link(db, file_id, offset, anchor_file_id)
 }

--- a/crates/ide/src/hover/macro_hover/markup.rs
+++ b/crates/ide/src/hover/macro_hover/markup.rs
@@ -9,7 +9,13 @@ use hir::{
 use vfs::FileId;
 
 use super::expansion::macro_expansion_hover_text;
-use crate::{db::root_db::RootDb, markup::Markup};
+use crate::{
+    db::{line_index_db::LineIndexDb, root_db::RootDb},
+    markup::{
+        Markup, display_hover_path, display_project_path, file_link_target, inline_code,
+        markdown_link,
+    },
+};
 
 struct MacroSourceLink {
     label: String,
@@ -20,6 +26,7 @@ pub(super) fn render_macro_expansion_header(
     markup: &mut Markup,
     definition: &MacroExpansionDefinition,
 ) {
+    markup.title(&macro_expansion_title(definition));
     match definition {
         MacroExpansionDefinition::Source(definition) => {
             markup.push_with_code_fence(&macro_signature(definition));
@@ -30,10 +37,15 @@ pub(super) fn render_macro_expansion_header(
     }
 }
 
-pub(super) fn render_macro_expansion_separator(markup: &mut Markup) {
-    markup.newline();
-    markup.print(super::MACRO_EXPANSION_SEPARATOR);
-    markup.newline();
+fn macro_expansion_title(definition: &MacroExpansionDefinition) -> String {
+    match definition {
+        MacroExpansionDefinition::Source(definition) => macro_title(definition.name.as_str()),
+        MacroExpansionDefinition::Builtin { name, .. } => macro_title(name.as_str()),
+    }
+}
+
+fn macro_title(name: &str) -> String {
+    format!("Macro {}", inline_code(name))
 }
 
 fn macro_signature(definition: &MacroDefinition) -> String {
@@ -135,22 +147,6 @@ fn has_normal_path_component(path: &utils::paths::AbsPath) -> bool {
     path.components().any(|component| matches!(component, utils::paths::Utf8Component::Normal(_)))
 }
 
-fn display_project_path(mut path: String) -> String {
-    while path.starts_with('/') {
-        path.remove(0);
-    }
-    display_hover_path(path)
-}
-
-fn display_hover_path(path: String) -> String {
-    path.replace('\\', "/")
-}
-
-fn file_link_target(path: &str) -> String {
-    let path = display_hover_path(path.to_owned());
-    if path.starts_with('/') { format!("file://{path}") } else { format!("file:///{path}") }
-}
-
 pub(super) fn macro_param_definition_markup(definition: &MacroParamDefinition) -> Markup {
     macro_param_definitions_markup(std::slice::from_ref(definition))
 }
@@ -158,20 +154,23 @@ pub(super) fn macro_param_definition_markup(definition: &MacroParamDefinition) -
 pub(super) fn macro_param_definitions_markup(definitions: &[MacroParamDefinition]) -> Markup {
     let mut markup = Markup::new();
     if definitions.len() == 1 {
-        markup.print("Macro parameter");
-        markup.newline();
-        markup.push_with_backticks(definitions[0].name.as_str());
-        markup.print(" of ");
-        markup.push_with_backticks(definitions[0].macro_definition.name.as_str());
+        let definition = &definitions[0];
+        markup.title(&format!("Macro parameter {}", inline_code(definition.name.as_str())));
+        markup.section("Facts");
+        markup.fact("Macro", &inline_code(definition.macro_definition.name.as_str()));
         return markup;
     }
 
-    markup.print("Macro parameters");
+    markup.title("Macro parameters");
+    markup.section("Candidates");
     for definition in definitions {
-        markup.newline();
-        markup.push_with_backticks(definition.name.as_str());
+        if !markup.as_str().ends_with('\n') {
+            markup.print("\n");
+        }
+        markup.print("- ");
+        markup.print(&inline_code(definition.name.as_str()));
         markup.print(" of ");
-        markup.push_with_backticks(definition.macro_definition.name.as_str());
+        markup.print(&inline_code(definition.macro_definition.name.as_str()));
     }
     markup
 }
@@ -195,13 +194,17 @@ pub(super) fn macro_definitions_markup(
         return markup;
     }
 
-    markup.print("Macro definitions");
+    markup.title("Macro definitions");
+    markup.section("Candidates");
     for definition in definitions {
-        markup.newline();
-        markup.push_with_backticks(definition.name.as_str());
-        if let Some(path) = db.file_path(definition.file_id) {
+        if !markup.as_str().ends_with('\n') {
+            markup.print("\n");
+        }
+        markup.print("- ");
+        markup.print(&inline_code(definition.name.as_str()));
+        if let Some(source) = macro_definition_source_fact(db, definition, anchor_file_id) {
             markup.print(" ");
-            markup.print(&path.to_string());
+            markup.print(&source);
         }
     }
     markup
@@ -213,53 +216,42 @@ fn render_macro_definition_display(
     anchor_file_id: FileId,
     definition: &MacroDefinition,
 ) {
+    markup.title(&macro_title(definition.name.as_str()));
     markup.push_with_code_fence(&macro_definition_line(db, definition));
-    render_macro_expansion_separator(markup);
-    render_macro_source_link(db, markup, definition, anchor_file_id);
+    markup.section("Facts");
+    let source = macro_definition_source_fact(db, definition, anchor_file_id)
+        .unwrap_or_else(|| "unavailable".to_string());
+    markup.fact("Source", &source);
 }
 
-pub(super) fn render_macro_source_link(
+fn macro_definition_source_fact(
     db: &RootDb,
-    markup: &mut Markup,
     definition: &MacroDefinition,
     anchor_file_id: FileId,
-) {
-    render_macro_file_source_link(db, markup, definition.file_id, anchor_file_id);
+) -> Option<String> {
+    macro_file_source_fact(db, definition.file_id, definition.source_range.start(), anchor_file_id)
 }
 
-pub(super) fn render_macro_expansion_source_link(
+pub(super) fn macro_expansion_source_fact(
     db: &RootDb,
-    markup: &mut Markup,
     definition: &MacroExpansionDefinition,
     anchor_file_id: FileId,
-) {
-    let MacroExpansionDefinition::Source(definition) = definition else {
-        return;
-    };
-    render_macro_file_source_link(db, markup, definition.file_id, anchor_file_id);
+) -> Option<String> {
+    match definition {
+        MacroExpansionDefinition::Source(definition) => {
+            macro_definition_source_fact(db, definition, anchor_file_id)
+        }
+        MacroExpansionDefinition::Builtin { .. } => Some("Builtin".to_string()),
+    }
 }
 
-fn render_macro_file_source_link(
+fn macro_file_source_fact(
     db: &RootDb,
-    markup: &mut Markup,
     file_id: FileId,
+    offset: utils::line_index::TextSize,
     anchor_file_id: FileId,
-) {
-    let Some(source) = macro_file_source_link(db, file_id, anchor_file_id) else {
-        return;
-    };
-    markup.print_with_strong("Macro");
-    markup.print(" from [");
-    markup.print(&markdown_link_label(&source.label));
-    markup.print("](<");
-    markup.print(&markdown_link_destination(&source.target));
-    markup.print(">)");
-}
-
-fn markdown_link_label(label: &str) -> String {
-    label.replace('\\', "\\\\").replace('[', "\\[").replace(']', "\\]")
-}
-
-fn markdown_link_destination(destination: &str) -> String {
-    destination.replace('>', "%3E")
+) -> Option<String> {
+    let source = macro_file_source_link(db, file_id, anchor_file_id)?;
+    let line = db.line_index(file_id).try_line_col(offset)?.line + 1;
+    Some(format!("{} line {line}", markdown_link(&source.label, &source.target)))
 }

--- a/crates/ide/src/markup.rs
+++ b/crates/ide/src/markup.rs
@@ -73,14 +73,9 @@ impl Markup {
         self.text.push('\n');
     }
 
-    pub fn fact(&mut self, key: &str, value: &str) {
-        if !self.text.ends_with('\n') {
-            self.text.push('\n');
-        }
-        self.text.push_str("- ");
-        self.text.push_str(key);
-        self.text.push_str(": ");
-        self.text.push_str(value);
+    pub fn metadata_line(&mut self, contents: &str) {
+        self.horizontal_line();
+        self.text.push_str(contents);
     }
 
     pub fn new_section(&mut self, title: &str) {

--- a/crates/ide/src/markup.rs
+++ b/crates/ide/src/markup.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+const HOVER_BLOCK_DIVIDER: &str = "---";
+
 #[derive(Clone, Default, Debug, Hash, PartialEq, Eq)]
 pub struct Markup {
     text: String,
@@ -46,6 +48,11 @@ impl Markup {
         self.text.push_str(contents);
     }
 
+    pub fn title(&mut self, contents: &str) {
+        self.text.push_str(contents);
+        self.newline();
+    }
+
     pub fn as_str(&self) -> &str {
         self.text.as_str()
     }
@@ -55,7 +62,25 @@ impl Markup {
     }
 
     pub fn horizontal_line(&mut self) {
-        self.text.push_str("\n\n---------\n\n");
+        self.text.push_str("\n\n");
+        self.text.push_str(HOVER_BLOCK_DIVIDER);
+        self.text.push_str("\n\n");
+    }
+
+    pub fn section(&mut self, title: &str) {
+        self.horizontal_line();
+        self.text.push_str(title);
+        self.text.push('\n');
+    }
+
+    pub fn fact(&mut self, key: &str, value: &str) {
+        if !self.text.ends_with('\n') {
+            self.text.push('\n');
+        }
+        self.text.push_str("- ");
+        self.text.push_str(key);
+        self.text.push_str(": ");
+        self.text.push_str(value);
     }
 
     pub fn new_section(&mut self, title: &str) {
@@ -83,22 +108,48 @@ impl Markup {
     }
 
     pub fn push_with_backticks(&mut self, contents: &str) {
-        let delimiter_len = max_backtick_run(contents).saturating_add(1);
-        let delimiter = "`".repeat(delimiter_len);
-        self.text.push_str(&delimiter);
-        if contents.contains('`') {
-            self.text.push(' ');
-        }
-        self.text.push_str(contents);
-        if contents.contains('`') {
-            self.text.push(' ');
-        }
-        self.text.push_str(&delimiter);
+        self.text.push_str(&inline_code(contents));
     }
 
     pub fn is_empty(&self) -> bool {
         self.text.is_empty()
     }
+}
+
+pub(crate) fn inline_code(contents: &str) -> String {
+    let delimiter_len = max_backtick_run(contents).saturating_add(1);
+    let delimiter = "`".repeat(delimiter_len);
+    let padding = if contents.contains('`') { " " } else { "" };
+    format!("{delimiter}{padding}{contents}{padding}{delimiter}")
+}
+
+pub(crate) fn markdown_link(label: &str, destination: &str) -> String {
+    format!("[{}](<{}>)", markdown_link_label(label), markdown_link_destination(destination))
+}
+
+pub(crate) fn display_hover_path(path: impl Into<String>) -> String {
+    path.into().replace('\\', "/")
+}
+
+pub(crate) fn display_project_path(path: impl Into<String>) -> String {
+    let mut path = display_hover_path(path);
+    while path.starts_with('/') {
+        path.remove(0);
+    }
+    path
+}
+
+pub(crate) fn file_link_target(path: &str) -> String {
+    let path = display_hover_path(path.to_owned());
+    if path.starts_with('/') { format!("file://{path}") } else { format!("file:///{path}") }
+}
+
+fn markdown_link_label(label: &str) -> String {
+    label.replace('\\', "\\\\").replace('[', "\\[").replace(']', "\\]")
+}
+
+fn markdown_link_destination(destination: &str) -> String {
+    destination.replace('>', "%3E")
 }
 
 fn max_backtick_run(contents: &str) -> usize {

--- a/crates/ide/src/render.rs
+++ b/crates/ide/src/render.rs
@@ -36,7 +36,7 @@ use utils::get::GetRef;
 use crate::{
     db::{line_index_db::LineIndexDb, root_db::RootDb},
     definitions::{Definition, DefinitionOrigin},
-    markup::Markup,
+    markup::{Markup, display_project_path, file_link_target, inline_code, markdown_link},
     module_resolution::resolve_module_name,
 };
 
@@ -164,6 +164,7 @@ pub(crate) fn render_definition_location(sema: &Semantics<RootDb>, def: Definiti
         if idx > 0 {
             res.print("\n");
         }
+        res.print("- ");
         res.print(&location);
     }
     res
@@ -171,41 +172,107 @@ pub(crate) fn render_definition_location(sema: &Semantics<RootDb>, def: Definiti
 
 fn render_def_origin_location(db: &RootDb, origin: &DefinitionOrigin) -> Option<String> {
     let InFile { value: range, file_id } = origin.range(db)?;
-    let file_id = file_id.file_id();
-    let source_root = db.source_root(db.source_root_id(file_id));
-    let path = source_root
-        .path_for_file(&file_id)
-        .map(ToString::to_string)
-        .or_else(|| db.file_path(file_id).map(|path| path.to_string()))
-        .unwrap_or_else(|| format!("{file_id:?}"));
-    let line = db.line_index(file_id).try_line_col(range.start())?.line + 1;
+    source_line_link(db, file_id.file_id(), range.start())
+}
 
-    Some(format!("{path}:{line}"))
+pub(crate) fn source_file_link(db: &RootDb, file_id: vfs::FileId) -> Option<String> {
+    let source_root = db.source_root(db.source_root_id(file_id));
+    let label = source_root
+        .path_for_file(&file_id)
+        .map(|path| display_project_path(path.to_string()))
+        .or_else(|| db.file_path(file_id).map(|path| display_project_path(path.to_string())))?;
+    let target = db
+        .file_path(file_id)
+        .map(|path| file_link_target(&path.to_string()))
+        .unwrap_or_else(|| label.clone());
+
+    Some(markdown_link(&label, &target))
+}
+
+pub(crate) fn source_line_link(
+    db: &RootDb,
+    file_id: vfs::FileId,
+    offset: utils::line_index::TextSize,
+) -> Option<String> {
+    let line = db.line_index(file_id).try_line_col(offset)?.line + 1;
+    Some(format!("{} line {line}", source_file_link(db, file_id)?))
 }
 
 fn render_def_origin(sema: &Semantics<RootDb>, origin: &DefinitionOrigin) -> Markup {
     let mut res = Markup::new();
-    let mut has_signature = false;
 
+    if let Some(title) = render_definition_title(sema.db, origin) {
+        res.title(&title);
+    }
     if let Some(signature) = render_signature(sema, origin) {
         res.push_with_code_fence(&signature);
-        has_signature = true;
     }
 
-    let containers = render_containers(sema, origin);
-    if has_signature && !containers.is_empty() {
-        res.horizontal_line();
+    let mut facts = Vec::new();
+    if let Some(scope) = render_scope_fact(sema, origin) {
+        facts.push(("Scope", scope));
     }
-    res.merge(containers);
+    if let Some(source) = render_def_origin_location(sema.db, origin) {
+        facts.push(("Source", source));
+    }
 
+    if !facts.is_empty() {
+        res.section("Facts");
+        for (key, value) in facts {
+            res.fact(key, &value);
+        }
+    }
     if let Some(markup) = render_side_comments(sema, origin) {
         if !res.is_empty() {
-            res.horizontal_line();
+            res.section("Documentation");
         }
         res.merge(markup);
     }
 
     res
+}
+
+fn render_definition_title(db: &RootDb, origin: &DefinitionOrigin) -> Option<String> {
+    let name = origin.name(db)?;
+    let kind = match origin {
+        DefinitionOrigin::ModuleId(_) => "Module",
+        DefinitionOrigin::Config(_) => "Config",
+        DefinitionOrigin::Library(_) => "Library",
+        DefinitionOrigin::Udp(_) => "Primitive",
+        DefinitionOrigin::BlockId(_) => "Block",
+        DefinitionOrigin::GenerateBlockId(_) => "Generate block",
+        DefinitionOrigin::SubroutineId(subroutine_id) => match db.subroutine(*subroutine_id).kind {
+            SubroutineKind::Task => "Task",
+            SubroutineKind::Function { .. } => "Function",
+        },
+        DefinitionOrigin::SubroutinePort(_) | DefinitionOrigin::NonAnsiPort(_) => "Port",
+        DefinitionOrigin::Decl(decl_id) => render_decl_title_kind(db, *decl_id)?,
+        DefinitionOrigin::Typedef(_) => "Typedef",
+        DefinitionOrigin::Instance(_) => "Instance",
+        DefinitionOrigin::Stmt(_) => "Statement",
+    };
+
+    Some(format!("{kind} {}", inline_code(name.as_str())))
+}
+
+fn render_decl_title_kind(db: &RootDb, decl_id: InContainer<DeclId>) -> Option<&'static str> {
+    let container = decl_id.cont_id.to_container(db);
+    let decl = container.get(decl_id.value);
+
+    Some(match decl.parent {
+        DeclaratorParent::PortDeclId(_) => "Port",
+        DeclaratorParent::DeclarationId(parent) => match container.get(parent) {
+            Declaration::ParamDecl(param_decl) => match param_decl.kind.keyword() {
+                "parameter" => "Parameter",
+                "localparam" => "Localparam",
+                _ => "Parameter",
+            },
+            Declaration::GenvarDecl(_) => "Genvar",
+            Declaration::SpecparamDecl(_) => "Specparam",
+            Declaration::DataDecl(_) | Declaration::NetDecl(_) => "Declaration",
+        },
+        DeclaratorParent::StmtId(_) => "Variable",
+    })
 }
 
 fn render_signature(sema: &Semantics<RootDb>, origin: &DefinitionOrigin) -> Option<String> {
@@ -560,12 +627,10 @@ fn render_side_comments(sema: &Semantics<'_, RootDb>, origin: &DefinitionOrigin)
     }
 }
 
-fn render_containers(sema: &Semantics<RootDb>, origin: &DefinitionOrigin) -> Markup {
+fn render_scope_fact(sema: &Semantics<RootDb>, origin: &DefinitionOrigin) -> Option<String> {
     // elaboration?
     let db = sema.db;
-    let Some(InFile { value: range, .. }) = origin.range(db) else {
-        return Markup::new();
-    };
+    let InFile { value: range, .. } = origin.range(db)?;
     let cont_id = origin.container_id(db);
 
     let mut containers = Vec::new();
@@ -590,11 +655,8 @@ fn render_containers(sema: &Semantics<RootDb>, origin: &DefinitionOrigin) -> Mar
         }
     }
 
-    let mut ans = Markup::new();
     if containers.is_empty() {
-        return ans;
+        return None;
     }
-    ans.print("in ");
-    ans.push_with_backticks(&containers.into_iter().rev().join(" > "));
-    ans
+    Some(inline_code(&containers.into_iter().rev().join(" > ")))
 }

--- a/crates/ide/src/render.rs
+++ b/crates/ide/src/render.rs
@@ -136,9 +136,13 @@ fn render_svint_as_ieee754(svint: &SVInt) -> Option<String> {
     }
 }
 
-pub(crate) fn render_definition(sema: &Semantics<RootDb>, def: Definition) -> Markup {
+pub(crate) fn render_definition(
+    sema: &Semantics<RootDb>,
+    def: Definition,
+    anchor_file_id: vfs::FileId,
+) -> Markup {
     def.def_origins().into_iter().fold(Markup::new(), |mut res, origin| {
-        let origin = render_def_origin(sema, &origin);
+        let origin = render_def_origin(sema, &origin, anchor_file_id);
 
         if !res.is_empty() && !origin.is_empty() {
             res.newline();
@@ -149,12 +153,16 @@ pub(crate) fn render_definition(sema: &Semantics<RootDb>, def: Definition) -> Ma
     })
 }
 
-pub(crate) fn render_definition_location(sema: &Semantics<RootDb>, def: Definition) -> Markup {
+pub(crate) fn render_definition_location(
+    sema: &Semantics<RootDb>,
+    def: Definition,
+    anchor_file_id: vfs::FileId,
+) -> Markup {
     let db = sema.db;
     let mut locations = def
         .def_origins()
         .into_iter()
-        .filter_map(|origin| render_def_origin_location(db, &origin))
+        .filter_map(|origin| render_def_origin_location(db, &origin, anchor_file_id))
         .collect_vec();
     locations.sort();
     locations.dedup();
@@ -170,17 +178,21 @@ pub(crate) fn render_definition_location(sema: &Semantics<RootDb>, def: Definiti
     res
 }
 
-fn render_def_origin_location(db: &RootDb, origin: &DefinitionOrigin) -> Option<String> {
+fn render_def_origin_location(
+    db: &RootDb,
+    origin: &DefinitionOrigin,
+    anchor_file_id: vfs::FileId,
+) -> Option<String> {
     let InFile { value: range, file_id } = origin.range(db)?;
-    source_line_link(db, file_id.file_id(), range.start())
+    source_line_link(db, file_id.file_id(), range.start(), anchor_file_id)
 }
 
-pub(crate) fn source_file_link(db: &RootDb, file_id: vfs::FileId) -> Option<String> {
-    let source_root = db.source_root(db.source_root_id(file_id));
-    let label = source_root
-        .path_for_file(&file_id)
-        .map(|path| display_project_path(path.to_string()))
-        .or_else(|| db.file_path(file_id).map(|path| display_project_path(path.to_string())))?;
+pub(crate) fn source_file_link(
+    db: &RootDb,
+    file_id: vfs::FileId,
+    anchor_file_id: vfs::FileId,
+) -> Option<String> {
+    let label = source_file_label(db, file_id, anchor_file_id)?;
     let target = db
         .file_path(file_id)
         .map(|path| file_link_target(&path.to_string()))
@@ -193,12 +205,62 @@ pub(crate) fn source_line_link(
     db: &RootDb,
     file_id: vfs::FileId,
     offset: utils::line_index::TextSize,
+    anchor_file_id: vfs::FileId,
 ) -> Option<String> {
     let line = db.line_index(file_id).try_line_col(offset)?.line + 1;
-    Some(format!("{} line {line}", source_file_link(db, file_id)?))
+    Some(format!("{} line {line}", source_file_link(db, file_id, anchor_file_id)?))
 }
 
-fn render_def_origin(sema: &Semantics<RootDb>, origin: &DefinitionOrigin) -> Markup {
+fn source_file_label(
+    db: &RootDb,
+    file_id: vfs::FileId,
+    anchor_file_id: vfs::FileId,
+) -> Option<String> {
+    if let Some(label) = relative_source_file_label(db, file_id, anchor_file_id) {
+        return Some(label);
+    }
+
+    let source_root = db.source_root(db.source_root_id(file_id));
+    source_root
+        .path_for_file(&file_id)
+        .map(|path| display_project_path(path.to_string()))
+        .or_else(|| db.file_path(file_id).map(|path| display_project_path(path.to_string())))
+}
+
+fn relative_source_file_label(
+    db: &RootDb,
+    file_id: vfs::FileId,
+    anchor_file_id: vfs::FileId,
+) -> Option<String> {
+    let source_root = db.source_root(db.source_root_id(file_id));
+    let target_path = source_root.path_for_file(&file_id)?.as_abs_path()?;
+
+    let anchor_source_root = db.source_root(db.source_root_id(anchor_file_id));
+    let anchor_path = anchor_source_root.path_for_file(&anchor_file_id)?.as_abs_path()?;
+    let mut common_dir = anchor_path.parent()?.to_path_buf();
+    while !target_path.starts_with(common_dir.as_path()) {
+        if !common_dir.pop() {
+            return None;
+        }
+    }
+    if !has_normal_path_component(common_dir.as_path()) {
+        return None;
+    }
+
+    target_path
+        .strip_prefix(common_dir.as_path())
+        .map(|path| display_project_path(path.as_ref().display().to_string()))
+}
+
+fn has_normal_path_component(path: &utils::paths::AbsPath) -> bool {
+    path.components().any(|component| matches!(component, utils::paths::Utf8Component::Normal(_)))
+}
+
+fn render_def_origin(
+    sema: &Semantics<RootDb>,
+    origin: &DefinitionOrigin,
+    anchor_file_id: vfs::FileId,
+) -> Markup {
     let mut res = Markup::new();
 
     if let Some(title) = render_definition_title(sema.db, origin) {
@@ -208,19 +270,8 @@ fn render_def_origin(sema: &Semantics<RootDb>, origin: &DefinitionOrigin) -> Mar
         res.push_with_code_fence(&signature);
     }
 
-    let mut facts = Vec::new();
-    if let Some(scope) = render_scope_fact(sema, origin) {
-        facts.push(("Scope", scope));
-    }
-    if let Some(source) = render_def_origin_location(sema.db, origin) {
-        facts.push(("Source", source));
-    }
-
-    if !facts.is_empty() {
-        res.section("Facts");
-        for (key, value) in facts {
-            res.fact(key, &value);
-        }
+    if let Some(metadata) = render_definition_metadata(sema, origin, anchor_file_id) {
+        res.metadata_line(&metadata);
     }
     if let Some(markup) = render_side_comments(sema, origin) {
         if !res.is_empty() {
@@ -659,4 +710,19 @@ fn render_scope_fact(sema: &Semantics<RootDb>, origin: &DefinitionOrigin) -> Opt
         return None;
     }
     Some(inline_code(&containers.into_iter().rev().join(" > ")))
+}
+
+fn render_definition_metadata(
+    sema: &Semantics<RootDb>,
+    origin: &DefinitionOrigin,
+    anchor_file_id: vfs::FileId,
+) -> Option<String> {
+    let mut parts = Vec::new();
+    if let Some(scope) = render_scope_fact(sema, origin) {
+        parts.push(format!("in {scope}"));
+    }
+    if let Some(source) = render_def_origin_location(sema.db, origin, anchor_file_id) {
+        parts.push(format!("from {source}"));
+    }
+    (!parts.is_empty()).then(|| parts.join(" "))
 }

--- a/crates/ide/src/snapshots/ide__verilog_2005__ambiguous_instantiation_hover_lists_locations_without_expanding_signatures.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__ambiguous_instantiation_hover_lists_locations_without_expanding_signatures.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Module reference `child`
 
@@ -11,9 +11,7 @@ child
 
 ---
 
-Facts
-- Status: ambiguous
-- Candidates: 2
+ambiguous reference, 2 candidates
 
 ---
 

--- a/crates/ide/src/snapshots/ide__verilog_2005__ambiguous_instantiation_hover_lists_locations_without_expanding_signatures.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__ambiguous_instantiation_hover_lists_locations_without_expanding_signatures.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Module reference `child`
+
+```systemverilog
+child
+```
+
+
+---
+
+Facts
+- Status: ambiguous
+- Candidates: 2
+
+---
+
+Candidates
+- [feature.v](<feature.v>) line 2
+- [feature.v](<feature.v>) line 5

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_builtin_macro_hover_shows_expanded_text____FILE__.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_builtin_macro_hover_shows_expanded_text____FILE__.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Macro `__FILE__`
 
@@ -11,8 +11,7 @@ Macro `__FILE__`
 
 ---
 
-Facts
-- Source: Builtin
+from builtin
 
 ---
 

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_builtin_macro_hover_shows_expanded_text____FILE__.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_builtin_macro_hover_shows_expanded_text____FILE__.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Macro `__FILE__`
+
+```systemverilog
+`__FILE__
+```
+
+
+---
+
+Facts
+- Source: Builtin
+
+---
+
+Expansion
+```systemverilog
+"source"
+```

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_builtin_macro_hover_shows_expanded_text____LINE__.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_builtin_macro_hover_shows_expanded_text____LINE__.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Macro `__LINE__`
+
+```systemverilog
+`__LINE__
+```
+
+
+---
+
+Facts
+- Source: Builtin
+
+---
+
+Expansion
+```systemverilog
+3
+```

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_builtin_macro_hover_shows_expanded_text____LINE__.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_builtin_macro_hover_shows_expanded_text____LINE__.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Macro `__LINE__`
 
@@ -11,8 +11,7 @@ Macro `__LINE__`
 
 ---
 
-Facts
-- Source: Builtin
+from builtin
 
 ---
 

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_include_literal_supports_navigation_and_hover.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_include_literal_supports_navigation_and_hover.snap
@@ -11,5 +11,4 @@ Include `defs.svh`
 
 ---
 
-Facts
-- Resolves to: [$FILE/defs.svh](<file:///$FILE/defs.svh>)
+resolves to [defs.svh](<file:///$FILE/defs.svh>)

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_include_literal_supports_navigation_and_hover.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_include_literal_supports_navigation_and_hover.snap
@@ -1,0 +1,15 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(hover.info.as_str())
+---
+Include `defs.svh`
+
+```systemverilog
+`include "defs.svh"
+```
+
+
+---
+
+Facts
+- Resolves to: [$FILE/defs.svh](<file:///$FILE/defs.svh>)

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_include_macro_definition_feeds_ide_features.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_include_macro_definition_feeds_ide_features.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Macro `HEADER_WIDTH`
 
@@ -11,8 +11,7 @@ Macro `HEADER_WIDTH`
 
 ---
 
-Facts
-- Source: [include/defs.vh](<file:///$FILE/defs.vh>) line 2
+from [include/defs.vh](<file:///$FILE/defs.vh>) line 2
 
 ---
 

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_include_macro_definition_feeds_ide_features.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_include_macro_definition_feeds_ide_features.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Macro `HEADER_WIDTH`
+
+```systemverilog
+`HEADER_WIDTH
+```
+
+
+---
+
+Facts
+- Source: [include/defs.vh](<file:///$FILE/defs.vh>) line 2
+
+---
+
+Expansion
+```systemverilog
+8
+```

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_argument_source_token_resolves_to_hir_definition__argument.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_argument_source_token_resolves_to_hir_definition__argument.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Port `payload_i`
 
@@ -11,6 +11,4 @@ input wire logic payload_i
 
 ---
 
-Facts
-- Scope: `top`
-- Source: [feature.v](<feature.v>) line 3
+in `top` from [feature.v](<feature.v>) line 3

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_argument_source_token_resolves_to_hir_definition__argument.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_argument_source_token_resolves_to_hir_definition__argument.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Port `payload_i`
+
+```systemverilog
+input wire logic payload_i
+```
+
+
+---
+
+Facts
+- Scope: `top`
+- Source: [feature.v](<feature.v>) line 3

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_call_hover_shows_expanded_text__argument.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_call_hover_shows_expanded_text__argument.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Declaration `generated`
+
+```systemverilog
+logic generated
+```
+
+
+---
+
+Facts
+- Scope: `top`
+- Source: [feature.v](<feature.v>) line 4

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_call_hover_shows_expanded_text__argument.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_call_hover_shows_expanded_text__argument.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(arg_hover.info.as_str())
 ---
 Declaration `generated`
 
@@ -11,6 +11,4 @@ logic generated
 
 ---
 
-Facts
-- Scope: `top`
-- Source: [feature.v](<feature.v>) line 4
+in `top` from [feature.v](<feature.v>) line 4

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_call_hover_shows_expanded_text__call.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_call_hover_shows_expanded_text__call.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Macro `MAKE_DECL`
 
@@ -11,8 +11,7 @@ Macro `MAKE_DECL`
 
 ---
 
-Facts
-- Source: [feature.v](<feature.v>) line 2
+from [feature.v](<feature.v>) line 2
 
 ---
 

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_call_hover_shows_expanded_text__call.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_call_hover_shows_expanded_text__call.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Macro `MAKE_DECL`
+
+```systemverilog
+`MAKE_DECL(name)
+```
+
+
+---
+
+Facts
+- Source: [feature.v](<feature.v>) line 2
+
+---
+
+Expansion
+```systemverilog
+logic generated;
+```

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_definition_supports_navigation_and_hover.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_definition_supports_navigation_and_hover.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Macro `LOCAL_WIDTH`
 
@@ -11,5 +11,4 @@ Macro `LOCAL_WIDTH`
 
 ---
 
-Facts
-- Source: [feature.v](<feature.v>) line 2
+from [feature.v](<feature.v>) line 2

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_definition_supports_navigation_and_hover.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_definition_supports_navigation_and_hover.snap
@@ -1,0 +1,15 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Macro `LOCAL_WIDTH`
+
+```systemverilog
+`define LOCAL_WIDTH 8
+```
+
+
+---
+
+Facts
+- Source: [feature.v](<feature.v>) line 2

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_expands_through_configured_predefine_argument__assign_argument.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_expands_through_configured_predefine_argument__assign_argument.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(argument_hover.info.as_str())
+---
+Declaration `sample_q`
+
+```systemverilog
+logic [12 - 1:0] sample_q
+```
+
+
+---
+
+Facts
+- Scope: `macro_hover_top`
+- Source: [$FILE/top.sv](<file:///$FILE/top.sv>) line 17

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_expands_through_configured_predefine_argument__assign_argument.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_expands_through_configured_predefine_argument__assign_argument.snap
@@ -11,6 +11,4 @@ logic [12 - 1:0] sample_q
 
 ---
 
-Facts
-- Scope: `macro_hover_top`
-- Source: [$FILE/top.sv](<file:///$FILE/top.sv>) line 17
+in `macro_hover_top` from [top.sv](<file:///$FILE/top.sv>) line 17

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_expands_through_configured_predefine_argument__assign_call.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_expands_through_configured_predefine_argument__assign_call.snap
@@ -1,0 +1,28 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Macro `PIPE_ASSIGN`
+
+```systemverilog
+`PIPE_ASSIGN(name, next_value)
+```
+
+
+---
+
+Facts
+- Source: [top.sv](<file:///$FILE/top.sv>) line 3
+
+---
+
+Expansion
+```systemverilog
+always_ff @(posedge clk_i or negedge rst_ni) begin 
+  if (!rst_ni) begin 
+    trace_q <= '0; 
+  end else begin 
+    trace_q <= (sample_q ^ {{(12-1){1'b0}}, 1'b1}); 
+  end 
+end
+```

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_expands_through_configured_predefine_argument__assign_call.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_expands_through_configured_predefine_argument__assign_call.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(assign_hover.info.as_str())
 ---
 Macro `PIPE_ASSIGN`
 
@@ -11,8 +11,7 @@ Macro `PIPE_ASSIGN`
 
 ---
 
-Facts
-- Source: [top.sv](<file:///$FILE/top.sv>) line 3
+from [top.sv](<file:///$FILE/top.sv>) line 3
 
 ---
 

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_expands_through_configured_predefine_argument__decl_call.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_expands_through_configured_predefine_argument__decl_call.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(decl_hover.info.as_str())
 ---
 Macro `DECL_PIPE`
 
@@ -11,8 +11,7 @@ Macro `DECL_PIPE`
 
 ---
 
-Facts
-- Source: [top.sv](<file:///$FILE/top.sv>) line 2
+from [top.sv](<file:///$FILE/top.sv>) line 2
 
 ---
 

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_expands_through_configured_predefine_argument__decl_call.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_expands_through_configured_predefine_argument__decl_call.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Macro `DECL_PIPE`
+
+```systemverilog
+`DECL_PIPE(name, width)
+```
+
+
+---
+
+Facts
+- Source: [top.sv](<file:///$FILE/top.sv>) line 2
+
+---
+
+Expansion
+```systemverilog
+logic [(12)-1:0] sample_q
+```

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_expands_through_configured_predefine_argument__sample_name.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_expands_through_configured_predefine_argument__sample_name.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(sample_name_hover.info.as_str())
+---
+Declaration `sample_q`
+
+```systemverilog
+logic [12 - 1:0] sample_q
+```
+
+
+---
+
+Facts
+- Scope: `macro_hover_top`
+- Source: [$FILE/top.sv](<file:///$FILE/top.sv>) line 17

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_expands_through_configured_predefine_argument__sample_name.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_expands_through_configured_predefine_argument__sample_name.snap
@@ -11,6 +11,4 @@ logic [12 - 1:0] sample_q
 
 ---
 
-Facts
-- Scope: `macro_hover_top`
-- Source: [$FILE/top.sv](<file:///$FILE/top.sv>) line 17
+in `macro_hover_top` from [top.sv](<file:///$FILE/top.sv>) line 17

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_expands_through_configured_predefine_argument__trace_name.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_expands_through_configured_predefine_argument__trace_name.snap
@@ -11,6 +11,4 @@ logic [12 - 1:0] trace_q
 
 ---
 
-Facts
-- Scope: `macro_hover_top`
-- Source: [$FILE/top.sv](<file:///$FILE/top.sv>) line 16
+in `macro_hover_top` from [top.sv](<file:///$FILE/top.sv>) line 16

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_expands_through_configured_predefine_argument__trace_name.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_expands_through_configured_predefine_argument__trace_name.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(trace_name_hover.info.as_str())
+---
+Declaration `trace_q`
+
+```systemverilog
+logic [12 - 1:0] trace_q
+```
+
+
+---
+
+Facts
+- Scope: `macro_hover_top`
+- Source: [$FILE/top.sv](<file:///$FILE/top.sv>) line 16

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_keeps_nested_actual_argument_macro_reference__actual_argument.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_keeps_nested_actual_argument_macro_reference__actual_argument.snap
@@ -1,0 +1,44 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Macro `DEMO_NEXT`
+
+```systemverilog
+`DEMO_NEXT(value)
+```
+
+
+---
+
+Facts
+- Source: [feature.v](<feature.v>) line 4
+
+---
+
+Expansion
+```systemverilog
+((payload_i) + 12'd1)
+```
+
+
+---
+
+Macro `PAYL`
+
+```systemverilog
+`PAYL
+```
+
+
+---
+
+Facts
+- Source: [feature.v](<feature.v>) line 2
+
+---
+
+Expansion
+```systemverilog
+payload_i
+```

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_keeps_nested_actual_argument_macro_reference__actual_argument.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_keeps_nested_actual_argument_macro_reference__actual_argument.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(payl_hover.info.as_str())
 ---
 Macro `DEMO_NEXT`
 
@@ -11,8 +11,7 @@ Macro `DEMO_NEXT`
 
 ---
 
-Facts
-- Source: [feature.v](<feature.v>) line 4
+from [feature.v](<feature.v>) line 4
 
 ---
 
@@ -33,8 +32,7 @@ Macro `PAYL`
 
 ---
 
-Facts
-- Source: [feature.v](<feature.v>) line 2
+from [feature.v](<feature.v>) line 2
 
 ---
 

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_keeps_nested_actual_argument_macro_reference__outer.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_keeps_nested_actual_argument_macro_reference__outer.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Macro `DEMO_NEXT`
+
+```systemverilog
+`DEMO_NEXT(value)
+```
+
+
+---
+
+Facts
+- Source: [feature.v](<feature.v>) line 4
+
+---
+
+Expansion
+```systemverilog
+((payload_i) + 12'd1)
+```

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_keeps_nested_actual_argument_macro_reference__outer.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_keeps_nested_actual_argument_macro_reference__outer.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(call_hover.info.as_str())
 ---
 Macro `DEMO_NEXT`
 
@@ -11,8 +11,7 @@ Macro `DEMO_NEXT`
 
 ---
 
-Facts
-- Source: [feature.v](<feature.v>) line 4
+from [feature.v](<feature.v>) line 4
 
 ---
 

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_shows_nested_compact_expansion.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_shows_nested_compact_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Macro `DEMO_NEXT`
 
@@ -11,8 +11,7 @@ Macro `DEMO_NEXT`
 
 ---
 
-Facts
-- Source: [feature.v](<feature.v>) line 3
+from [feature.v](<feature.v>) line 3
 
 ---
 

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_shows_nested_compact_expansion.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_shows_nested_compact_expansion.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Macro `DEMO_NEXT`
+
+```systemverilog
+`DEMO_NEXT(value)
+```
+
+
+---
+
+Facts
+- Source: [feature.v](<feature.v>) line 3
+
+---
+
+Expansion
+```systemverilog
+((payload_i) + 12'd1)
+```

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_shows_token_paste_expansion.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_shows_token_paste_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Macro `JOIN`
 
@@ -11,8 +11,7 @@ Macro `JOIN`
 
 ---
 
-Facts
-- Source: [feature.v](<feature.v>) line 2
+from [feature.v](<feature.v>) line 2
 
 ---
 

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_shows_token_paste_expansion.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_hover_shows_token_paste_expansion.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Macro `JOIN`
+
+```systemverilog
+`JOIN(a, b)
+```
+
+
+---
+
+Facts
+- Source: [feature.v](<feature.v>) line 2
+
+---
+
+Expansion
+```systemverilog
+foobar
+```

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_param_supports_navigation_hover_and_references.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_param_supports_navigation_hover_and_references.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Macro parameter `value`
 
@@ -8,5 +8,4 @@ Macro parameter `value`
 
 ---
 
-Facts
-- Macro: `SHIFT`
+in macro `SHIFT`

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_param_supports_navigation_hover_and_references.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_param_supports_navigation_hover_and_references.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Macro parameter `value`
+
+
+
+---
+
+Facts
+- Macro: `SHIFT`

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_usage_supports_navigation_and_hover.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_usage_supports_navigation_and_hover.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Macro `WIDTH`
 
@@ -11,8 +11,7 @@ Macro `WIDTH`
 
 ---
 
-Facts
-- Source: [feature.v](<feature.v>) line 2
+from [feature.v](<feature.v>) line 2
 
 ---
 

--- a/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_usage_supports_navigation_and_hover.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__preproc_macro_usage_supports_navigation_and_hover.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Macro `WIDTH`
+
+```systemverilog
+`WIDTH
+```
+
+
+---
+
+Facts
+- Source: [feature.v](<feature.v>) line 2
+
+---
+
+Expansion
+```systemverilog
+8
+```

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_after_truncation_uses_current_syntax_context.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_after_truncation_uses_current_syntax_context.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Module `axi_addr_miter`
 
@@ -11,5 +11,4 @@ module axi_addr_miter ()
 
 ---
 
-Facts
-- Source: [feature.v](<feature.v>) line 1
+from [feature.v](<feature.v>) line 1

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_after_truncation_uses_current_syntax_context.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_after_truncation_uses_current_syntax_context.snap
@@ -1,0 +1,15 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Module `axi_addr_miter`
+
+```systemverilog
+module axi_addr_miter ()
+```
+
+
+---
+
+Facts
+- Source: [feature.v](<feature.v>) line 1

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__block_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__block_ref.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Block `blk`
 
@@ -11,6 +11,4 @@ block blk
 
 ---
 
-Facts
-- Scope: `top`
-- Source: [feature.v](<feature.v>) line 38
+in `top` from [feature.v](<feature.v>) line 38

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__block_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__block_ref.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Block `blk`
+
+```systemverilog
+block blk
+```
+
+
+---
+
+Facts
+- Scope: `top`
+- Source: [feature.v](<feature.v>) line 38

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__config_def.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__config_def.snap
@@ -1,0 +1,15 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Config `cfg_top`
+
+```systemverilog
+config cfg_top
+```
+
+
+---
+
+Facts
+- Source: [feature.v](<feature.v>) line 47

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__config_def.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__config_def.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Config `cfg_top`
 
@@ -11,5 +11,4 @@ config cfg_top
 
 ---
 
-Facts
-- Source: [feature.v](<feature.v>) line 47
+from [feature.v](<feature.v>) line 47

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__gen_label.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__gen_label.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Generate block `g_loop`
+
+```systemverilog
+generate g_loop
+```
+
+
+---
+
+Facts
+- Scope: `top`
+- Source: [feature.v](<feature.v>) line 28

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__gen_label.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__gen_label.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Generate block `g_loop`
 
@@ -11,6 +11,4 @@ generate g_loop
 
 ---
 
-Facts
-- Scope: `top`
-- Source: [feature.v](<feature.v>) line 28
+in `top` from [feature.v](<feature.v>) line 28

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__generate_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__generate_ref.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Generate block `g_loop`
+
+```systemverilog
+generate g_loop
+```
+
+
+---
+
+Facts
+- Scope: `top`
+- Source: [feature.v](<feature.v>) line 28

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__generate_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__generate_ref.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Generate block `g_loop`
 
@@ -11,6 +11,4 @@ generate g_loop
 
 ---
 
-Facts
-- Scope: `top`
-- Source: [feature.v](<feature.v>) line 28
+in `top` from [feature.v](<feature.v>) line 28

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__genvar_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__genvar_ref.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Genvar `i`
 
@@ -11,6 +11,4 @@ genvar integer signed i
 
 ---
 
-Facts
-- Scope: `top`
-- Source: [feature.v](<feature.v>) line 27
+in `top` from [feature.v](<feature.v>) line 27

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__genvar_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__genvar_ref.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Genvar `i`
+
+```systemverilog
+genvar integer signed i
+```
+
+
+---
+
+Facts
+- Scope: `top`
+- Source: [feature.v](<feature.v>) line 27

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__instance_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__instance_ref.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Instance `u_child`
 
@@ -16,6 +16,4 @@ module child (
 
 ---
 
-Facts
-- Scope: `top`
-- Source: [feature.v](<feature.v>) line 16
+in `top` from [feature.v](<feature.v>) line 16

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__instance_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__instance_ref.snap
@@ -1,0 +1,21 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Instance `u_child`
+
+```systemverilog
+instance u_child of child
+
+module child (
+    input wire logic a,
+    output wire logic y
+)
+```
+
+
+---
+
+Facts
+- Scope: `top`
+- Source: [feature.v](<feature.v>) line 16

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__lane_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__lane_ref.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Declaration `lane`
 
@@ -11,6 +11,4 @@ wire logic lane
 
 ---
 
-Facts
-- Scope: `top > g_loop`
-- Source: [feature.v](<feature.v>) line 29
+in `top > g_loop` from [feature.v](<feature.v>) line 29

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__lane_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__lane_ref.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Declaration `lane`
+
+```systemverilog
+wire logic lane
+```
+
+
+---
+
+Facts
+- Scope: `top > g_loop`
+- Source: [feature.v](<feature.v>) line 29

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__module_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__module_ref.snap
@@ -1,0 +1,18 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Module `child`
+
+```systemverilog
+module child (
+    input wire logic a,
+    output wire logic y
+)
+```
+
+
+---
+
+Facts
+- Source: [feature.v](<feature.v>) line 2

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__module_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__module_ref.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Module `child`
 
@@ -14,5 +14,4 @@ module child (
 
 ---
 
-Facts
-- Source: [feature.v](<feature.v>) line 2
+from [feature.v](<feature.v>) line 2

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__port_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__port_ref.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Port `a`
+
+```systemverilog
+input wire logic a
+```
+
+
+---
+
+Facts
+- Scope: `child`
+- Source: [feature.v](<feature.v>) line 2

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__port_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__port_ref.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Port `a`
 
@@ -11,6 +11,4 @@ input wire logic a
 
 ---
 
-Facts
-- Scope: `child`
-- Source: [feature.v](<feature.v>) line 2
+in `child` from [feature.v](<feature.v>) line 2

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__sig_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__sig_ref.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Declaration `sig`
+
+```systemverilog
+wire logic sig
+```
+
+
+---
+
+Facts
+- Scope: `top`
+- Source: [feature.v](<feature.v>) line 15

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__sig_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__sig_ref.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Declaration `sig`
 
@@ -11,6 +11,4 @@ wire logic sig
 
 ---
 
-Facts
-- Scope: `top`
-- Source: [feature.v](<feature.v>) line 15
+in `top` from [feature.v](<feature.v>) line 15

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__specparam_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__specparam_ref.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Specparam `T_SETUP`
 
@@ -11,6 +11,4 @@ specparam logic T_SETUP = 1
 
 ---
 
-Facts
-- Scope: `top`
-- Source: [feature.v](<feature.v>) line 34
+in `top` from [feature.v](<feature.v>) line 34

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__specparam_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__specparam_ref.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Specparam `T_SETUP`
+
+```systemverilog
+specparam logic T_SETUP = 1
+```
+
+
+---
+
+Facts
+- Scope: `top`
+- Source: [feature.v](<feature.v>) line 34

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__task_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__task_ref.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Task `do_task`
+
+```systemverilog
+task do_task()
+```
+
+
+---
+
+Facts
+- Scope: `top`
+- Source: [feature.v](<feature.v>) line 19

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__task_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__task_ref.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Task `do_task`
 
@@ -11,6 +11,4 @@ task do_task()
 
 ---
 
-Facts
-- Scope: `top`
-- Source: [feature.v](<feature.v>) line 19
+in `top` from [feature.v](<feature.v>) line 19

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__udp_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__udp_ref.snap
@@ -1,0 +1,15 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Primitive `udp_and`
+
+```systemverilog
+primitive udp_and
+```
+
+
+---
+
+Facts
+- Source: [feature.v](<feature.v>) line 6

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__udp_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_covers_all_definition_kinds__udp_ref.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Primitive `udp_and`
 
@@ -11,5 +11,4 @@ primitive udp_and
 
 ---
 
-Facts
-- Source: [feature.v](<feature.v>) line 6
+from [feature.v](<feature.v>) line 6

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_renders_side_comment_from_trivia.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_renders_side_comment_from_trivia.snap
@@ -1,0 +1,21 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Declaration `sig`
+
+```systemverilog
+wire logic sig
+```
+
+
+---
+
+Facts
+- Scope: `side_comment_ctx`
+- Source: [feature.v](<feature.v>) line 3
+
+---
+
+Documentation
+side comment from trivia

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_renders_side_comment_from_trivia.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_renders_side_comment_from_trivia.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Declaration `sig`
 
@@ -11,9 +11,7 @@ wire logic sig
 
 ---
 
-Facts
-- Scope: `side_comment_ctx`
-- Source: [feature.v](<feature.v>) line 3
+in `side_comment_ctx` from [feature.v](<feature.v>) line 3
 
 ---
 

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_relative_source_label_for_absolute_workspace_path.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_relative_source_label_for_absolute_workspace_path.snap
@@ -1,0 +1,14 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(hover.info.as_str())
+---
+Port `sample_o`
+
+```systemverilog
+output logic [12 - 1:0] sample_o
+```
+
+
+---
+
+in `macro_hover_top` from [02_macro_hover_top.sv](<file:///$FILE/02_macro_hover_top.sv>) line 3

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__func_def.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__func_def.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(func_hover.info.as_str())
 ---
 Function `add1`
 
@@ -13,6 +13,4 @@ function logic [3:0] add1(
 
 ---
 
-Facts
-- Scope: `child`
-- Source: [feature.v](<feature.v>) line 11
+in `child` from [feature.v](<feature.v>) line 11

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__func_def.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__func_def.snap
@@ -1,0 +1,18 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Function `add1`
+
+```systemverilog
+function logic [3:0] add1(
+    input logic [3:0] value
+)
+```
+
+
+---
+
+Facts
+- Scope: `child`
+- Source: [feature.v](<feature.v>) line 11

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__instance_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__instance_ref.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Instance `u_child`
+
+```systemverilog
+instance u_child of child
+
+module child #(
+    parameter logic WIDTH = 8
+) (
+    input wire logic clk
+)
+```
+
+
+---
+
+Facts
+- Scope: `top`
+- Source: [feature.v](<feature.v>) line 19

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__instance_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__instance_ref.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(instance_hover.info.as_str())
 ---
 Instance `u_child`
 
@@ -17,6 +17,4 @@ module child #(
 
 ---
 
-Facts
-- Scope: `top`
-- Source: [feature.v](<feature.v>) line 19
+in `top` from [feature.v](<feature.v>) line 19

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__module_def.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__module_def.snap
@@ -1,0 +1,19 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Module `child`
+
+```systemverilog
+module child #(
+    parameter logic WIDTH = 8
+) (
+    input wire logic clk
+)
+```
+
+
+---
+
+Facts
+- Source: [feature.v](<feature.v>) line 2

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__module_def.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__module_def.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(module_hover.info.as_str())
 ---
 Module `child`
 
@@ -15,5 +15,4 @@ module child #(
 
 ---
 
-Facts
-- Source: [feature.v](<feature.v>) line 2
+from [feature.v](<feature.v>) line 2

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__module_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__module_ref.snap
@@ -1,0 +1,19 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Module `child`
+
+```systemverilog
+module child #(
+    parameter logic WIDTH = 8
+) (
+    input wire logic clk
+)
+```
+
+
+---
+
+Facts
+- Source: [feature.v](<feature.v>) line 2

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__module_ref.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__module_ref.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(inst_module_hover.info.as_str())
 ---
 Module `child`
 
@@ -15,5 +15,4 @@ module child #(
 
 ---
 
-Facts
-- Source: [feature.v](<feature.v>) line 2
+from [feature.v](<feature.v>) line 2

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__param_def.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__param_def.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(param_hover.info.as_str())
 ---
 Localparam `DEPTH`
 
@@ -11,6 +11,4 @@ localparam logic DEPTH = WIDTH + 1
 
 ---
 
-Facts
-- Scope: `child`
-- Source: [feature.v](<feature.v>) line 5
+in `child` from [feature.v](<feature.v>) line 5

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__param_def.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__param_def.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Localparam `DEPTH`
+
+```systemverilog
+localparam logic DEPTH = WIDTH + 1
+```
+
+
+---
+
+Facts
+- Scope: `child`
+- Source: [feature.v](<feature.v>) line 5

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__port_def.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__port_def.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Port `clk`
+
+```systemverilog
+input wire logic clk
+```
+
+
+---
+
+Facts
+- Scope: `child`
+- Source: [feature.v](<feature.v>) line 3

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__port_def.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__port_def.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(port_hover.info.as_str())
 ---
 Port `clk`
 
@@ -11,6 +11,4 @@ input wire logic clk
 
 ---
 
-Facts
-- Scope: `child`
-- Source: [feature.v](<feature.v>) line 3
+in `child` from [feature.v](<feature.v>) line 3

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__task_def.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__task_def.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(task_hover.info.as_str())
 ---
 Task `drive`
 
@@ -13,6 +13,4 @@ task drive(
 
 ---
 
-Facts
-- Scope: `child`
-- Source: [feature.v](<feature.v>) line 9
+in `child` from [feature.v](<feature.v>) line 9

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__task_def.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_hover_uses_symbol_specific_renderers__task_def.snap
@@ -1,0 +1,18 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Task `drive`
+
+```systemverilog
+task drive(
+    input reg [3:0] value
+)
+```
+
+
+---
+
+Facts
+- Scope: `child`
+- Source: [feature.v](<feature.v>) line 9

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_library_map_declaration_lowers_without_fallback.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_library_map_declaration_lowers_without_fallback.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Library `work`
 
@@ -11,5 +11,4 @@ library work
 
 ---
 
-Facts
-- Source: [feature.map](<feature.map>) line 2
+from [feature.map](<feature.map>) line 2

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_library_map_declaration_lowers_without_fallback.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_library_map_declaration_lowers_without_fallback.snap
@@ -1,0 +1,15 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Library `work`
+
+```systemverilog
+library work
+```
+
+
+---
+
+Facts
+- Source: [feature.map](<feature.map>) line 2

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_module_definition_names_support_references.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_module_definition_names_support_references.snap
@@ -1,0 +1,20 @@
+---
+source: crates/ide/src/verilog_2005.rs
+expression: normalize_hover_snapshot(info)
+---
+Module `mux2X1`
+
+```systemverilog
+module mux2X1 (
+    in0,
+    in1,
+    sel,
+    out
+)
+```
+
+
+---
+
+Facts
+- Source: [feature.v](<feature.v>) line 2

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_module_definition_names_support_references.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_module_definition_names_support_references.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
-expression: normalize_hover_snapshot(info)
+expression: normalize_hover_snapshot(hover.info.as_str())
 ---
 Module `mux2X1`
 
@@ -16,5 +16,4 @@ module mux2X1 (
 
 ---
 
-Facts
-- Source: [feature.v](<feature.v>) line 2
+from [feature.v](<feature.v>) line 2

--- a/crates/ide/src/verilog_2005.rs
+++ b/crates/ide/src/verilog_2005.rs
@@ -2675,6 +2675,52 @@ endmodule
 }
 
 #[test]
+fn verilog_2005_hover_uses_relative_source_label_for_absolute_workspace_path() {
+    let dir = TestDir::new("hover-source-label");
+    let rtl_dir = dir.path().join("rtl");
+    std::fs::create_dir_all(&rtl_dir).unwrap();
+
+    let file_path = rtl_dir.join("02_macro_hover_top.sv");
+    let (text, markers) = strip_markers(normalize_fixture_text(
+        r#"
+module macro_hover_top(
+  output logic [12 - 1:0] /*marker:port*/sample_o
+);
+endmodule
+"#,
+    ));
+    std::fs::write(&file_path, &text).unwrap();
+
+    let file_id = FileId(0);
+    let mut file_set = FileSet::default();
+    file_set.insert(file_id, VfsPath::from(file_path));
+
+    let mut change = Change::new();
+    change.set_roots(vec![SourceRoot::new_local(file_set)]);
+    change.add_changed_file(ChangedFile {
+        file_id,
+        change_kind: ChangeKind::Create(Arc::from(text.as_str()), LineEnding::Unix),
+    });
+
+    let mut host = AnalysisHost::default();
+    host.apply_change(change);
+    let hover = host
+        .make_analysis()
+        .hover(position(file_id, &markers, "port"), HoverConfig { format: HoverFormat::PlainText })
+        .unwrap()
+        .expect("port hover expected");
+    let normalized = normalize_hover_snapshot(hover.info.as_str());
+    assert!(
+        !normalized.contains("[$FILE/"),
+        "source link label should be relative, got:\n{normalized}"
+    );
+    assert_hover_snapshot!(
+        "verilog_2005_hover_uses_relative_source_label_for_absolute_workspace_path",
+        hover.info.as_str(),
+    );
+}
+
+#[test]
 fn ambiguous_instantiation_hover_lists_locations_without_expanding_signatures() {
     let text = r#"
 module child(input logic a);

--- a/crates/ide/src/verilog_2005.rs
+++ b/crates/ide/src/verilog_2005.rs
@@ -331,6 +331,89 @@ fn text_at_range(text: &str, range: TextRange) -> &str {
     &text[usize::from(range.start())..usize::from(range.end())]
 }
 
+macro_rules! assert_hover_snapshot {
+    ($name:expr, $info:expr $(,)?) => {
+        assert_snapshot!(($name).to_string(), normalize_hover_snapshot($info));
+    };
+}
+
+fn normalize_hover_snapshot(info: &str) -> String {
+    let info = redact_file_uri_targets(&info.replace('\\', "/"));
+    redact_absolute_file_link_labels(&info)
+}
+
+fn redact_file_uri_targets(info: &str) -> String {
+    let marker = "](<file:///";
+    let mut output = String::with_capacity(info.len());
+    let mut rest = info;
+
+    while let Some(start) = rest.find(marker) {
+        let target_start = start + marker.len();
+        output.push_str(&rest[..target_start]);
+        let target = &rest[target_start..];
+        let Some(end) = target.find(">)") else {
+            output.push_str(target);
+            return output;
+        };
+        let file_name = target[..end].rsplit('/').next().unwrap_or("path");
+        output.push_str("$FILE/");
+        output.push_str(file_name);
+        output.push_str(">)");
+        rest = &target[end + 2..];
+    }
+
+    output.push_str(rest);
+    output
+}
+
+fn redact_absolute_file_link_labels(info: &str) -> String {
+    let target_prefix = "](<file:///$FILE/";
+    let mut output = String::with_capacity(info.len());
+    let mut rest = info;
+
+    while let Some(open) = rest.find('[') {
+        output.push_str(&rest[..open]);
+        let link = &rest[open + 1..];
+        let Some(close) = link.find(target_prefix) else {
+            output.push('[');
+            rest = link;
+            continue;
+        };
+        let label = &link[..close];
+        if label.contains('\n') {
+            output.push('[');
+            rest = link;
+            continue;
+        }
+        let target = &link[close + target_prefix.len()..];
+        let Some(end) = target.find(">)") else {
+            output.push('[');
+            output.push_str(link);
+            return output;
+        };
+        let file_name = &target[..end];
+
+        if is_unstable_file_link_label(label) {
+            output.push_str("[$FILE/");
+            output.push_str(file_name);
+        } else {
+            output.push('[');
+            output.push_str(label);
+        }
+        output.push_str(target_prefix);
+        output.push_str(file_name);
+        output.push_str(">)");
+        rest = &target[end + 2..];
+    }
+
+    output.push_str(rest);
+    output
+}
+
+fn is_unstable_file_link_label(label: &str) -> bool {
+    label.contains(":/") || label.starts_with('/')
+}
+
 fn fixtures_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/verilog_2005/fixtures")
 }
@@ -1315,18 +1398,9 @@ endmodule
         .hover(position, HoverConfig { format: HoverFormat::PlainText })
         .unwrap()
         .expect("include hover expected");
-    let info = hover.info.as_str();
-    assert!(
-        info.starts_with("Include `defs.svh`"),
-        "include hover should start with the canonical title: {info}"
-    );
-    assert!(
-        info.contains("```systemverilog\n`include \"defs.svh\"\n```"),
-        "include hover should render the directive as the primary code block: {info}"
-    );
-    assert!(
-        info.contains("\n\n---\n\nFacts\n- Resolves to: ["),
-        "include hover should render the resolved target as a fact link: {info}"
+    assert_hover_snapshot!(
+        "preproc_include_literal_supports_navigation_and_hover",
+        hover.info.as_str(),
     );
 }
 
@@ -1356,8 +1430,10 @@ endmodule
         .hover(position, HoverConfig { format: HoverFormat::PlainText })
         .unwrap()
         .expect("macro hover expected");
-    assert!(hover.info.as_str().contains("WIDTH"), "hover should mention macro name");
-    assert!(hover.info.as_str().contains("8"), "hover should show macro expansion");
+    assert_hover_snapshot!(
+        "preproc_macro_usage_supports_navigation_and_hover",
+        hover.info.as_str()
+    );
 }
 
 #[test]
@@ -1397,12 +1473,9 @@ endmodule
         .hover(param_ref, HoverConfig { format: HoverFormat::PlainText })
         .unwrap()
         .expect("macro parameter hover expected");
-    assert!(
-        hover.info.as_str().contains("Macro parameter")
-            && hover.info.as_str().contains("value")
-            && hover.info.as_str().contains("SHIFT"),
-        "hover should identify macro parameter: {}",
-        hover.info.as_str()
+    assert_hover_snapshot!(
+        "preproc_macro_param_supports_navigation_hover_and_references",
+        hover.info.as_str(),
     );
 
     let refs = analysis
@@ -1467,16 +1540,9 @@ endmodule
         .hover(arg, HoverConfig { format: HoverFormat::PlainText })
         .unwrap()
         .expect("macro argument source token hover expected");
-    assert!(
-        hover.info.as_str().contains("payload_i"),
-        "macro argument hover should render the HIR definition: {}",
-        hover.info.as_str()
-    );
-    assert!(
-        !hover.info.as_str().contains("`define `NEXT(value)")
-            && !hover.info.as_str().contains("Expands to"),
-        "macro argument hover should not show macro expansion away from the macro name: {}",
-        hover.info.as_str()
+    assert_hover_snapshot!(
+        "preproc_macro_argument_source_token_resolves_to_hir_definition__argument",
+        hover.info.as_str(),
     );
 
     let refs = analysis
@@ -1527,37 +1593,18 @@ endmodule
         .hover(position(file_id, &markers, "call"), HoverConfig { format: HoverFormat::PlainText })
         .unwrap()
         .expect("macro call hover expected");
-    let info = hover.info.as_str();
-    assert!(
-        info.contains("```systemverilog")
-            && info.contains("Macro")
-            && info.contains("`MAKE_DECL(name)")
-            && !info.contains("`define `MAKE_DECL(name)")
-            && info.starts_with("Macro `MAKE_DECL`")
-            && info.contains("\n\n---\n\nFacts\n- Source: [")
-            && info.contains("\n\n---\n\nExpansion\n```systemverilog\nlogic generated;\n```")
-            && !info.contains("--------------------")
-            && info.contains("logic generated;")
-            && !info.contains("from [feature.v]")
-            && !info.contains("Context ")
-            && !info.contains("Signature")
-            && !info.contains("Arguments")
-            && !info.contains("Expansion steps")
-            && !info.contains("Virtual expansion source")
-            && !info.contains("Token origin"),
-        "macro call hover should include the expanded macro text: {info}"
+    assert_hover_snapshot!(
+        "preproc_macro_call_hover_shows_expanded_text__call",
+        hover.info.as_str(),
     );
 
     let arg_hover = analysis
         .hover(position(file_id, &markers, "arg"), HoverConfig { format: HoverFormat::PlainText })
         .unwrap()
         .expect("macro argument hover expected");
-    let arg_info = arg_hover.info.as_str();
-    assert!(
-        arg_info.contains("generated")
-            && !arg_info.contains("`define `MAKE_DECL(name)")
-            && !arg_info.contains("Expands to"),
-        "macro argument hover should stay on the source token away from the macro name: {arg_info}"
+    assert_hover_snapshot!(
+        "preproc_macro_call_hover_shows_expanded_text__argument",
+        arg_hover.info.as_str(),
     );
 }
 
@@ -1580,15 +1627,9 @@ endmodule
             )
             .unwrap()
             .expect("builtin macro hover expected");
-        let info = hover.info.as_str();
-        assert!(
-            info.contains("```systemverilog")
-                && info.contains(&format!("`{name}"))
-                && info.starts_with(&format!("Macro `{name}`"))
-                && info.contains("\n\n---\n\nFacts\n- Source: Builtin")
-                && !info.contains("--------------------")
-                && !info.contains("unavailable"),
-            "builtin macro hover should show structured expansion: {info}"
+        assert_hover_snapshot!(
+            &format!("preproc_builtin_macro_hover_shows_expanded_text__{name}"),
+            hover.info.as_str(),
         );
     }
 }
@@ -1609,25 +1650,9 @@ endmodule
         .hover(position(file_id, &markers, "call"), HoverConfig { format: HoverFormat::PlainText })
         .unwrap()
         .expect("nested macro call hover expected");
-    let info = hover.info.as_str();
-    assert!(
-        info.contains("```systemverilog")
-            && info.contains("Macro")
-            && info.contains("`DEMO_NEXT(value)")
-            && !info.contains("`define `DEMO_NEXT(value)")
-            && !info.contains("`MATH_ONE")
-            && info.starts_with("Macro `DEMO_NEXT`")
-            && info.contains("\n\n---\n\nFacts\n- Source: [")
-            && info.contains("\n\n---\n\nExpansion\n```systemverilog")
-            && !info.contains("--------------------")
-            && info.contains("((payload_i) + 12'd1)")
-            && info.contains("payload_i")
-            && info.contains("12")
-            && info.contains("'d")
-            && info.contains("[feature.v]")
-            && !info.contains("Context ")
-            && !info.contains("Expansion steps"),
-        "nested macro hover should show compact signature, result, and source: {info}"
+    assert_hover_snapshot!(
+        "preproc_macro_hover_shows_nested_compact_expansion",
+        hover.info.as_str(),
     );
 }
 
@@ -1648,24 +1673,9 @@ endmodule
         .hover(position(file_id, &markers, "call"), HoverConfig { format: HoverFormat::PlainText })
         .unwrap()
         .expect("outer macro call hover expected");
-    let call_info = call_hover.info.as_str();
-    assert!(
-        call_info.contains("```systemverilog")
-            && call_info.contains("Macro")
-            && call_info.contains("`DEMO_NEXT(value)")
-            && !call_info.contains("`define `DEMO_NEXT(value)")
-            && !call_info.contains("`MATH_ONE")
-            && call_info.starts_with("Macro `DEMO_NEXT`")
-            && call_info.contains("\n\n---\n\nFacts\n- Source: [")
-            && call_info.contains("\n\n---\n\nExpansion\n```systemverilog")
-            && !call_info.contains("--------------------")
-            && call_info.contains("((payload_i) + 12'd1)")
-            && call_info.contains("payload_i")
-            && call_info.contains("12")
-            && call_info.contains("[feature.v]")
-            && !call_info.contains("Context ")
-            && !call_info.contains("Expansion steps"),
-        "outer macro hover should keep compact expansion facts: {call_info}"
+    assert_hover_snapshot!(
+        "preproc_macro_hover_keeps_nested_actual_argument_macro_reference__outer",
+        call_hover.info.as_str(),
     );
 
     let payl_position = position(file_id, &markers, "payl");
@@ -1685,20 +1695,9 @@ endmodule
         .hover(payl_position, HoverConfig { format: HoverFormat::PlainText })
         .unwrap()
         .expect("nested actual-argument macro hover expected");
-    let payl_info = payl_hover.info.as_str();
-    assert!(
-        payl_info.contains("```systemverilog")
-            && payl_info.contains("Macro")
-            && payl_info.contains("`PAYL")
-            && !payl_info.contains("`define `PAYL payload_i")
-            && payl_info.contains("\n\n---\n\nMacro `PAYL`")
-            && payl_info.contains("\n\n---\n\nFacts\n- Source: [")
-            && payl_info.contains("\n\n---\n\nExpansion\n```systemverilog")
-            && !payl_info.contains("--------------------")
-            && payl_info.contains("payload_i")
-            && !payl_info.contains("from [feature.v]")
-            && !payl_info.contains("unavailable"),
-        "PAYL hover should show the nested macro expansion without unavailable text: {payl_info}"
+    assert_hover_snapshot!(
+        "preproc_macro_hover_keeps_nested_actual_argument_macro_reference__actual_argument",
+        payl_hover.info.as_str(),
     );
 }
 
@@ -1717,18 +1716,7 @@ endmodule
         .hover(position(file_id, &markers, "call"), HoverConfig { format: HoverFormat::PlainText })
         .unwrap()
         .expect("macro call hover expected");
-    let info = hover.info.as_str();
-    assert!(
-        info.starts_with("Macro `JOIN`")
-            && info.contains("```systemverilog")
-            && info.contains("`JOIN(a, b)")
-            && info.contains("\n\n---\n\nFacts\n- Source: [")
-            && info.contains("\n\n---\n\nExpansion\n```systemverilog")
-            && info.contains("foobar")
-            && info.contains("[feature.v]")
-            && !info.contains("unavailable"),
-        "token paste expansion hover should show the expanded display text: {info}"
-    );
+    assert_hover_snapshot!("preproc_macro_hover_shows_token_paste_expansion", hover.info.as_str());
 }
 
 #[test]
@@ -1807,17 +1795,9 @@ endmodule
         )
         .unwrap()
         .expect("DECL_PIPE macro call hover expected");
-    let decl_info = decl_hover.info.as_str();
-    assert!(
-        decl_info.starts_with("Macro `DECL_PIPE`")
-            && decl_info.contains("```systemverilog")
-            && decl_info.contains("`DECL_PIPE(name, width)")
-            && !decl_info.contains("`define `DECL_PIPE(name, width)")
-            && decl_info.contains("\n\n---\n\nFacts\n- Source: [")
-            && decl_info.contains("\n\n---\n\nExpansion\n```systemverilog")
-            && decl_info.contains("logic [(12)-1:0] sample_q")
-            && !decl_info.contains("unavailable"),
-        "DECL_PIPE hover should show expansion through configured predefine: {decl_info}"
+    assert_hover_snapshot!(
+        "preproc_macro_hover_expands_through_configured_predefine_argument__decl_call",
+        decl_hover.info.as_str(),
     );
 
     let assign_hover = analysis
@@ -1827,16 +1807,9 @@ endmodule
         )
         .unwrap()
         .expect("PIPE_ASSIGN macro call hover expected");
-    let assign_info = assign_hover.info.as_str();
-    assert!(
-        assign_info.starts_with("Macro `PIPE_ASSIGN`")
-            && assign_info.contains("`PIPE_ASSIGN(name, next_value)")
-            && !assign_info.contains("`define `PIPE_ASSIGN(name, next_value)")
-            && assign_info.contains("\n\n---\n\nFacts\n- Source: [")
-            && assign_info.contains("\n\n---\n\nExpansion\n```systemverilog")
-            && assign_info.contains("trace_q <= (sample_q ^ {{(12-1){1'b0}}, 1'b1});")
-            && !assign_info.contains("unavailable"),
-        "PIPE_ASSIGN hover should show actual-argument expansion through configured predefine: {assign_info}"
+    assert_hover_snapshot!(
+        "preproc_macro_hover_expands_through_configured_predefine_argument__assign_call",
+        assign_hover.info.as_str(),
     );
 
     let argument_hover = analysis
@@ -1846,13 +1819,9 @@ endmodule
         )
         .unwrap()
         .expect("PIPE_ASSIGN actual argument hover expected");
-    let argument_info = argument_hover.info.as_str();
-    assert!(
-        argument_info.contains("sample_q")
-            && !argument_info.contains("clk_i")
-            && !argument_info.contains("rst_ni")
-            && !argument_info.contains("trace_q"),
-        "actual argument hover should stay on sample_q only: {argument_info}"
+    assert_hover_snapshot!(
+        "preproc_macro_hover_expands_through_configured_predefine_argument__assign_argument",
+        argument_hover.info.as_str(),
     );
 
     let sample_name_hover = analysis
@@ -1862,13 +1831,9 @@ endmodule
         )
         .unwrap()
         .expect("PIPE_ASSIGN pasted sample name hover expected");
-    let sample_name_info = sample_name_hover.info.as_str();
-    assert!(
-        sample_name_info.contains("sample_q")
-            && !sample_name_info.contains("clk_i")
-            && !sample_name_info.contains("rst_ni")
-            && !sample_name_info.contains("trace_q"),
-        "pasted sample name hover should resolve to sample_q only: {sample_name_info}"
+    assert_hover_snapshot!(
+        "preproc_macro_hover_expands_through_configured_predefine_argument__sample_name",
+        sample_name_hover.info.as_str(),
     );
 
     let trace_name_hover = analysis
@@ -1878,13 +1843,9 @@ endmodule
         )
         .unwrap()
         .expect("PIPE_ASSIGN pasted trace name hover expected");
-    let trace_name_info = trace_name_hover.info.as_str();
-    assert!(
-        trace_name_info.contains("trace_q")
-            && !trace_name_info.contains("clk_i")
-            && !trace_name_info.contains("rst_ni")
-            && !trace_name_info.contains("sample_q"),
-        "pasted trace name hover should resolve to trace_q only: {trace_name_info}"
+    assert_hover_snapshot!(
+        "preproc_macro_hover_expands_through_configured_predefine_argument__trace_name",
+        trace_name_hover.info.as_str(),
     );
 }
 
@@ -1920,13 +1881,9 @@ endmodule
         .hover(definition, HoverConfig { format: HoverFormat::PlainText })
         .unwrap()
         .expect("macro definition hover expected");
-    assert!(
-        hover.info.as_str().contains("`define LOCAL_WIDTH 8"),
-        "hover should show macro definition"
-    );
-    assert!(
-        hover.info.as_str().contains("\n\n---\n\nFacts\n- Source: [feature.v]"),
-        "hover should show linked macro source"
+    assert_hover_snapshot!(
+        "preproc_macro_definition_supports_navigation_and_hover",
+        hover.info.as_str(),
     );
 
     let conditional_nav = analysis
@@ -2050,19 +2007,9 @@ endmodule
         .hover(usage, HoverConfig { format: HoverFormat::PlainText })
         .unwrap()
         .expect("included macro hover expected");
-    assert!(hover.info.as_str().contains("HEADER_WIDTH"), "hover should mention macro name");
-    assert!(
-        hover.info.as_str().contains("macro")
-            && hover.info.as_str().contains("`HEADER_WIDTH")
-            && !hover.info.as_str().contains("`define `HEADER_WIDTH"),
-        "hover should show macro expansion header"
-    );
-    assert!(hover.info.as_str().contains("8"), "hover should show macro expansion");
-    assert!(
-        hover.info.as_str().contains("\n\n---\n\nFacts\n- Source: [include/defs.vh]")
-            && hover.info.as_str().contains("line 2"),
-        "hover should show linked project-relative macro source path: {}",
-        hover.info.as_str()
+    assert_hover_snapshot!(
+        "preproc_include_macro_definition_feeds_ide_features",
+        hover.info.as_str(),
     );
 
     let completion_items = analysis
@@ -2520,8 +2467,12 @@ include "vendor.map";
             position(file_id, &markers, "library_def"),
             HoverConfig { format: HoverFormat::PlainText },
         )
-        .unwrap();
-    assert!(hover.is_some(), "library declaration hover should not panic or disappear");
+        .unwrap()
+        .expect("library declaration hover expected");
+    assert_hover_snapshot!(
+        "verilog_2005_library_map_declaration_lowers_without_fallback",
+        hover.info.as_str(),
+    );
 
     let highlights = analysis
         .document_highlight(
@@ -2580,11 +2531,9 @@ endmodule
         )
         .unwrap()
         .expect("signal hover expected");
-
-    assert!(
-        hover.info.as_str().contains("side comment from trivia"),
-        "hover should render the declaration side comment: {}",
-        hover.info.as_str()
+    assert_hover_snapshot!(
+        "verilog_2005_hover_renders_side_comment_from_trivia",
+        hover.info.as_str(),
     );
 }
 
@@ -2608,11 +2557,9 @@ fn verilog_2005_hover_after_truncation_uses_current_syntax_context() {
         .hover(position(file_id, &markers, "name"), HoverConfig { format: HoverFormat::PlainText })
         .unwrap()
         .expect("truncated module hover expected");
-
-    assert!(
-        !hover.info.as_str().contains("full declaration"),
-        "hover should not render stale side comments: {}",
-        hover.info.as_str()
+    assert_hover_snapshot!(
+        "verilog_2005_hover_after_truncation_uses_current_syntax_context",
+        hover.info.as_str(),
     );
 }
 
@@ -2649,12 +2596,9 @@ endmodule
         )
         .unwrap()
         .expect("module hover expected");
-    assert!(
-        module_hover.info.as_str().contains(
-            "module child #(\n    parameter logic WIDTH = 8\n) (\n    input wire logic clk\n)"
-        ),
-        "module hover should use module-specific renderer: {}",
-        module_hover.info.as_str()
+    assert_hover_snapshot!(
+        "verilog_2005_hover_uses_symbol_specific_renderers__module_def",
+        module_hover.info.as_str(),
     );
 
     let inst_module_hover = analysis
@@ -2664,12 +2608,9 @@ endmodule
         )
         .unwrap()
         .expect("instantiated module hover expected");
-    assert!(
-        inst_module_hover.info.as_str().contains(
-            "module child #(\n    parameter logic WIDTH = 8\n) (\n    input wire logic clk\n)"
-        ),
-        "instantiation module name hover should reuse module signature: {}",
-        inst_module_hover.info.as_str()
+    assert_hover_snapshot!(
+        "verilog_2005_hover_uses_symbol_specific_renderers__module_ref",
+        inst_module_hover.info.as_str(),
     );
 
     let instance_hover = analysis
@@ -2679,13 +2620,9 @@ endmodule
         )
         .unwrap()
         .expect("instance hover expected");
-    assert!(
-        instance_hover.info.as_str().contains("instance u_child of child")
-            && instance_hover.info.as_str().contains(
-                "module child #(\n    parameter logic WIDTH = 8\n) (\n    input wire logic clk\n)"
-            ),
-        "instance hover should include the target module signature: {}",
-        instance_hover.info.as_str()
+    assert_hover_snapshot!(
+        "verilog_2005_hover_uses_symbol_specific_renderers__instance_ref",
+        instance_hover.info.as_str(),
     );
 
     let port_hover = analysis
@@ -2695,26 +2632,9 @@ endmodule
         )
         .unwrap()
         .expect("port hover expected");
-    assert!(
-        port_hover.info.as_str().contains("input wire logic clk"),
-        "port hover should use port-specific renderer: {}",
-        port_hover.info.as_str()
-    );
-    assert!(
-        port_hover.info.as_str().starts_with("Port `clk`"),
-        "port hover should start with the canonical title: {}",
-        port_hover.info.as_str()
-    );
-    assert!(
-        port_hover.info.as_str().contains("\n\n---\n\nFacts\n- Scope: `child`")
-            && port_hover.info.as_str().contains("- Source: ["),
-        "port hover should render context as facts: {}",
-        port_hover.info.as_str()
-    );
-    assert!(
-        !port_hover.info.as_str().contains("---------"),
-        "port hover should not use legacy dividers: {}",
-        port_hover.info.as_str()
+    assert_hover_snapshot!(
+        "verilog_2005_hover_uses_symbol_specific_renderers__port_def",
+        port_hover.info.as_str(),
     );
 
     let param_hover = analysis
@@ -2724,26 +2644,9 @@ endmodule
         )
         .unwrap()
         .expect("parameter hover expected");
-    assert!(
-        param_hover.info.as_str().contains("localparam logic DEPTH = WIDTH + 1"),
-        "parameter hover should use parameter-specific renderer: {}",
-        param_hover.info.as_str()
-    );
-    assert!(
-        param_hover.info.as_str().starts_with("Localparam `DEPTH`"),
-        "parameter hover should start with the canonical title: {}",
-        param_hover.info.as_str()
-    );
-    assert!(
-        param_hover.info.as_str().contains("\n\n---\n\nFacts\n- Scope: `child`")
-            && param_hover.info.as_str().contains("- Source: ["),
-        "parameter hover should render context as facts: {}",
-        param_hover.info.as_str()
-    );
-    assert!(
-        !param_hover.info.as_str().contains("---------"),
-        "parameter hover should not use legacy dividers: {}",
-        param_hover.info.as_str()
+    assert_hover_snapshot!(
+        "verilog_2005_hover_uses_symbol_specific_renderers__param_def",
+        param_hover.info.as_str(),
     );
 
     let task_hover = analysis
@@ -2753,11 +2656,9 @@ endmodule
         )
         .unwrap()
         .expect("task hover expected");
-    assert!(
-        task_hover.info.as_str().contains("task drive(")
-            && task_hover.info.as_str().contains("value"),
-        "task hover should use subroutine-specific renderer: {}",
-        task_hover.info.as_str()
+    assert_hover_snapshot!(
+        "verilog_2005_hover_uses_symbol_specific_renderers__task_def",
+        task_hover.info.as_str(),
     );
 
     let func_hover = analysis
@@ -2767,12 +2668,9 @@ endmodule
         )
         .unwrap()
         .expect("function hover expected");
-    assert!(
-        func_hover.info.as_str().contains("function")
-            && func_hover.info.as_str().contains("add1(")
-            && func_hover.info.as_str().contains("value"),
-        "function hover should use subroutine-specific renderer: {}",
-        func_hover.info.as_str()
+    assert_hover_snapshot!(
+        "verilog_2005_hover_uses_symbol_specific_renderers__func_def",
+        func_hover.info.as_str(),
     );
 }
 
@@ -2799,31 +2697,9 @@ endmodule
         )
         .unwrap()
         .expect("ambiguous module hover expected");
-    let info = hover.info.as_str();
-
-    assert!(
-        info.starts_with("Module reference `child`"),
-        "ambiguous hover should start with the canonical title: {info}"
-    );
-    assert!(
-        info.contains("```systemverilog\nchild\n```"),
-        "ambiguous hover should render the reference as the primary code block: {info}"
-    );
-    assert!(
-        info.contains("\n\n---\n\nFacts\n- Status: ambiguous\n- Candidates: 2"),
-        "ambiguous hover should render ambiguity summary as facts: {info}"
-    );
-    assert!(
-        info.contains("[feature.v]") && info.contains("line 2") && info.contains("line 5"),
-        "ambiguous hover should list linked declaration locations: {info}"
-    );
-    assert!(
-        !info.contains("input logic a") && !info.contains("output logic y"),
-        "ambiguous hover should not expand candidate signatures: {info}"
-    );
-    assert!(
-        info.contains("\n\n---\n\nCandidates\n- [") && !info.contains("---------"),
-        "ambiguous hover should use the canonical candidates section: {info}"
+    assert_hover_snapshot!(
+        "ambiguous_instantiation_hover_lists_locations_without_expanding_signatures",
+        hover.info.as_str(),
     );
 }
 
@@ -2852,10 +2728,9 @@ endmodule
         )
         .unwrap()
         .expect("module definition hover expected");
-    assert!(
-        hover.info.as_str().contains("module mux2X1"),
-        "module definition hover should resolve to the declared module: {}",
-        hover.info.as_str()
+    assert_hover_snapshot!(
+        "verilog_2005_module_definition_names_support_references",
+        hover.info.as_str(),
     );
 
     let refs = analysis
@@ -2885,20 +2760,20 @@ fn verilog_2005_hover_covers_all_definition_kinds() {
     let (host, file_id, _clean_text, markers) = setup_marked(VERILOG_2005_NAV_TEXT);
     let analysis = host.make_analysis();
 
-    for (marker, expected) in [
-        ("module_ref", "module child"),
-        ("port_ref", "input wire logic a"),
-        ("sig_ref", "wire logic sig"),
-        ("udp_ref", "primitive udp_and"),
-        ("task_ref", "task do_task"),
-        ("genvar_ref", "genvar"),
-        ("gen_label", "generate g_loop"),
-        ("specparam_ref", "specparam"),
-        ("instance_ref", "instance u_child"),
-        ("generate_ref", "generate g_loop"),
-        ("lane_ref", "wire logic lane"),
-        ("block_ref", "block blk"),
-        ("config_def", "config cfg_top"),
+    for marker in [
+        "module_ref",
+        "port_ref",
+        "sig_ref",
+        "udp_ref",
+        "task_ref",
+        "genvar_ref",
+        "gen_label",
+        "specparam_ref",
+        "instance_ref",
+        "generate_ref",
+        "lane_ref",
+        "block_ref",
+        "config_def",
     ] {
         let hover = analysis
             .hover(
@@ -2907,10 +2782,9 @@ fn verilog_2005_hover_covers_all_definition_kinds() {
             )
             .unwrap()
             .unwrap_or_else(|| panic!("{marker} hover expected"));
-        assert!(
-            hover.info.as_str().contains(expected),
-            "{marker} hover should contain {expected:?}: {}",
-            hover.info.as_str()
+        assert_hover_snapshot!(
+            &format!("verilog_2005_hover_covers_all_definition_kinds__{marker}"),
+            hover.info.as_str(),
         );
     }
 }

--- a/crates/ide/src/verilog_2005.rs
+++ b/crates/ide/src/verilog_2005.rs
@@ -1315,7 +1315,19 @@ endmodule
         .hover(position, HoverConfig { format: HoverFormat::PlainText })
         .unwrap()
         .expect("include hover expected");
-    assert!(hover.info.as_str().contains("defs.svh"), "hover should mention include target");
+    let info = hover.info.as_str();
+    assert!(
+        info.starts_with("Include `defs.svh`"),
+        "include hover should start with the canonical title: {info}"
+    );
+    assert!(
+        info.contains("```systemverilog\n`include \"defs.svh\"\n```"),
+        "include hover should render the directive as the primary code block: {info}"
+    );
+    assert!(
+        info.contains("\n\n---\n\nFacts\n- Resolves to: ["),
+        "include hover should render the resolved target as a fact link: {info}"
+    );
 }
 
 #[test]
@@ -1462,7 +1474,7 @@ endmodule
     );
     assert!(
         !hover.info.as_str().contains("`define `NEXT(value)")
-            && !hover.info.as_str().contains("--------------------"),
+            && !hover.info.as_str().contains("Expands to"),
         "macro argument hover should not show macro expansion away from the macro name: {}",
         hover.info.as_str()
     );
@@ -1521,10 +1533,12 @@ endmodule
             && info.contains("Macro")
             && info.contains("`MAKE_DECL(name)")
             && !info.contains("`define `MAKE_DECL(name)")
-            && info.contains("Expands to")
-            && info.contains("--------------------")
+            && info.starts_with("Macro `MAKE_DECL`")
+            && info.contains("\n\n---\n\nFacts\n- Source: [")
+            && info.contains("\n\n---\n\nExpansion\n```systemverilog\nlogic generated;\n```")
+            && !info.contains("--------------------")
             && info.contains("logic generated;")
-            && info.contains("from [feature.v]")
+            && !info.contains("from [feature.v]")
             && !info.contains("Context ")
             && !info.contains("Signature")
             && !info.contains("Arguments")
@@ -1542,7 +1556,7 @@ endmodule
     assert!(
         arg_info.contains("generated")
             && !arg_info.contains("`define `MAKE_DECL(name)")
-            && !arg_info.contains("--------------------"),
+            && !arg_info.contains("Expands to"),
         "macro argument hover should stay on the source token away from the macro name: {arg_info}"
     );
 }
@@ -1570,7 +1584,9 @@ endmodule
         assert!(
             info.contains("```systemverilog")
                 && info.contains(&format!("`{name}"))
-                && info.contains("--------------------")
+                && info.starts_with(&format!("Macro `{name}`"))
+                && info.contains("\n\n---\n\nFacts\n- Source: Builtin")
+                && !info.contains("--------------------")
                 && !info.contains("unavailable"),
             "builtin macro hover should show structured expansion: {info}"
         );
@@ -1600,13 +1616,15 @@ endmodule
             && info.contains("`DEMO_NEXT(value)")
             && !info.contains("`define `DEMO_NEXT(value)")
             && !info.contains("`MATH_ONE")
-            && info.contains("Expands to")
-            && info.contains("--------------------")
+            && info.starts_with("Macro `DEMO_NEXT`")
+            && info.contains("\n\n---\n\nFacts\n- Source: [")
+            && info.contains("\n\n---\n\nExpansion\n```systemverilog")
+            && !info.contains("--------------------")
             && info.contains("((payload_i) + 12'd1)")
             && info.contains("payload_i")
             && info.contains("12")
             && info.contains("'d")
-            && info.contains("from [feature.v]")
+            && info.contains("[feature.v]")
             && !info.contains("Context ")
             && !info.contains("Expansion steps"),
         "nested macro hover should show compact signature, result, and source: {info}"
@@ -1637,12 +1655,14 @@ endmodule
             && call_info.contains("`DEMO_NEXT(value)")
             && !call_info.contains("`define `DEMO_NEXT(value)")
             && !call_info.contains("`MATH_ONE")
-            && call_info.contains("Expands to")
-            && call_info.contains("--------------------")
+            && call_info.starts_with("Macro `DEMO_NEXT`")
+            && call_info.contains("\n\n---\n\nFacts\n- Source: [")
+            && call_info.contains("\n\n---\n\nExpansion\n```systemverilog")
+            && !call_info.contains("--------------------")
             && call_info.contains("((payload_i) + 12'd1)")
             && call_info.contains("payload_i")
             && call_info.contains("12")
-            && call_info.contains("from [feature.v]")
+            && call_info.contains("[feature.v]")
             && !call_info.contains("Context ")
             && !call_info.contains("Expansion steps"),
         "outer macro hover should keep compact expansion facts: {call_info}"
@@ -1671,10 +1691,12 @@ endmodule
             && payl_info.contains("Macro")
             && payl_info.contains("`PAYL")
             && !payl_info.contains("`define `PAYL payload_i")
-            && payl_info.contains("Expands to")
-            && payl_info.contains("--------------------")
+            && payl_info.contains("\n\n---\n\nMacro `PAYL`")
+            && payl_info.contains("\n\n---\n\nFacts\n- Source: [")
+            && payl_info.contains("\n\n---\n\nExpansion\n```systemverilog")
+            && !payl_info.contains("--------------------")
             && payl_info.contains("payload_i")
-            && payl_info.contains("from [feature.v]")
+            && !payl_info.contains("from [feature.v]")
             && !payl_info.contains("unavailable"),
         "PAYL hover should show the nested macro expansion without unavailable text: {payl_info}"
     );
@@ -1697,10 +1719,13 @@ endmodule
         .expect("macro call hover expected");
     let info = hover.info.as_str();
     assert!(
-        info.contains("```systemverilog")
+        info.starts_with("Macro `JOIN`")
+            && info.contains("```systemverilog")
             && info.contains("`JOIN(a, b)")
+            && info.contains("\n\n---\n\nFacts\n- Source: [")
+            && info.contains("\n\n---\n\nExpansion\n```systemverilog")
             && info.contains("foobar")
-            && info.contains("from [feature.v]")
+            && info.contains("[feature.v]")
             && !info.contains("unavailable"),
         "token paste expansion hover should show the expanded display text: {info}"
     );
@@ -1784,10 +1809,12 @@ endmodule
         .expect("DECL_PIPE macro call hover expected");
     let decl_info = decl_hover.info.as_str();
     assert!(
-        decl_info.contains("```systemverilog")
+        decl_info.starts_with("Macro `DECL_PIPE`")
+            && decl_info.contains("```systemverilog")
             && decl_info.contains("`DECL_PIPE(name, width)")
             && !decl_info.contains("`define `DECL_PIPE(name, width)")
-            && decl_info.contains("Expands to")
+            && decl_info.contains("\n\n---\n\nFacts\n- Source: [")
+            && decl_info.contains("\n\n---\n\nExpansion\n```systemverilog")
             && decl_info.contains("logic [(12)-1:0] sample_q")
             && !decl_info.contains("unavailable"),
         "DECL_PIPE hover should show expansion through configured predefine: {decl_info}"
@@ -1802,9 +1829,11 @@ endmodule
         .expect("PIPE_ASSIGN macro call hover expected");
     let assign_info = assign_hover.info.as_str();
     assert!(
-        assign_info.contains("`PIPE_ASSIGN(name, next_value)")
+        assign_info.starts_with("Macro `PIPE_ASSIGN`")
+            && assign_info.contains("`PIPE_ASSIGN(name, next_value)")
             && !assign_info.contains("`define `PIPE_ASSIGN(name, next_value)")
-            && assign_info.contains("Expands to")
+            && assign_info.contains("\n\n---\n\nFacts\n- Source: [")
+            && assign_info.contains("\n\n---\n\nExpansion\n```systemverilog")
             && assign_info.contains("trace_q <= (sample_q ^ {{(12-1){1'b0}}, 1'b1});")
             && !assign_info.contains("unavailable"),
         "PIPE_ASSIGN hover should show actual-argument expansion through configured predefine: {assign_info}"
@@ -1895,7 +1924,10 @@ endmodule
         hover.info.as_str().contains("`define LOCAL_WIDTH 8"),
         "hover should show macro definition"
     );
-    assert!(hover.info.as_str().contains("from [feature.v]"), "hover should show macro source");
+    assert!(
+        hover.info.as_str().contains("\n\n---\n\nFacts\n- Source: [feature.v]"),
+        "hover should show linked macro source"
+    );
 
     let conditional_nav = analysis
         .goto_definition(position(file_id, &markers, "conditional"))
@@ -2027,8 +2059,9 @@ endmodule
     );
     assert!(hover.info.as_str().contains("8"), "hover should show macro expansion");
     assert!(
-        hover.info.as_str().contains("from [include/defs.vh]"),
-        "hover should show project-relative macro source path: {}",
+        hover.info.as_str().contains("\n\n---\n\nFacts\n- Source: [include/defs.vh]")
+            && hover.info.as_str().contains("line 2"),
+        "hover should show linked project-relative macro source path: {}",
         hover.info.as_str()
     );
 
@@ -2668,8 +2701,19 @@ endmodule
         port_hover.info.as_str()
     );
     assert!(
-        port_hover.info.as_str().contains("---------"),
-        "port hover should separate signature and container: {}",
+        port_hover.info.as_str().starts_with("Port `clk`"),
+        "port hover should start with the canonical title: {}",
+        port_hover.info.as_str()
+    );
+    assert!(
+        port_hover.info.as_str().contains("\n\n---\n\nFacts\n- Scope: `child`")
+            && port_hover.info.as_str().contains("- Source: ["),
+        "port hover should render context as facts: {}",
+        port_hover.info.as_str()
+    );
+    assert!(
+        !port_hover.info.as_str().contains("---------"),
+        "port hover should not use legacy dividers: {}",
         port_hover.info.as_str()
     );
 
@@ -2686,8 +2730,19 @@ endmodule
         param_hover.info.as_str()
     );
     assert!(
-        param_hover.info.as_str().contains("---------"),
-        "parameter hover should separate signature and container: {}",
+        param_hover.info.as_str().starts_with("Localparam `DEPTH`"),
+        "parameter hover should start with the canonical title: {}",
+        param_hover.info.as_str()
+    );
+    assert!(
+        param_hover.info.as_str().contains("\n\n---\n\nFacts\n- Scope: `child`")
+            && param_hover.info.as_str().contains("- Source: ["),
+        "parameter hover should render context as facts: {}",
+        param_hover.info.as_str()
+    );
+    assert!(
+        !param_hover.info.as_str().contains("---------"),
+        "parameter hover should not use legacy dividers: {}",
         param_hover.info.as_str()
     );
 
@@ -2747,16 +2802,28 @@ endmodule
     let info = hover.info.as_str();
 
     assert!(
-        info.contains("Ambiguous reference"),
-        "ambiguous hover should identify the ambiguity: {info}"
+        info.starts_with("Module reference `child`"),
+        "ambiguous hover should start with the canonical title: {info}"
     );
     assert!(
-        info.contains("feature.v:2") && info.contains("feature.v:5"),
-        "ambiguous hover should list declaration locations: {info}"
+        info.contains("```systemverilog\nchild\n```"),
+        "ambiguous hover should render the reference as the primary code block: {info}"
+    );
+    assert!(
+        info.contains("\n\n---\n\nFacts\n- Status: ambiguous\n- Candidates: 2"),
+        "ambiguous hover should render ambiguity summary as facts: {info}"
+    );
+    assert!(
+        info.contains("[feature.v]") && info.contains("line 2") && info.contains("line 5"),
+        "ambiguous hover should list linked declaration locations: {info}"
     );
     assert!(
         !info.contains("input logic a") && !info.contains("output logic y"),
         "ambiguous hover should not expand candidate signatures: {info}"
+    );
+    assert!(
+        info.contains("\n\n---\n\nCandidates\n- [") && !info.contains("---------"),
+        "ambiguous hover should use the canonical candidates section: {info}"
     );
 }
 


### PR DESCRIPTION
## Summary
- Establish a shared hover layout with titles, SystemVerilog code blocks, canonical `---` dividers, and inline `in ... from ...` metadata lines.
- Render hover provenance and source locations as links, using relative labels for local source paths while preserving absolute file URI targets.
- Move Verilog-2005 hover expectations to insta snapshots with path normalization for temporary file links.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo insta test --check -p ide --lib -- verilog_2005 --nocapture`