### PR TITLE
ci: fix debug artifact script on macos bash

### DIFF
--- a/scripts/build-artifact.sh
+++ b/scripts/build-artifact.sh
@@ -7,12 +7,10 @@ cargo_profile="${3:-release}"
 
 case "$cargo_profile" in
   release)
-    cargo_profile_args=(--release)
     cargo_profile_dir="release"
     artifact_profile_suffix=""
     ;;
   debug)
-    cargo_profile_args=()
     cargo_profile_dir="debug"
     artifact_profile_suffix="-debug"
     ;;
@@ -25,27 +23,27 @@ esac
 case "$target" in
   x86_64-unknown-linux-gnu)
     build_target="x86_64-unknown-linux-gnu.2.17"
-    cargo_cmd=(cargo zigbuild "${cargo_profile_args[@]}" --target "$build_target" -p vide --bin vide)
+    cargo_cmd=(cargo zigbuild)
     binary="target/$target/$cargo_profile_dir/vide"
     ;;
   aarch64-unknown-linux-gnu)
     build_target="aarch64-unknown-linux-gnu.2.17"
-    cargo_cmd=(cargo zigbuild "${cargo_profile_args[@]}" --target "$build_target" -p vide --bin vide)
+    cargo_cmd=(cargo zigbuild)
     binary="target/$target/$cargo_profile_dir/vide"
     ;;
   x86_64-unknown-linux-musl|aarch64-unknown-linux-musl)
     build_target="$target"
-    cargo_cmd=(cargo zigbuild "${cargo_profile_args[@]}" --target "$build_target" -p vide --bin vide)
+    cargo_cmd=(cargo zigbuild)
     binary="target/$target/$cargo_profile_dir/vide"
     ;;
   aarch64-apple-darwin)
     build_target="$target"
-    cargo_cmd=(cargo build "${cargo_profile_args[@]}" --target "$build_target" -p vide --bin vide)
+    cargo_cmd=(cargo build)
     binary="target/$target/$cargo_profile_dir/vide"
     ;;
   x86_64-pc-windows-msvc)
     build_target="$target"
-    cargo_cmd=(cargo build "${cargo_profile_args[@]}" --target "$build_target" -p vide --bin vide)
+    cargo_cmd=(cargo build)
     binary="target/$target/$cargo_profile_dir/vide.exe"
     ;;
   *)
@@ -53,6 +51,11 @@ case "$target" in
     exit 2
     ;;
 esac
+
+if [[ "$cargo_profile" == "release" ]]; then
+  cargo_cmd+=(--release)
+fi
+cargo_cmd+=(--target "$build_target" -p vide --bin vide)
 
 echo "::group::Build $target ($cargo_profile)"
 printf 'command:'


### PR DESCRIPTION
## Summary

Fix `scripts/build-artifact.sh` under macOS bash 3.2 with `set -u` when `cargo-profile: debug` is used.

The previous implementation expanded an intentionally empty array for debug builds. That works in newer bash, but macOS bash treats it as an unbound variable under `set -u`:

```text
scripts/build-artifact.sh: line 43: cargo_profile_args[@]: unbound variable
```

This patch builds the cargo command incrementally instead, only appending `--release` for release builds.

## Verification

- Reproduced from master CI: `Dev Artifacts / aarch64-apple-darwin`
- Local fake-cargo test for `aarch64-apple-darwin darwin-arm64 debug` confirmed:
  - command is `cargo build --target aarch64-apple-darwin -p vide --bin vide`
  - no `--release` is passed for debug
  - debug archive/staged server paths are produced
