### PR TITLE
chore: prepare v1.3.0-beta.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vide"
-version = "1.2.3"
+version = "1.3.0-beta.1"
 edition = "2024"
 authors = ["roifewu <roifewu@gmail.com>", "hongjr03 <hongjr03@gmail.com>"]
 repository = "https://github.com/pascal-lab/vide"

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vide-ide",
-  "version": "1.2.3",
+  "version": "1.3.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vide-ide",
-      "version": "1.2.3",
+      "version": "1.3.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vide-ide",
   "displayName": "Vide - Verilog/SystemVerilog Coding IDE",
   "description": "%extension.description%",
-  "version": "1.2.3",
+  "version": "1.3.0-beta.1",
   "publisher": "pascal-lab",
   "license": "MIT",
   "icon": "media/icon.png",


### PR DESCRIPTION
## Summary

Prepare the first 1.3.0 prerelease.

- Bump the Rust package version to `1.3.0-beta.1`.
- Bump the VS Code extension package and lockfile to `1.3.0-beta.1`.
- Validate that cargo-dist recognizes `v1.3.0-beta.1` as a prerelease tag.

## Verification

- `cargo fmt --all --check`
- `cargo test -p xtask`
- `npm test -- --runInBand` in `editors/vscode`
- `cargo-dist plan --tag v1.3.0-beta.1 --output-format=json`

## Release follow-up

After this PR lands and CI is green, push tag `v1.3.0-beta.1` from `master` to create a GitHub prerelease. The prerelease workflow should upload native archives and VSIX artifacts, but skip publishing to VS Code Marketplace/Open VSX.
