### PR TITLE
refactor(root): remove direct slang dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ hir.workspace = true
 ide.workspace = true
 project-model.workspace = true
 syntax.workspace = true
-slang.workspace = true
 utils.workspace = true
 vfs.workspace = true
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ use const_format::formatcp;
 use itertools::Itertools;
 use lsp_server::Connection;
 use lsp_types::{MessageType, ShowMessageParams};
-use slang as _;
 use utils::{
     json::from_json,
     paths::{AbsPathBuf, patch_path_prefix},


### PR DESCRIPTION
## Summary

- remove the root package's direct `slang` dependency from `Cargo.toml`
- remove the unused `use slang as _;` import from `src/lib.rs`
- keep the workspace `slang` dependency for crates that still consume it, such as `syntax`

## Validation

- `cargo check -p vide --locked`