### PR TITLE
refactor(hir): remove dead scaffolding and dedup scope queries

### DIFF
--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -114,19 +114,6 @@ impl HirDisplay for Ty {
             }
             Ty::Event => f.write_str("event"),
             Ty::Chandle => f.write_str("chandle"),
-            Ty::ClassHandle { def, .. } => hir_fmt_def_backed_type(f, "class", *def),
-            Ty::VirtualInterface { def, modport } => {
-                f.write_str("virtual interface")?;
-                if let Some(name) = def.name(f.db) {
-                    f.write_str(" ")?;
-                    f.write_str(name.as_str())?;
-                }
-                if let Some(modport) = modport.and_then(|def| def.name(f.db)) {
-                    f.write_str(".")?;
-                    f.write_str(modport.as_str())?;
-                }
-                Ok(())
-            }
             Ty::Alias { typedef, target } => {
                 let container = typedef.cont_id.to_container(f.db);
                 if let Some(name) = &container.get(typedef.value).name {

--- a/crates/hir/src/scope.rs
+++ b/crates/hir/src/scope.rs
@@ -1,27 +1,27 @@
-use la_arena::{Idx, RawIdx};
+use la_arena::{Arena, Idx, RawIdx};
 use smol_str::SmolStr;
 use syntax::ast;
 use triomphe::Arc;
 use utils::get::{Get, GetRef};
 
 use crate::{
-    container::{InContainer, InFile, InModule, InSubroutine},
+    container::{InContainer, InFile, InModule, InSubroutine, ScopeId},
     db::HirDb,
     file::HirFileId,
     hir_def::{
         PackageImport,
         block::BlockInfo,
         declaration::DeclarationId,
-        expr::declarator::{DeclId, DeclaratorParent},
+        expr::declarator::{DeclId, Declarator, DeclaratorParent},
         lower_ident_opt,
         module::{
             Module, ModuleKind, PackageId,
             generate::GenerateBlockId,
             port::{PortDeclId, Ports},
         },
-        stmt::StmtKind,
+        stmt::{Stmt, StmtKind},
         subroutine::{LocalSubroutineId, SubroutinePortId},
-        typedef::TypedefId,
+        typedef::{Typedef, TypedefId},
     },
     source_map::ToAstNode,
     symbol::{DefId, DefLoc, Import, NameScope},
@@ -36,6 +36,38 @@ use crate::{
 
 fn def_id(db: &dyn HirDb, loc: impl Into<DefLoc>) -> DefId {
     DefId::new(db, loc)
+}
+
+/// Inserts the data-net-param declarations and typedefs that every scope
+/// owns, keyed by `cont_id`. The declaration/typedef loops are identical across
+/// file, module, generate-block, block, and subroutine scopes, so they live
+/// here as the single source of truth.
+fn insert_decls_and_typedefs(
+    scope: &mut NameScope,
+    db: &dyn HirDb,
+    cont_id: ScopeId,
+    decls: &Arena<Declarator>,
+    typedefs: &Arena<Typedef>,
+) {
+    for (decl_id, decl) in decls.iter() {
+        scope.insert_value_opt(&decl.name, def_id(db, InContainer::new(cont_id, decl_id)));
+    }
+    for (typedef_id, typedef) in typedefs.iter() {
+        scope.insert_type_opt(&typedef.name, def_id(db, InContainer::new(cont_id, typedef_id)));
+    }
+}
+
+/// Inserts statement labels (and their nested named blocks), which every
+/// scope owns. Kept separate from `insert_decls_and_typedefs` so callers can
+/// place module/generate specific members between the two while preserving
+/// insertion order.
+fn insert_stmts(scope: &mut NameScope, db: &dyn HirDb, cont_id: ScopeId, stmts: &Arena<Stmt>) {
+    for (stmt_id, stmt) in stmts.iter() {
+        scope.insert_value_opt(&stmt.label, def_id(db, InContainer::new(cont_id, stmt_id)));
+        if let StmtKind::Block(BlockInfo { name, block_id }) = &stmt.kind {
+            scope.insert_value_opt(name, def_id(db, *block_id));
+        }
+    }
 }
 
 impl NameScope {
@@ -153,19 +185,13 @@ impl NameScope {
             scope.insert_value_opt(&subroutine.name, def_id(db, subroutine_id));
         }
 
-        for (decl_id, decl) in module.decls.iter() {
-            scope.insert_value_opt(
-                &decl.name,
-                def_id(db, InContainer::new(module_id.into(), decl_id)),
-            );
-        }
-
-        for (typedef_id, typedef) in module.typedefs.iter() {
-            scope.insert_type_opt(
-                &typedef.name,
-                def_id(db, InContainer::new(module_id.into(), typedef_id)),
-            );
-        }
+        insert_decls_and_typedefs(
+            &mut scope,
+            db,
+            module_id.into(),
+            &module.decls,
+            &module.typedefs,
+        );
 
         for (instance_id, instance) in module.instances.iter() {
             scope.insert_value_opt(
@@ -189,16 +215,7 @@ impl NameScope {
             }
         }
 
-        for (stmt_id, stmt) in module.stmts.iter() {
-            scope.insert_value_opt(
-                &stmt.label,
-                def_id(db, InContainer::new(module_id.into(), stmt_id)),
-            );
-
-            if let StmtKind::Block(BlockInfo { name, block_id }) = &stmt.kind {
-                scope.insert_value_opt(name, def_id(db, *block_id));
-            }
-        }
+        insert_stmts(&mut scope, db, module_id.into(), &module.stmts);
 
         Arc::new(scope)
     }
@@ -217,19 +234,13 @@ impl NameScope {
             scope.insert_value_opt(&subroutine.name, def_id(db, subroutine_id));
         }
 
-        for (decl_id, decl) in generate_block.decls.iter() {
-            scope.insert_value_opt(
-                &decl.name,
-                def_id(db, InContainer::new(generate_block_id.into(), decl_id)),
-            );
-        }
-
-        for (typedef_id, typedef) in generate_block.typedefs.iter() {
-            scope.insert_type_opt(
-                &typedef.name,
-                def_id(db, InContainer::new(generate_block_id.into(), typedef_id)),
-            );
-        }
+        insert_decls_and_typedefs(
+            &mut scope,
+            db,
+            generate_block_id.into(),
+            &generate_block.decls,
+            &generate_block.typedefs,
+        );
 
         for item in &generate_block.items {
             if let crate::hir_def::module::generate::GenerateBlockItem::GenerateBlockId(child_id) =
@@ -240,16 +251,7 @@ impl NameScope {
             }
         }
 
-        for (stmt_id, stmt) in generate_block.stmts.iter() {
-            scope.insert_value_opt(
-                &stmt.label,
-                def_id(db, InContainer::new(generate_block_id.into(), stmt_id)),
-            );
-
-            if let StmtKind::Block(BlockInfo { name, block_id }) = &stmt.kind {
-                scope.insert_value_opt(name, def_id(db, *block_id));
-            }
-        }
+        insert_stmts(&mut scope, db, generate_block_id.into(), &generate_block.stmts);
 
         Arc::new(scope)
     }
@@ -261,30 +263,8 @@ impl NameScope {
         let mut scope = NameScope::default();
         let block = db.block(block_id);
 
-        for (decl_id, decl) in block.decls.iter() {
-            scope.insert_value_opt(
-                &decl.name,
-                def_id(db, InContainer::new(block_id.into(), decl_id)),
-            );
-        }
-
-        for (typedef_id, typedef) in block.typedefs.iter() {
-            scope.insert_type_opt(
-                &typedef.name,
-                def_id(db, InContainer::new(block_id.into(), typedef_id)),
-            );
-        }
-
-        for (stmt_id, stmt) in block.stmts.iter() {
-            scope.insert_value_opt(
-                &stmt.label,
-                def_id(db, InContainer::new(block_id.into(), stmt_id)),
-            );
-
-            if let StmtKind::Block(BlockInfo { name, block_id }) = &stmt.kind {
-                scope.insert_value_opt(name, def_id(db, *block_id));
-            }
-        }
+        insert_decls_and_typedefs(&mut scope, db, block_id.into(), &block.decls, &block.typedefs);
+        insert_stmts(&mut scope, db, block_id.into(), &block.stmts);
 
         Arc::new(scope)
     }
@@ -304,30 +284,14 @@ impl NameScope {
             );
         }
 
-        for (decl_id, decl) in subroutine.decls.iter() {
-            scope.insert_value_opt(
-                &decl.name,
-                def_id(db, InContainer::new(subroutine_id.into(), decl_id)),
-            );
-        }
-
-        for (typedef_id, typedef) in subroutine.typedefs.iter() {
-            scope.insert_type_opt(
-                &typedef.name,
-                def_id(db, InContainer::new(subroutine_id.into(), typedef_id)),
-            );
-        }
-
-        for (stmt_id, stmt) in subroutine.stmts.iter() {
-            scope.insert_value_opt(
-                &stmt.label,
-                def_id(db, InContainer::new(subroutine_id.into(), stmt_id)),
-            );
-
-            if let StmtKind::Block(BlockInfo { name, block_id }) = &stmt.kind {
-                scope.insert_value_opt(name, def_id(db, *block_id));
-            }
-        }
+        insert_decls_and_typedefs(
+            &mut scope,
+            db,
+            subroutine_id.into(),
+            &subroutine.decls,
+            &subroutine.typedefs,
+        );
+        insert_stmts(&mut scope, db, subroutine_id.into(), &subroutine.stmts);
 
         Arc::new(scope)
     }

--- a/crates/hir/src/symbol.rs
+++ b/crates/hir/src/symbol.rs
@@ -165,9 +165,6 @@ pub enum DefKind {
     Interface,
     Package,
     Program,
-    Class,
-    Covergroup,
-    Checker,
     Udp,
     Config,
     Library,
@@ -177,8 +174,6 @@ pub enum DefKind {
     SubroutinePort,
     NonAnsiPort,
     Typedef,
-    Enum,
-    Struct,
     Net,
     Variable,
     Param,
@@ -186,12 +181,6 @@ pub enum DefKind {
     Genvar,
     Specparam,
     Instance,
-    ClassField,
-    Method,
-    Modport,
-    ClockingBlock,
-    Sequence,
-    Property,
     Stmt,
 }
 
@@ -200,27 +189,18 @@ impl DefKind {
         match self {
             DefKind::Module => SymbolKind::Module,
             DefKind::Interface => SymbolKind::Interface,
-            DefKind::Package
-            | DefKind::Program
-            | DefKind::Class
-            | DefKind::Covergroup
-            | DefKind::Checker
-            | DefKind::Modport
-            | DefKind::ClockingBlock
-            | DefKind::Sequence
-            | DefKind::Property => SymbolKind::Unknown,
+            DefKind::Package | DefKind::Program => SymbolKind::Unknown,
             DefKind::Udp => SymbolKind::Primitive,
             DefKind::Config => SymbolKind::Config,
             DefKind::Library => SymbolKind::Library,
             DefKind::Block => SymbolKind::Block,
             DefKind::GenerateBlock => SymbolKind::Generate,
-            DefKind::Subroutine | DefKind::Method => SymbolKind::Fn,
+            DefKind::Subroutine => SymbolKind::Fn,
             DefKind::NonAnsiPort => SymbolKind::NonAnsiPortLabel,
             DefKind::SubroutinePort | DefKind::Port => SymbolKind::PortDecl,
-            DefKind::Typedef | DefKind::Enum => SymbolKind::Typedef,
-            DefKind::Struct => SymbolKind::Struct,
+            DefKind::Typedef => SymbolKind::Typedef,
             DefKind::Net => SymbolKind::NetDecl,
-            DefKind::Variable | DefKind::ClassField => SymbolKind::DataDecl,
+            DefKind::Variable => SymbolKind::DataDecl,
             DefKind::Param => SymbolKind::ParamDecl,
             DefKind::Genvar => SymbolKind::Genvar,
             DefKind::Specparam => SymbolKind::Specparam,
@@ -235,10 +215,7 @@ impl DefKind {
             | DefKind::Interface
             | DefKind::Package
             | DefKind::Program
-            | DefKind::Class
-            | DefKind::Typedef
-            | DefKind::Enum
-            | DefKind::Struct => NameContext::Type,
+            | DefKind::Typedef => NameContext::Type,
             _ => NameContext::Value,
         }
     }

--- a/crates/hir/src/type_infer.rs
+++ b/crates/hir/src/type_infer.rs
@@ -175,14 +175,10 @@ fn type_of_def_id(db: &dyn HirDb, def_id: DefId) -> TyResult {
             .as_decl(db)
             .map(|decl| type_of_decl_impl(db, decl))
             .unwrap_or_else(|| TyResult::new(Ty::Unknown)),
-        DefKind::Typedef | DefKind::Struct => def_id
+        DefKind::Typedef => def_id
             .as_typedef(db)
             .map(|typedef| type_of_typedef_impl(db, typedef))
             .unwrap_or_else(|| TyResult::new(Ty::Unknown)),
-        DefKind::Enum => def_id
-            .as_typedef(db)
-            .map(|typedef| type_of_typedef_impl(db, typedef))
-            .unwrap_or_else(|| TyResult::new(Ty::Enum(def_id))),
         DefKind::SubroutinePort => def_id
             .as_subroutine_port(db)
             .map(|port| type_of_subroutine_port_impl(db, port))
@@ -202,20 +198,11 @@ fn type_of_def_id(db: &dyn HirDb, def_id: DefId) -> TyResult {
             .unwrap_or_else(|| TyResult::new(Ty::Unknown)),
         DefKind::Interface
         | DefKind::Program
-        | DefKind::Class
-        | DefKind::Covergroup
-        | DefKind::Checker
         | DefKind::Udp
         | DefKind::Config
         | DefKind::Library
         | DefKind::Subroutine
         | DefKind::NonAnsiPort
-        | DefKind::ClassField
-        | DefKind::Method
-        | DefKind::Modport
-        | DefKind::ClockingBlock
-        | DefKind::Sequence
-        | DefKind::Property
         | DefKind::Stmt => TyResult::new(Ty::Unknown),
     }
 }

--- a/crates/hir/src/type_infer.rs
+++ b/crates/hir/src/type_infer.rs
@@ -43,19 +43,10 @@ pub enum Ty {
     Dynamic(Box<Ty>),
     Event,
     Chandle,
-    ClassHandle { def: DefId, spec_args: Vec<SpecArg> },
-    VirtualInterface { def: DefId, modport: Option<DefId> },
     Alias { typedef: InContainer<TypedefId>, target: Box<Ty> },
     Module(ModuleId),
     GenerateBlock(GenerateBlockId),
     Block(crate::hir_def::block::BlockId),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SpecArg {
-    Default,
-    Value(ExprId),
-    Type(Ty),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -251,9 +242,7 @@ pub fn members_of_ty(db: &dyn HirDb, ty: &Ty) -> Vec<TyMember> {
         | Ty::Assoc { .. }
         | Ty::Dynamic(_)
         | Ty::Event
-        | Ty::Chandle
-        | Ty::ClassHandle { .. }
-        | Ty::VirtualInterface { .. } => Vec::new(),
+        | Ty::Chandle => Vec::new(),
     }
 }
 
@@ -285,8 +274,6 @@ pub fn type_class(db: &dyn HirDb, ty: &Ty) -> Option<TyClass> {
         | Ty::Dynamic(_)
         | Ty::Event
         | Ty::Chandle
-        | Ty::ClassHandle { .. }
-        | Ty::VirtualInterface { .. }
         | Ty::Module(_)
         | Ty::GenerateBlock(_)
         | Ty::Block(_) => None,
@@ -359,8 +346,6 @@ pub fn packed_bit_width(db: &dyn HirDb, ty: &Ty) -> Option<u64> {
         | Ty::Dynamic(_)
         | Ty::Event
         | Ty::Chandle
-        | Ty::ClassHandle { .. }
-        | Ty::VirtualInterface { .. }
         | Ty::Module(_)
         | Ty::GenerateBlock(_)
         | Ty::Block(_) => None,

--- a/crates/ide/src/semantic_tokens.rs
+++ b/crates/ide/src/semantic_tokens.rs
@@ -689,7 +689,7 @@ fn collect_resolved_path(
                 };
                 collector.tokens.add(sema_token);
             }
-            DefKind::Typedef | DefKind::Struct | DefKind::Enum => {
+            DefKind::Typedef => {
                 collector.tokens.add(SemaToken {
                     range,
                     tag: SemaTokenTag::Type,


### PR DESCRIPTION
## Summary

Cleanup follow-up to the merged semantic-foundations stack (#289/#290/#288), addressing the maintainability issues raised in review. Three independent commits, each behavior-preserving.

### 1. Drop dead `DefKind` variants
`DefId::kind()` never produced 11 variants (`Class`, `Covergroup`, `Checker`, `Modport`, `ClockingBlock`, `Sequence`, `Property`, `ClassField`, `Method`, `Struct`, `Enum`); they only sat in match arms returning `Unknown`/empty, which reads as "intentionally unsupported" when it is actually "not yet implemented". `DefKind` is already `#[non_exhaustive]`, so variants can be reintroduced together with their lowering later and the compiler will force every in-crate match to update then.

### 2. Drop dead `Ty` variants and `SpecArg`
`Ty::ClassHandle` and `Ty::VirtualInterface` are never constructed anywhere; they only appear in match arms returning `Unknown`/empty, alongside the `SpecArg` enum that exists solely to feed `ClassHandle`. Class/interface specialization is deferred, so these are forward scaffolding.

### 3. Deduplicate scope query member insertion
`module`/`generate_block`/`block`/`subroutine` scope queries each repeated the same decl/typedef/stmt-label insertion loops. Extracted into `insert_decls_and_typedefs` and `insert_stmts` so a new declaration category is added in one place, not four. Insertion order preserved (the two helpers bracket the container-specific members).

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (483 passed, unchanged from baseline)

## Notes

Each commit passes the full gate independently. Deliberately left untouched: the unreachable `BuiltinDataTy::Event|Chandle|Void` arms inside the `Ty::Builtin` matches of `type_class`/`packed_bit_width` — those types are promoted out of `Ty::Builtin` during normalization, so the arms are unreachable, but removing them would need a `_` wildcard (losing exhaustive coverage of `BuiltinDataTy`) or a larger representation unification; both are poorer tradeoffs than leaving the defensive arms. Flagging it here so it is a conscious decision, not an oversight.