### PR TITLE
refactor(syntax): list explicit slang re-exports

### DIFF
--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -3,7 +3,18 @@ pub mod has_text_range;
 pub mod ptr;
 pub mod slang_ext;
 
-pub use slang::*;
+pub use slang::{
+    ActualArgument, Bit, ChildrenIter, Compilation, CxxSV, DiagnosticSeverity, EmittedToken, Event,
+    EventId, IncludeEdge, LexedTokenAtOffset, LiteralBase, MacroCallId, MacroDefinitionId,
+    MacroExpansionId, MacroParam, ParserExpectedSyntax, SVInt, SVLogic, SemanticFacts,
+    SourceBufferId, SourceBufferOrigin, SourceBufferRange, SourceLocation, SourceRange,
+    SyntaxAncestors, SyntaxChildren, SyntaxCursor, SyntaxDiagnostic, SyntaxElemPreorder,
+    SyntaxElement, SyntaxElementKind, SyntaxFacts, SyntaxIdxChildren, SyntaxKeywordContext,
+    SyntaxKind, SyntaxNode, SyntaxNodePreorder, SyntaxToken, SyntaxTokenWithParent, SyntaxTree,
+    SyntaxTreeBuffer, SyntaxTreeBufferIds, SyntaxTreeOptions, SyntaxTreeWithTrace, SyntaxTrivia,
+    SyntaxTriviaIter, SyntaxTriviaLoc, TimeUnit, Token, TokenKind, TokenOrigin, Trace, Trivia,
+    TriviaKind, WalkEvent, ast, preproc,
+};
 pub use slang_ext::*;
 
 #[macro_export]


### PR DESCRIPTION
## Summary
- replace `pub use slang::*` in the syntax crate with an explicit re-export list
- keep the existing syntax extension re-exports unchanged

## Validation
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`