### PR TITLE
fix(vscode): isolate package target outputs

### DIFF
--- a/editors/vscode/scripts/package/manifest.ts
+++ b/editors/vscode/scripts/package/manifest.ts
@@ -32,17 +32,16 @@ export function stagePackageJsonForTarget(
   context: PackageContext,
   plan: PackagePlan,
 ): string | undefined {
-  if (!plan.targetSpec.removeBrowserEntry && plan.profileTrace) {
-    return undefined;
-  }
-
   const packagePath = packageJsonPath(context);
   const originalPackageJson = fs.readFileSync(packagePath, 'utf8');
   const packageJson = JSON.parse(originalPackageJson) as {
+    main?: unknown;
     browser?: unknown;
     contributes?: { commands?: Array<{ command?: unknown }> };
   };
-  if (plan.targetSpec.removeBrowserEntry) {
+  if (plan.targetSpec.kind === 'web') {
+    delete packageJson.main;
+  } else if (plan.targetSpec.removeBrowserEntry) {
     delete packageJson.browser;
   }
   if (!plan.profileTrace) {
@@ -53,6 +52,16 @@ export function stagePackageJsonForTarget(
   }
   fs.writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
   return originalPackageJson;
+}
+
+export function stageDistFilesForTarget(context: PackageContext, plan: PackagePlan): void {
+  const distDir = path.join(context.vscodeDir, 'dist');
+  if (plan.targetSpec.kind === 'web') {
+    fs.rmSync(path.join(distDir, 'extension.js'), { force: true });
+    return;
+  }
+
+  fs.rmSync(path.join(distDir, 'browser'), { recursive: true, force: true });
 }
 
 export function stageProfileTraceAssets(context: PackageContext, plan: PackagePlan): void {

--- a/editors/vscode/scripts/package/packageExtension.ts
+++ b/editors/vscode/scripts/package/packageExtension.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import { type PackageContext, createPackageContext } from './context';
 import {
   restorePackageJson,
+  stageDistFilesForTarget,
   stageProfileTraceAssets,
   stagePackageJsonForTarget,
   syncReadmeFromRepoRoot,
@@ -25,7 +26,13 @@ export function packageExtension(
 
   if (plan.targetSpec.kind === 'web') {
     cleanRuntimeServerFiles(context);
-    runVscePackage(context, plan);
+    stageDistFilesForTarget(context, plan);
+    const originalPackageJson = stagePackageJsonForTarget(context, plan);
+    try {
+      runVscePackage(context, plan);
+    } finally {
+      restorePackageJson(context, originalPackageJson);
+    }
     return path.join(context.vscodeDir, plan.vsixFile);
   }
 
@@ -38,6 +45,7 @@ export function packageExtension(
   );
   cleanRuntimeServerFiles(context);
   const runtimeServerPath = stageRuntimeServer(context, targetServerPath, plan.targetSpec);
+  stageDistFilesForTarget(context, plan);
   const originalPackageJson = stagePackageJsonForTarget(context, plan);
 
   try {

--- a/editors/vscode/test/package.test.ts
+++ b/editors/vscode/test/package.test.ts
@@ -8,6 +8,7 @@ import type { PackageContext } from '../scripts/package/context';
 import { parsePackageCliArgs } from '../scripts/package/cli';
 import {
   restorePackageJson,
+  stageDistFilesForTarget,
   stagePackageJsonForTarget,
   stageProfileTraceAssets,
 } from '../scripts/package/manifest';
@@ -86,6 +87,90 @@ describe('package staging', () => {
       fs.readFileSync(path.join(context.vscodeDir, 'package.json'), 'utf8'),
       /vide\.profileDiagnostics/,
     );
+  });
+
+  it('removes desktop entry points from web packages', () => {
+    const context = temporaryPackageContext();
+    fs.writeFileSync(
+      path.join(context.vscodeDir, 'package.json'),
+      `${JSON.stringify(
+        {
+          main: './dist/extension.js',
+          browser: './dist/browser/extension.js',
+          contributes: {
+            commands: [
+              { command: 'vide.profileDiagnostics' },
+              { command: 'vide.showOutput' },
+            ],
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const plan = createPackagePlan({
+      target: 'web',
+      profile: 'release',
+      serverMode: 'build',
+    });
+    const originalPackageJson = stagePackageJsonForTarget(context, plan);
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(context.vscodeDir, 'package.json'), 'utf8'),
+    ) as {
+      main?: unknown;
+      browser?: unknown;
+      contributes?: { commands?: Array<{ command?: unknown }> };
+    };
+
+    assert.equal(packageJson.main, undefined);
+    assert.equal(packageJson.browser, './dist/browser/extension.js');
+    assert.deepEqual(packageJson.contributes?.commands, [{ command: 'vide.showOutput' }]);
+
+    restorePackageJson(context, originalPackageJson);
+    const restored = fs.readFileSync(path.join(context.vscodeDir, 'package.json'), 'utf8');
+    assert.match(restored, /"main"/);
+    assert.match(restored, /vide\.profileDiagnostics/);
+  });
+
+  it('removes stale desktop bundle from web packages', () => {
+    const context = temporaryPackageContext();
+    const nodeBundle = path.join(context.vscodeDir, 'dist', 'extension.js');
+    const browserBundle = path.join(context.vscodeDir, 'dist', 'browser', 'extension.js');
+    fs.mkdirSync(path.dirname(nodeBundle), { recursive: true });
+    fs.mkdirSync(path.dirname(browserBundle), { recursive: true });
+    fs.writeFileSync(nodeBundle, '');
+    fs.writeFileSync(browserBundle, '');
+
+    const plan = createPackagePlan({
+      target: 'web',
+      profile: 'release',
+      serverMode: 'build',
+    });
+    stageDistFilesForTarget(context, plan);
+
+    assert.equal(fs.existsSync(nodeBundle), false);
+    assert.equal(fs.existsSync(browserBundle), true);
+  });
+
+  it('removes stale browser bundle from native packages', () => {
+    const context = temporaryPackageContext();
+    const nodeBundle = path.join(context.vscodeDir, 'dist', 'extension.js');
+    const browserBundle = path.join(context.vscodeDir, 'dist', 'browser', 'extension.js');
+    fs.mkdirSync(path.dirname(nodeBundle), { recursive: true });
+    fs.mkdirSync(path.dirname(browserBundle), { recursive: true });
+    fs.writeFileSync(nodeBundle, '');
+    fs.writeFileSync(browserBundle, '');
+
+    const plan = createPackagePlan({
+      target: 'linux-x64',
+      profile: 'release',
+      serverMode: 'build',
+    });
+    stageDistFilesForTarget(context, plan);
+
+    assert.equal(fs.existsSync(nodeBundle), true);
+    assert.equal(fs.existsSync(browserBundle), false);
   });
 
   it('removes stale profile trace assets when profile trace is disabled', () => {


### PR DESCRIPTION
## Summary
- strip desktop-only `main` and profiling command contributions from web VSIX manifests
- remove stale desktop/browser bundles before packaging target-specific VSIX files
- add package staging tests for web/native output isolation

## Tests
- `node --import tsx --test test/package.test.ts`
- `npm run typecheck`
- `npm audit --omit=dev --json`
- `git diff --check`