### PR TITLE
ci: specify repository for VSIX release uploads

### DIFF
--- a/.github/workflows/publish-vsix.yml
+++ b/.github/workflows/publish-vsix.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Upload VSIX files
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           PLAN: ${{ inputs.plan }}
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

Fix VSIX upload jobs that run without a checkout.

`gh release upload` attempted to infer the repository from git, but the `upload-github-release` job only downloads artifacts and does not check out the repo. On the v1.3.0-beta.1 run this failed with:

```text
failed to run git: fatal: not a git repository
```

Set `GH_REPO` from `github.repository` so `gh release upload` does not need a local git remote.

## Verification

- YAML lint passed via patch tool
- Failure diagnosed from Release run 27872249699 job 82487105427
