### PR TITLE
refactor(analysis): unify profile parsing and diagnostics snapshots

### DIFF
--- a/crates/hir/src/base_db.rs
+++ b/crates/hir/src/base_db.rs
@@ -1,5 +1,6 @@
 pub use salsa::{self, Cancelled};
 
+pub mod analysis_snapshot;
 pub mod change;
 pub mod compilation_plan;
 pub mod diagnostics_config;

--- a/crates/hir/src/base_db/analysis_snapshot.rs
+++ b/crates/hir/src/base_db/analysis_snapshot.rs
@@ -92,15 +92,15 @@ mod tests {
     fn compilation_context_owns_immutable_inputs() {
         let context = CompilationContext::new(
             Some(CompilationProfileId(3)),
-            vec![FileId(1)],
+            vec![FileId::from_raw(1)],
             Vec::<AbsPathBuf>::new(),
             vec!["FEATURE=1".to_owned()],
-            vec![FileId(2)],
+            vec![FileId::from_raw(2)],
             vec!["top".to_owned()],
         );
 
         assert_eq!(context.profile, Some(CompilationProfileId(3)));
-        assert_eq!(context.root_ids(), [FileId(1)]);
-        assert_eq!(context.library_map_ids(), [FileId(2)]);
+        assert_eq!(context.root_ids(), [FileId::from_raw(1)]);
+        assert_eq!(context.library_map_ids(), [FileId::from_raw(2)]);
     }
 }

--- a/crates/hir/src/base_db/analysis_snapshot.rs
+++ b/crates/hir/src/base_db/analysis_snapshot.rs
@@ -22,7 +22,7 @@ impl AnalysisSnapshotId {
     }
 
     pub const fn next(self) -> Self {
-        Self(self.0.saturating_add(1))
+        Self(self.0.checked_add(1).expect("analysis snapshot id exhausted"))
     }
 }
 
@@ -88,6 +88,12 @@ mod tests {
         assert_eq!(initial.get(), 41);
         assert_eq!(initial.next().get(), 42);
         assert_eq!(AnalysisSnapshotId::default().get(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "analysis snapshot id exhausted")]
+    fn snapshot_id_overflow_fails_fast() {
+        AnalysisSnapshotId::new(u64::MAX).next();
     }
 
     #[test]

--- a/crates/hir/src/base_db/analysis_snapshot.rs
+++ b/crates/hir/src/base_db/analysis_snapshot.rs
@@ -1,0 +1,106 @@
+use triomphe::Arc;
+use utils::paths::AbsPathBuf;
+use vfs::FileId;
+
+use crate::base_db::project::CompilationProfileId;
+
+/// Stable identity for all analysis results derived from one immutable
+/// analysis state.
+///
+/// The id advances when the analysis host applies a change. Creating several
+/// read-only views of the same host state does not create several identities.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct AnalysisSnapshotId(u64);
+
+impl AnalysisSnapshotId {
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    pub const fn next(self) -> Self {
+        Self(self.0.saturating_add(1))
+    }
+}
+
+/// The complete compilation inputs visible to a single analysis snapshot.
+///
+/// Collections are stored behind immutable slices so callers cannot mutate a
+/// context in place and accidentally make a result refer to a different
+/// compilation. `roots` and `library_maps` contain VFS file ids, not paths;
+/// their text and paths are owned by the same salsa snapshot as the context.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompilationContext {
+    pub profile: Option<CompilationProfileId>,
+    pub roots: Arc<[FileId]>,
+    pub include_dirs: Arc<[AbsPathBuf]>,
+    pub predefines: Arc<[String]>,
+    pub library_maps: Arc<[FileId]>,
+    pub top_modules: Arc<[String]>,
+    pub document_revision: u64,
+}
+
+impl CompilationContext {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        profile: Option<CompilationProfileId>,
+        roots: impl Into<Arc<[FileId]>>,
+        include_dirs: impl Into<Arc<[AbsPathBuf]>>,
+        predefines: impl Into<Arc<[String]>>,
+        library_maps: impl Into<Arc<[FileId]>>,
+        top_modules: impl Into<Arc<[String]>>,
+        document_revision: u64,
+    ) -> Self {
+        Self {
+            profile,
+            roots: roots.into(),
+            include_dirs: include_dirs.into(),
+            predefines: predefines.into(),
+            library_maps: library_maps.into(),
+            top_modules: top_modules.into(),
+            document_revision,
+        }
+    }
+
+    pub fn root_ids(&self) -> &[FileId] {
+        &self.roots
+    }
+
+    pub fn library_map_ids(&self) -> &[FileId] {
+        &self.library_maps
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_ids_are_monotonic() {
+        let initial = AnalysisSnapshotId::new(41);
+        assert_eq!(initial.get(), 41);
+        assert_eq!(initial.next().get(), 42);
+        assert_eq!(AnalysisSnapshotId::default().get(), 0);
+    }
+
+    #[test]
+    fn compilation_context_owns_immutable_inputs() {
+        let context = CompilationContext::new(
+            Some(CompilationProfileId(3)),
+            vec![FileId(1)],
+            Vec::<AbsPathBuf>::new(),
+            vec!["FEATURE=1".to_owned()],
+            vec![FileId(2)],
+            vec!["top".to_owned()],
+            9,
+        );
+
+        assert_eq!(context.profile, Some(CompilationProfileId(3)));
+        assert_eq!(context.root_ids(), [FileId(1)]);
+        assert_eq!(context.library_map_ids(), [FileId(2)]);
+        assert_eq!(context.document_revision, 9);
+    }
+}

--- a/crates/hir/src/base_db/analysis_snapshot.rs
+++ b/crates/hir/src/base_db/analysis_snapshot.rs
@@ -72,6 +72,10 @@ impl CompilationContext {
     pub fn library_map_ids(&self) -> &[FileId] {
         &self.library_maps
     }
+
+    pub fn with_document_revision(&self, document_revision: u64) -> Self {
+        Self { document_revision, ..self.clone() }
+    }
 }
 
 #[cfg(test)]

--- a/crates/hir/src/base_db/analysis_snapshot.rs
+++ b/crates/hir/src/base_db/analysis_snapshot.rs
@@ -40,11 +40,9 @@ pub struct CompilationContext {
     pub predefines: Arc<[String]>,
     pub library_maps: Arc<[FileId]>,
     pub top_modules: Arc<[String]>,
-    pub document_revision: u64,
 }
 
 impl CompilationContext {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         profile: Option<CompilationProfileId>,
         roots: impl Into<Arc<[FileId]>>,
@@ -52,7 +50,6 @@ impl CompilationContext {
         predefines: impl Into<Arc<[String]>>,
         library_maps: impl Into<Arc<[FileId]>>,
         top_modules: impl Into<Arc<[String]>>,
-        document_revision: u64,
     ) -> Self {
         Self {
             profile,
@@ -61,7 +58,6 @@ impl CompilationContext {
             predefines: predefines.into(),
             library_maps: library_maps.into(),
             top_modules: top_modules.into(),
-            document_revision,
         }
     }
 
@@ -71,10 +67,6 @@ impl CompilationContext {
 
     pub fn library_map_ids(&self) -> &[FileId] {
         &self.library_maps
-    }
-
-    pub fn with_document_revision(&self, document_revision: u64) -> Self {
-        Self { document_revision, ..self.clone() }
     }
 }
 
@@ -105,12 +97,10 @@ mod tests {
             vec!["FEATURE=1".to_owned()],
             vec![FileId(2)],
             vec!["top".to_owned()],
-            9,
         );
 
         assert_eq!(context.profile, Some(CompilationProfileId(3)));
         assert_eq!(context.root_ids(), [FileId(1)]);
         assert_eq!(context.library_map_ids(), [FileId(2)]);
-        assert_eq!(context.document_revision, 9);
     }
 }

--- a/crates/hir/src/base_db/change.rs
+++ b/crates/hir/src/base_db/change.rs
@@ -3,7 +3,7 @@ use triomphe::Arc;
 use vfs::{Change as VfsChange, ChangedFile};
 
 use crate::base_db::{
-    project::{PreprocessConfig, SharedProjectConfig},
+    project::SharedProjectConfig,
     source_db::SourceRootDb,
     source_root::{SourceRoot, SourceRootId},
 };
@@ -83,33 +83,9 @@ impl Change {
             db.set_file_text_with_durability(file_id, text, durability);
         }
 
-        update_file_preprocess_configs(db, files.as_ref());
-
         if files_changed {
             db.set_files_with_durability(files, Durability::HIGH);
         }
-    }
-}
-
-fn update_file_preprocess_configs(
-    db: &mut dyn SourceRootDb,
-    files: &rustc_hash::FxHashSet<vfs::FileId>,
-) {
-    let project_config = db.project_config();
-    for file_id in files.iter().copied() {
-        let source_root_id = db.source_root_id(file_id);
-        let source_root = db.source_root(source_root_id);
-        let profile_id = db.file_compilation_profile(file_id);
-        let preprocess = if source_root.is_ignored() {
-            PreprocessConfig::default()
-        } else {
-            project_config.preprocess_for_profile(profile_id)
-        };
-        db.set_file_preprocess_config_with_durability(
-            file_id,
-            Arc::new(preprocess),
-            durability(&source_root),
-        );
     }
 }
 

--- a/crates/hir/src/base_db/source_db.rs
+++ b/crates/hir/src/base_db/source_db.rs
@@ -707,7 +707,7 @@ mod tests {
 
     use super::*;
     use crate::base_db::{
-        project::{CompilationProfile, Predefine, PredefineSource},
+        project::{CompilationProfile, Predefine, PredefineSource, PreprocessConfig},
         salsa::{self, Durability},
     };
 
@@ -824,13 +824,35 @@ mod tests {
 
     #[test]
     fn parsed_profile_uses_the_compilation_context() {
-        let db = db_with_root_file();
+        let mut db = db_with_root_file();
         db.set_project_config_with_durability(Arc::new(ProjectConfig::default()), Durability::LOW);
         let profile = db.parsed_profile(None);
         assert_eq!(profile.units.len(), 1);
         let tree = profile.units[0].1.syntax_tree.clone();
         let root = tree.root().expect("compilation parse should have a root");
         assert!(root.children().next().is_some());
+    }
+
+    #[test]
+    fn profile_compilation_units_reuse_the_authoritative_profile_parse() {
+        let mut db = db_with_root_file();
+        db.set_project_config_with_durability(
+            Arc::new(ProjectConfig::new(
+                vec![Some(CompilationProfileId(0))],
+                vec![CompilationProfile {
+                    source_roots: vec![ROOT],
+                    top_modules: Vec::new(),
+                    preprocess: PreprocessConfig::default(),
+                }],
+            )),
+            Durability::LOW,
+        );
+
+        let profile_tree =
+            db.parsed_profile(Some(CompilationProfileId(0))).units[0].1.syntax_tree.clone();
+        let compilation_tree = db.parsed_compilation_unit(TOP).syntax_tree;
+
+        assert_eq!(profile_tree, compilation_tree);
     }
 
     #[test]

--- a/crates/hir/src/base_db/source_db.rs
+++ b/crates/hir/src/base_db/source_db.rs
@@ -84,11 +84,8 @@ pub struct ParsedCompilationUnit {
     pub preprocessor_trace: Option<Trace>,
 }
 
-type CompilationProfileParsedUnits = Arc<[(FileId, ParsedCompilationUnit, SyntaxTreeBufferIds)]>;
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompilationProfileAnalysis {
-    parsed_units: CompilationProfileParsedUnits,
     diagnostics: Arc<[CompilationDiagnostic]>,
 }
 
@@ -442,8 +439,6 @@ fn compilation_profile_analysis(
     )
     .entered();
     let mut compilation = Compilation::new_with_top_modules(&context.top_modules);
-    let mut root_file_ids = Vec::with_capacity(root_count);
-    let mut root_buffer_ids = Vec::with_capacity(root_count);
     let mut buffer_file_ids = FxHashMap::default();
     let path_file_ids = path_file_ids(db);
 
@@ -472,35 +467,12 @@ fn compilation_profile_analysis(
             SourceFileKind::IncludeHeader | SourceFileKind::ProjectManifest => continue,
         };
         let buffer_ids_for_map = buffer_ids.clone();
-        root_file_ids.push(file_id);
-        root_buffer_ids.push(buffer_ids);
         insert_buffer_file_ids(&mut buffer_file_ids, &path_file_ids, buffer_ids_for_map, file_id);
     }
 
-    let syntax_trees = compilation.syntax_trees();
-    assert_eq!(
-        syntax_trees.len(),
-        root_file_ids.len(),
-        "slang compilation returned a different number of syntax trees than roots"
-    );
-    let parsed_units = root_file_ids
-        .into_iter()
-        .zip(root_buffer_ids)
-        .zip(syntax_trees)
-        .map(|((file_id, buffer_ids), syntax_tree)| {
-            (
-                file_id,
-                ParsedCompilationUnit {
-                    preprocessor_trace: syntax_tree.preprocessor_trace(),
-                    syntax_tree,
-                },
-                buffer_ids,
-            )
-        })
-        .collect::<Vec<_>>();
     let diagnostics =
         compilation_diagnostics_from_compilation(&config, &compilation, &buffer_file_ids);
-    Arc::new(CompilationProfileAnalysis { parsed_units: Arc::from(parsed_units), diagnostics })
+    Arc::new(CompilationProfileAnalysis { diagnostics })
 }
 
 fn compilation_diagnostics_from_compilation(
@@ -797,7 +769,7 @@ mod tests {
     }
 
     #[test]
-    fn compilation_profile_parse_exposes_a_root_syntax_tree() {
+    fn compilation_profile_analysis_uses_the_compilation_context() {
         let mut db = db_with_root_file();
         db.set_project_config_with_durability(Arc::new(ProjectConfig::default()), Durability::LOW);
         db.set_file_preprocess_config_with_durability(
@@ -810,8 +782,7 @@ mod tests {
         assert!(root.children().next().is_some());
 
         let profile_analysis = db.compilation_profile_analysis(None);
-        assert_eq!(profile_analysis.parsed_units.len(), 1);
-        assert!(profile_analysis.parsed_units[0].1.syntax_tree.root().is_some());
+        assert!(profile_analysis.diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/hir/src/base_db/source_db.rs
+++ b/crates/hir/src/base_db/source_db.rs
@@ -8,6 +8,7 @@ use utils::{line_index::TextSize, path_identity::PathIdentityIndex};
 use vfs::{AnchoredPath, FileId};
 
 use crate::base_db::{
+    analysis_snapshot::CompilationContext,
     compilation_plan::{self, CompilationPlan},
     diagnostics_config::{DiagnosticSource, DiagnosticsConfig},
     project::{CompilationProfileId, PreprocessConfig, ProjectConfig},
@@ -63,6 +64,12 @@ pub trait SourceDb: FileLoader + std::fmt::Debug {
 
     #[salsa::input]
     fn project_config(&self) -> Arc<ProjectConfig>;
+
+    /// Monotonic document revision owned by the analysis host. Keeping this as
+    /// an input makes every compilation context part of the same salsa state
+    /// as the text it describes.
+    #[salsa::input]
+    fn document_revision(&self) -> u64;
 }
 
 fn parse_src(db: &dyn SourceDb, file_id: FileId) -> SyntaxTree {
@@ -152,27 +159,24 @@ fn syntax_tree_options_for_file(
     file_id: FileId,
 ) -> syntax::SyntaxTreeOptions {
     let _span = tracing::info_span!("slang.syntax_tree_options.file", ?file_id).entered();
-    let preprocess = db.file_preprocess_config(file_id);
     let profile_id = db.file_compilation_profile(file_id);
+    let context = db.compilation_context(profile_id);
     let include_buffers = db.include_buffers_for_profile(profile_id).as_ref().clone();
     syntax::SyntaxTreeOptions {
-        predefines: preprocess.predefine_strings(),
-        include_paths: preprocess.include_dir_strings(),
+        predefines: context.predefines.to_vec(),
+        include_paths: context.include_dirs.iter().map(ToString::to_string).collect(),
         include_buffers,
         ..syntax::SyntaxTreeOptions::default()
     }
 }
 
 fn syntax_tree_options_for_profile(
-    project_config: &ProjectConfig,
-    profile_id: Option<CompilationProfileId>,
+    context: &CompilationContext,
     include_buffers: Vec<SyntaxTreeBuffer>,
 ) -> syntax::SyntaxTreeOptions {
-    let preprocess = project_config.preprocess_for_profile(profile_id);
-    let include_paths = preprocess.include_dir_strings();
     syntax::SyntaxTreeOptions {
-        predefines: preprocess.predefine_strings(),
-        include_paths,
+        predefines: context.predefines.to_vec(),
+        include_paths: context.include_dirs.iter().map(ToString::to_string).collect(),
         include_buffers,
         ..syntax::SyntaxTreeOptions::default()
     }
@@ -317,6 +321,10 @@ pub trait SourceRootDb: SourceDb {
         &self,
         profile_id: Option<CompilationProfileId>,
     ) -> Arc<CompilationPlan>;
+    fn compilation_context(
+        &self,
+        profile_id: Option<CompilationProfileId>,
+    ) -> Arc<CompilationContext>;
     /// Diagnostics produced by one slang compilation profile. This is the
     /// semantic diagnostics path, but it also returns parse diagnostics from
     /// the same syntax trees so one request does not parse the same roots
@@ -400,6 +408,28 @@ fn compilation_plan_for_profile(
     Arc::new(CompilationPlan::for_profile(db, profile_id))
 }
 
+fn compilation_context(
+    db: &dyn SourceRootDb,
+    profile_id: Option<CompilationProfileId>,
+) -> Arc<CompilationContext> {
+    let plan = db.compilation_plan_for_profile(profile_id);
+    let library_maps = plan
+        .roots
+        .iter()
+        .copied()
+        .filter(|file_id| matches!(db.file_kind(*file_id), SourceFileKind::LibraryMap))
+        .collect::<Vec<_>>();
+    Arc::new(CompilationContext::new(
+        profile_id,
+        plan.roots.clone(),
+        plan.include_dirs.clone(),
+        plan.predefines.clone(),
+        library_maps,
+        plan.top_modules.clone(),
+        db.document_revision(),
+    ))
+}
+
 fn include_buffers_for_profile(
     db: &dyn SourceRootDb,
     profile_id: Option<CompilationProfileId>,
@@ -450,14 +480,14 @@ fn compilation_profile_diagnostics(
         return Arc::from(Vec::<CompilationDiagnostic>::new());
     }
 
-    let project_config = db.project_config();
     let plan = db.compilation_plan_for_profile(Some(profile_id));
+    let context = db.compilation_context(Some(profile_id));
     let compilation_include_buffers = {
         let _span = tracing::info_span!("slang.semantic.compilation_buffers").entered();
         compilation_plan::compilation_source_buffers_for_plan(db, &plan)
     };
     let root_count = plan.roots.len();
-    let top_module_count = plan.top_modules.len();
+    let top_module_count = context.top_modules.len();
     let include_buffer_count = compilation_include_buffers.len();
     let _span = tracing::info_span!(
         "slang.compilation_profile_diagnostics",
@@ -467,19 +497,16 @@ fn compilation_profile_diagnostics(
         include_buffer_count
     )
     .entered();
-    let compilation_options = syntax_tree_options_for_profile(
-        &project_config,
-        Some(profile_id),
-        compilation_include_buffers,
-    );
-    let mut compilation = Compilation::new_with_top_modules(&plan.top_modules);
+    let compilation_options =
+        syntax_tree_options_for_profile(&context, compilation_include_buffers);
+    let mut compilation = Compilation::new_with_top_modules(&context.top_modules);
     let mut buffer_file_ids = FxHashMap::default();
     let path_file_ids = path_file_ids(db);
     let mut compilation_root_count = 0usize;
     let mut compilation_buffer_count = 0usize;
     {
         let _span = tracing::info_span!("slang.semantic.add_roots", root_count).entered();
-        for file_id in plan.roots.iter().copied() {
+        for file_id in context.roots.iter().copied() {
             let text = {
                 let _span =
                     tracing::info_span!("slang.semantic.add_root.file_text", ?file_id).entered();

--- a/crates/hir/src/base_db/source_db.rs
+++ b/crates/hir/src/base_db/source_db.rs
@@ -11,7 +11,7 @@ use crate::base_db::{
     analysis_snapshot::CompilationContext,
     compilation_plan::{self, CompilationPlan},
     diagnostics_config::{DiagnosticSource, DiagnosticsConfig},
-    project::{CompilationProfileId, PreprocessConfig, ProjectConfig},
+    project::{CompilationProfileId, ProjectConfig},
     source_root::{SourceRoot, SourceRootId},
 };
 
@@ -52,9 +52,6 @@ pub trait SourceDb: FileLoader + std::fmt::Debug {
     fn file_path(&self, file_id: FileId) -> Option<utils::paths::AbsPathBuf>;
 
     #[salsa::input]
-    fn file_preprocess_config(&self, file_id: FileId) -> Arc<PreprocessConfig>;
-
-    #[salsa::input]
     fn files(&self) -> Box<FxHashSet<FileId>>;
 
     #[salsa::input]
@@ -84,9 +81,16 @@ pub struct ParsedCompilationUnit {
     pub preprocessor_trace: Option<Trace>,
 }
 
+pub type ParsedProfileUnits = Arc<[(FileId, ParsedCompilationUnit, SyntaxTreeBufferIds)]>;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CompilationProfileAnalysis {
-    diagnostics: Arc<[CompilationDiagnostic]>,
+pub struct ParsedProfile {
+    pub units: ParsedProfileUnits,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompilationProfileDiagnostics {
+    pub diagnostics: Arc<[CompilationDiagnostic]>,
 }
 
 fn source_file_identity(db: &dyn SourceDb, file_id: FileId) -> SourceFileIdentity {
@@ -151,7 +155,36 @@ fn syntax_tree_options_for_profile(
 }
 
 fn parsed_compilation_unit(db: &dyn SourceRootDb, file_id: FileId) -> ParsedCompilationUnit {
-    let _span = tracing::info_span!("slang.parse_for_compilation", ?file_id).entered();
+    let profile_id = db.file_compilation_profile(file_id);
+    if let Some(profile_id) = profile_id {
+        let plan = db.compilation_plan_for_profile(Some(profile_id));
+        if plan.roots.contains(&file_id) {
+            let parsed_profile = db.parsed_profile(Some(profile_id));
+            let Some((_, parsed, _)) =
+                parsed_profile.units.iter().find(|(root_file_id, _, _)| *root_file_id == file_id)
+            else {
+                panic!(
+                    "profile root {file_id:?} is missing from authoritative parse for profile {profile_id:?}"
+                );
+            };
+            tracing::debug!(
+                ?profile_id,
+                ?file_id,
+                root_count = plan.roots.len(),
+                parse_mode = "authoritative",
+                "reusing profile root syntax tree"
+            );
+            return parsed.clone();
+        }
+    }
+
+    let _span = tracing::info_span!(
+        "slang.parse_for_compilation",
+        ?profile_id,
+        ?file_id,
+        parse_mode = "authoritative"
+    )
+    .entered();
     let text = {
         let _span =
             tracing::info_span!("slang.parse_for_compilation.file_text", ?file_id).entered();
@@ -192,6 +225,68 @@ fn parsed_compilation_unit(db: &dyn SourceRootDb, file_id: FileId) -> ParsedComp
     }
 }
 
+fn parsed_profile(
+    db: &dyn SourceRootDb,
+    profile_id: Option<CompilationProfileId>,
+) -> Arc<ParsedProfile> {
+    let context = db.compilation_context(profile_id);
+    let plan = db.compilation_plan_for_profile(profile_id);
+    let include_buffers = compilation_plan::include_buffers_for_plan(db, &plan);
+    let root_count = plan.roots.len();
+    let _span = tracing::info_span!(
+        "slang.profile_parse",
+        ?profile_id,
+        root_count,
+        parse_mode = "authoritative"
+    )
+    .entered();
+
+    let mut session = Compilation::new_with_top_modules(&context.top_modules);
+    let mut units = Vec::with_capacity(root_count);
+    for file_id in plan.roots.iter().copied() {
+        let text = db.file_text(file_id);
+        let identity = source_file_identity(db, file_id);
+        let (syntax_tree, preprocessor_trace) = match db.file_kind(file_id) {
+            SourceFileKind::SystemVerilog => {
+                let options = syntax_tree_options_for_profile(&context, include_buffers.clone());
+                let syntax_tree = session.parse_syntax_tree_from_text(
+                    &text,
+                    &identity.name,
+                    &identity.path,
+                    &options,
+                );
+                let preprocessor_trace = syntax_tree.preprocessor_trace();
+                (syntax_tree, preprocessor_trace)
+            }
+            SourceFileKind::LibraryMap => (
+                session.parse_library_map_syntax_tree_from_text(
+                    &text,
+                    &identity.name,
+                    &identity.path,
+                ),
+                None,
+            ),
+            SourceFileKind::IncludeHeader | SourceFileKind::ProjectManifest => {
+                panic!("non-compilation unit {file_id:?} appeared in profile roots")
+            }
+        };
+        let buffer_ids = syntax_tree.buffer_ids();
+        units.push((
+            file_id,
+            ParsedCompilationUnit { syntax_tree, preprocessor_trace },
+            buffer_ids,
+        ));
+    }
+
+    tracing::debug!(
+        ?profile_id,
+        root_count = units.len(),
+        parse_mode = "authoritative",
+        "profile authoritative parse complete"
+    );
+    Arc::new(ParsedProfile { units: Arc::from(units) })
+}
+
 fn parse_src_for_compilation(db: &dyn SourceRootDb, file_id: FileId) -> SyntaxTree {
     db.parsed_compilation_unit(file_id).syntax_tree.clone()
 }
@@ -205,6 +300,14 @@ fn parser_expected_syntax(
         return Arc::from(Vec::<ParserExpectedSyntax>::new());
     }
 
+    let profile_id = db.file_compilation_profile(file_id);
+    let _span = tracing::info_span!(
+        "slang.parser_expected_syntax",
+        ?profile_id,
+        ?file_id,
+        parse_mode = "completion"
+    )
+    .entered();
     let text = db.file_text(file_id);
     let identity = source_file_identity(db, file_id);
     let offset = usize::from(offset);
@@ -301,7 +404,7 @@ pub trait SourceRootDb: SourceDb {
     fn compilation_profile_diagnostics(
         &self,
         profile_id: CompilationProfileId,
-    ) -> Arc<[CompilationDiagnostic]>;
+    ) -> Arc<CompilationProfileDiagnostics>;
     fn include_buffers_for_profile(
         &self,
         profile_id: Option<CompilationProfileId>,
@@ -323,10 +426,7 @@ pub trait SourceRootDb: SourceDb {
         profile_id: Option<CompilationProfileId>,
     ) -> Arc<crate::preproc::MacroReferenceIndex>;
     fn parsed_compilation_unit(&self, file_id: FileId) -> ParsedCompilationUnit;
-    fn compilation_profile_analysis(
-        &self,
-        profile_id: Option<CompilationProfileId>,
-    ) -> Arc<CompilationProfileAnalysis>;
+    fn parsed_profile(&self, profile_id: Option<CompilationProfileId>) -> Arc<ParsedProfile>;
     fn parse_src_for_compilation(&self, file_id: FileId) -> SyntaxTree;
     fn parser_expected_syntax(
         &self,
@@ -404,73 +504,36 @@ fn compilation_context(
 
 fn compilation_context_for_file(db: &dyn SourceRootDb, file_id: FileId) -> Arc<CompilationContext> {
     let profile_id = db.file_compilation_profile(file_id);
-    let context = db.compilation_context(profile_id);
-    let preprocess = db.file_preprocess_config(file_id);
-    Arc::new(CompilationContext::new(
-        context.profile,
-        context.roots.clone(),
-        preprocess.include_dirs.clone(),
-        preprocess.predefine_strings(),
-        context.library_maps.clone(),
-        context.top_modules.clone(),
-    ))
+    db.compilation_context(profile_id)
 }
 
-fn compilation_profile_analysis(
+fn compilation_profile_diagnostics(
     db: &dyn SourceRootDb,
-    profile_id: Option<CompilationProfileId>,
-) -> Arc<CompilationProfileAnalysis> {
+    profile_id: CompilationProfileId,
+) -> Arc<CompilationProfileDiagnostics> {
     let config = db.diagnostics_config();
-    let plan = db.compilation_plan_for_profile(profile_id);
-    let context = db.compilation_context(profile_id);
-    let compilation_include_buffers = {
-        let _span = tracing::info_span!("slang.compilation_profile_parse_buffers").entered();
-        compilation_plan::include_buffers_for_plan(db, &plan)
-    };
-    let root_count = context.roots.len();
-    let include_buffer_count = compilation_include_buffers.len();
-    let _span = tracing::info_span!(
-        "slang.compilation_profile_parse",
-        ?profile_id,
-        root_count,
-        include_buffer_count
-    )
-    .entered();
+    let _span =
+        tracing::info_span!("slang.profile_compilation", ?profile_id, parse_mode = "authoritative")
+            .entered();
+    if !config.enabled {
+        return Arc::new(CompilationProfileDiagnostics { diagnostics: Arc::from(Vec::new()) });
+    }
+
+    let context = db.compilation_context(Some(profile_id));
+    let parsed_profile = db.parsed_profile(Some(profile_id));
     let mut compilation = Compilation::new_with_top_modules(&context.top_modules);
     let mut buffer_file_ids = FxHashMap::default();
     let path_file_ids = path_file_ids(db);
 
-    for file_id in context.roots.iter().copied() {
-        let text = db.file_text(file_id);
-        let identity = source_file_identity(db, file_id);
-        let buffer_ids = match db.file_kind(file_id) {
-            SourceFileKind::SystemVerilog => {
-                let file_context = db.compilation_context_for_file(file_id);
-                let options = syntax_tree_options_for_profile(
-                    &file_context,
-                    compilation_include_buffers.clone(),
-                );
-                compilation.add_syntax_tree_from_text(
-                    &text,
-                    &identity.name,
-                    &identity.path,
-                    &options,
-                )
-            }
-            SourceFileKind::LibraryMap => compilation.add_library_map_syntax_tree_from_text(
-                &text,
-                &identity.name,
-                &identity.path,
-            ),
-            SourceFileKind::IncludeHeader | SourceFileKind::ProjectManifest => continue,
-        };
+    for (file_id, parsed_unit, buffer_ids) in parsed_profile.units.iter() {
+        compilation.add_syntax_tree(parsed_unit.syntax_tree.clone());
         let buffer_ids_for_map = buffer_ids.clone();
-        insert_buffer_file_ids(&mut buffer_file_ids, &path_file_ids, buffer_ids_for_map, file_id);
+        insert_buffer_file_ids(&mut buffer_file_ids, &path_file_ids, buffer_ids_for_map, *file_id);
     }
 
     let diagnostics =
         compilation_diagnostics_from_compilation(&config, &compilation, &buffer_file_ids);
-    Arc::new(CompilationProfileAnalysis { diagnostics })
+    Arc::new(CompilationProfileDiagnostics { diagnostics })
 }
 
 fn compilation_diagnostics_from_compilation(
@@ -529,42 +592,46 @@ fn compilation_diagnostics_from_compilation(
         );
     }
 
-    let raw_semantic_diagnostics = {
-        let _span = tracing::info_span!("slang.semantic.raw_diagnostics").entered();
-        compilation.semantic_diagnostics_with_options(&config.slang.warnings)
-    };
-    let raw_semantic_diagnostic_count = raw_semantic_diagnostics.len();
-    let mut unmapped_semantic_buffer_count = 0usize;
-    let mut ignored_semantic_diagnostic_count = 0usize;
-    {
-        let _span =
-            tracing::info_span!("slang.semantic.map_diagnostics", raw_semantic_diagnostic_count)
-                .entered();
-        diagnostics.extend(raw_semantic_diagnostics.into_iter().filter_map(|diag| {
-            let diag_file_id =
-                diag.buffer_id.and_then(|buffer_id| buffer_file_ids.get(&buffer_id).copied());
-            let Some(diag_file_id) = diag_file_id else {
-                unmapped_semantic_buffer_count += 1;
-                return None;
-            };
-            let Some(diag) = config.apply_rules(DiagnosticSource::Semantic, diag) else {
-                ignored_semantic_diagnostic_count += 1;
-                return None;
-            };
-            Some(CompilationDiagnostic {
-                file_id: diag_file_id,
-                source: DiagnosticSource::Semantic,
-                diagnostic: diag,
-            })
-        }));
+    if config.semantic.enabled {
+        let raw_semantic_diagnostics = {
+            let _span = tracing::info_span!("slang.semantic.raw_diagnostics").entered();
+            compilation.semantic_diagnostics_with_options(&config.slang.warnings)
+        };
+        let raw_semantic_diagnostic_count = raw_semantic_diagnostics.len();
+        let mut unmapped_semantic_buffer_count = 0usize;
+        let mut ignored_semantic_diagnostic_count = 0usize;
+        {
+            let _span = tracing::info_span!(
+                "slang.semantic.map_diagnostics",
+                raw_semantic_diagnostic_count
+            )
+            .entered();
+            diagnostics.extend(raw_semantic_diagnostics.into_iter().filter_map(|diag| {
+                let diag_file_id =
+                    diag.buffer_id.and_then(|buffer_id| buffer_file_ids.get(&buffer_id).copied());
+                let Some(diag_file_id) = diag_file_id else {
+                    unmapped_semantic_buffer_count += 1;
+                    return None;
+                };
+                let Some(diag) = config.apply_rules(DiagnosticSource::Semantic, diag) else {
+                    ignored_semantic_diagnostic_count += 1;
+                    return None;
+                };
+                Some(CompilationDiagnostic {
+                    file_id: diag_file_id,
+                    source: DiagnosticSource::Semantic,
+                    diagnostic: diag,
+                })
+            }));
+        }
+        tracing::info!(
+            raw_semantic_diagnostic_count,
+            unmapped_semantic_buffer_count,
+            ignored_semantic_diagnostic_count,
+            diagnostic_count = diagnostics.len(),
+            "semantic diagnostics complete"
+        );
     }
-    tracing::info!(
-        raw_semantic_diagnostic_count,
-        unmapped_semantic_buffer_count,
-        ignored_semantic_diagnostic_count,
-        diagnostic_count = diagnostics.len(),
-        "semantic diagnostics complete"
-    );
 
     Arc::from(diagnostics)
 }
@@ -599,7 +666,7 @@ fn file_compilation_diagnostics(
 ) -> Arc<[CompilationDiagnostic]> {
     let source_root_id = db.source_root_id(file_id);
     let config = db.diagnostics_config();
-    if !config.enabled || !config.semantic.enabled || db.file_is_project_ignored(file_id) {
+    if !config.enabled || db.file_is_project_ignored(file_id) {
         return Arc::from(Vec::<CompilationDiagnostic>::new());
     }
 
@@ -607,18 +674,7 @@ fn file_compilation_diagnostics(
     let Some(profile_id) = project_config.profile_for_root(source_root_id) else {
         return Arc::from(Vec::<CompilationDiagnostic>::new());
     };
-    db.compilation_profile_diagnostics(profile_id)
-}
-
-fn compilation_profile_diagnostics(
-    db: &dyn SourceRootDb,
-    profile_id: CompilationProfileId,
-) -> Arc<[CompilationDiagnostic]> {
-    let config = db.diagnostics_config();
-    if !config.enabled || !config.semantic.enabled {
-        return Arc::from(Vec::<CompilationDiagnostic>::new());
-    }
-    db.compilation_profile_analysis(Some(profile_id)).diagnostics.clone()
+    db.compilation_profile_diagnostics(profile_id).diagnostics.clone()
 }
 
 fn source_root_semantic_diagnostics(
@@ -767,20 +823,14 @@ mod tests {
     }
 
     #[test]
-    fn compilation_profile_analysis_uses_the_compilation_context() {
-        let mut db = db_with_root_file();
+    fn parsed_profile_uses_the_compilation_context() {
+        let db = db_with_root_file();
         db.set_project_config_with_durability(Arc::new(ProjectConfig::default()), Durability::LOW);
-        db.set_file_preprocess_config_with_durability(
-            TOP,
-            Arc::new(PreprocessConfig::default()),
-            Durability::LOW,
-        );
-        let tree = db.parse_src_for_compilation(TOP);
+        let profile = db.parsed_profile(None);
+        assert_eq!(profile.units.len(), 1);
+        let tree = profile.units[0].1.syntax_tree.clone();
         let root = tree.root().expect("compilation parse should have a root");
         assert!(root.children().next().is_some());
-
-        let profile_analysis = db.compilation_profile_analysis(None);
-        assert!(profile_analysis.diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/hir/src/base_db/source_db.rs
+++ b/crates/hir/src/base_db/source_db.rs
@@ -271,6 +271,13 @@ fn parsed_profile(
             }
         };
         let buffer_ids = syntax_tree.buffer_ids();
+        tracing::debug!(
+            ?profile_id,
+            ?file_id,
+            root_count,
+            parse_mode = "authoritative",
+            "profile root syntax tree parsed"
+        );
         units.push((
             file_id,
             ParsedCompilationUnit { syntax_tree, preprocessor_trace },

--- a/crates/hir/src/base_db/source_db.rs
+++ b/crates/hir/src/base_db/source_db.rs
@@ -84,6 +84,14 @@ pub struct ParsedCompilationUnit {
     pub preprocessor_trace: Option<Trace>,
 }
 
+type CompilationProfileParsedUnits = Arc<[(FileId, ParsedCompilationUnit, SyntaxTreeBufferIds)]>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompilationProfileAnalysis {
+    parsed_units: CompilationProfileParsedUnits,
+    diagnostics: Arc<[CompilationDiagnostic]>,
+}
+
 fn source_file_identity(db: &dyn SourceDb, file_id: FileId) -> SourceFileIdentity {
     let path = db.file_path(file_id).map(|path| path.to_string()).unwrap_or_default();
     let name = if path.is_empty() { "source".to_owned() } else { path.clone() };
@@ -318,6 +326,10 @@ pub trait SourceRootDb: SourceDb {
         profile_id: Option<CompilationProfileId>,
     ) -> Arc<crate::preproc::MacroReferenceIndex>;
     fn parsed_compilation_unit(&self, file_id: FileId) -> ParsedCompilationUnit;
+    fn compilation_profile_analysis(
+        &self,
+        profile_id: Option<CompilationProfileId>,
+    ) -> Arc<CompilationProfileAnalysis>;
     fn parse_src_for_compilation(&self, file_id: FileId) -> SyntaxTree;
     fn parser_expected_syntax(
         &self,
@@ -409,127 +421,96 @@ fn compilation_context_for_file(db: &dyn SourceRootDb, file_id: FileId) -> Arc<C
     ))
 }
 
-fn include_buffers_for_profile(
+fn compilation_profile_analysis(
     db: &dyn SourceRootDb,
     profile_id: Option<CompilationProfileId>,
-) -> Arc<Vec<SyntaxTreeBuffer>> {
+) -> Arc<CompilationProfileAnalysis> {
+    let config = db.diagnostics_config();
     let plan = db.compilation_plan_for_profile(profile_id);
-    Arc::new(compilation_plan::include_buffers_for_plan(db, &plan))
-}
-
-fn macro_reference_index_for_profile(
-    db: &dyn SourceRootDb,
-    profile_id: Option<CompilationProfileId>,
-) -> Arc<crate::preproc::MacroReferenceIndex> {
-    Arc::new(crate::preproc::build_macro_reference_index(db, profile_id))
-}
-
-fn semantic_diagnostics(db: &dyn SourceRootDb, file_id: FileId) -> Arc<[SyntaxDiagnostic]> {
-    Arc::from(
-        db.source_root_semantic_diagnostics(file_id)
-            .iter()
-            .filter_map(|(diag_file_id, diag)| (*diag_file_id == file_id).then_some(diag.clone()))
-            .collect::<Vec<_>>(),
-    )
-}
-
-fn file_compilation_diagnostics(
-    db: &dyn SourceRootDb,
-    file_id: FileId,
-) -> Arc<[CompilationDiagnostic]> {
-    let source_root_id = db.source_root_id(file_id);
-    let config = db.diagnostics_config();
-    if !config.enabled || !config.semantic.enabled || db.file_is_project_ignored(file_id) {
-        return Arc::from(Vec::<CompilationDiagnostic>::new());
-    }
-
-    let project_config = db.project_config();
-    let Some(profile_id) = project_config.profile_for_root(source_root_id) else {
-        return Arc::from(Vec::<CompilationDiagnostic>::new());
-    };
-    db.compilation_profile_diagnostics(profile_id)
-}
-
-fn compilation_profile_diagnostics(
-    db: &dyn SourceRootDb,
-    profile_id: CompilationProfileId,
-) -> Arc<[CompilationDiagnostic]> {
-    let config = db.diagnostics_config();
-    if !config.enabled || !config.semantic.enabled {
-        return Arc::from(Vec::<CompilationDiagnostic>::new());
-    }
-
-    let plan = db.compilation_plan_for_profile(Some(profile_id));
-    let context = db.compilation_context(Some(profile_id));
+    let context = db.compilation_context(profile_id);
     let compilation_include_buffers = {
-        let _span = tracing::info_span!("slang.semantic.compilation_buffers").entered();
-        compilation_plan::compilation_source_buffers_for_plan(db, &plan)
+        let _span = tracing::info_span!("slang.compilation_profile_parse_buffers").entered();
+        compilation_plan::include_buffers_for_plan(db, &plan)
     };
-    let root_count = plan.roots.len();
-    let top_module_count = context.top_modules.len();
+    let root_count = context.roots.len();
     let include_buffer_count = compilation_include_buffers.len();
     let _span = tracing::info_span!(
-        "slang.compilation_profile_diagnostics",
+        "slang.compilation_profile_parse",
         ?profile_id,
         root_count,
-        top_module_count,
         include_buffer_count
     )
     .entered();
     let mut compilation = Compilation::new_with_top_modules(&context.top_modules);
+    let mut root_file_ids = Vec::with_capacity(root_count);
+    let mut root_buffer_ids = Vec::with_capacity(root_count);
     let mut buffer_file_ids = FxHashMap::default();
     let path_file_ids = path_file_ids(db);
-    let mut compilation_root_count = 0usize;
-    let mut compilation_buffer_count = 0usize;
-    {
-        let _span = tracing::info_span!("slang.semantic.add_roots", root_count).entered();
-        for file_id in context.roots.iter().copied() {
-            let text = {
-                let _span =
-                    tracing::info_span!("slang.semantic.add_root.file_text", ?file_id).entered();
-                db.file_text(file_id)
-            };
-            let identity = source_file_identity(db, file_id);
-            let buffer_ids = match db.file_kind(file_id) {
-                SourceFileKind::SystemVerilog => {
-                    let file_context = db.compilation_context_for_file(file_id);
-                    let compilation_options = syntax_tree_options_for_profile(
-                        &file_context,
-                        compilation_include_buffers.clone(),
-                    );
-                    let include_buffer_count = compilation_options.include_buffers.len();
-                    let _span = tracing::info_span!(
-                        "slang.semantic.add_root.from_text",
-                        ?file_id,
-                        bytes = text.len(),
-                        include_buffer_count
-                    )
-                    .entered();
-                    compilation.add_syntax_tree_from_text(
-                        &text,
-                        &identity.name,
-                        &identity.path,
-                        &compilation_options,
-                    )
-                }
-                SourceFileKind::LibraryMap => compilation.add_library_map_syntax_tree_from_text(
+
+    for file_id in context.roots.iter().copied() {
+        let text = db.file_text(file_id);
+        let identity = source_file_identity(db, file_id);
+        let buffer_ids = match db.file_kind(file_id) {
+            SourceFileKind::SystemVerilog => {
+                let file_context = db.compilation_context_for_file(file_id);
+                let options = syntax_tree_options_for_profile(
+                    &file_context,
+                    compilation_include_buffers.clone(),
+                );
+                compilation.add_syntax_tree_from_text(
                     &text,
                     &identity.name,
                     &identity.path,
-                ),
-                SourceFileKind::IncludeHeader | SourceFileKind::ProjectManifest => continue,
-            };
-            compilation_root_count += 1;
-            compilation_buffer_count += 1 + buffer_ids.source_buffers.len();
-            insert_buffer_file_ids(&mut buffer_file_ids, &path_file_ids, buffer_ids, file_id);
-        }
+                    &options,
+                )
+            }
+            SourceFileKind::LibraryMap => compilation.add_library_map_syntax_tree_from_text(
+                &text,
+                &identity.name,
+                &identity.path,
+            ),
+            SourceFileKind::IncludeHeader | SourceFileKind::ProjectManifest => continue,
+        };
+        let buffer_ids_for_map = buffer_ids.clone();
+        root_file_ids.push(file_id);
+        root_buffer_ids.push(buffer_ids);
+        insert_buffer_file_ids(&mut buffer_file_ids, &path_file_ids, buffer_ids_for_map, file_id);
     }
-    tracing::info!(
-        compilation_root_count,
-        compilation_buffer_count,
-        mapped_buffer_count = buffer_file_ids.len(),
-        "semantic compilation roots added"
+
+    let syntax_trees = compilation.syntax_trees();
+    assert_eq!(
+        syntax_trees.len(),
+        root_file_ids.len(),
+        "slang compilation returned a different number of syntax trees than roots"
     );
+    let parsed_units = root_file_ids
+        .into_iter()
+        .zip(root_buffer_ids)
+        .zip(syntax_trees)
+        .map(|((file_id, buffer_ids), syntax_tree)| {
+            (
+                file_id,
+                ParsedCompilationUnit {
+                    preprocessor_trace: syntax_tree.preprocessor_trace(),
+                    syntax_tree,
+                },
+                buffer_ids,
+            )
+        })
+        .collect::<Vec<_>>();
+    let diagnostics =
+        compilation_diagnostics_from_compilation(&config, &compilation, &buffer_file_ids);
+    Arc::new(CompilationProfileAnalysis { parsed_units: Arc::from(parsed_units), diagnostics })
+}
+
+fn compilation_diagnostics_from_compilation(
+    config: &DiagnosticsConfig,
+    compilation: &Compilation,
+    buffer_file_ids: &FxHashMap<u32, FileId>,
+) -> Arc<[CompilationDiagnostic]> {
+    if !config.enabled || (!config.parse.enabled && !config.semantic.enabled) {
+        return Arc::from(Vec::<CompilationDiagnostic>::new());
+    }
 
     let mut diagnostics = Vec::new();
     if config.parse.enabled {
@@ -616,6 +597,58 @@ fn compilation_profile_diagnostics(
     );
 
     Arc::from(diagnostics)
+}
+
+fn include_buffers_for_profile(
+    db: &dyn SourceRootDb,
+    profile_id: Option<CompilationProfileId>,
+) -> Arc<Vec<SyntaxTreeBuffer>> {
+    let plan = db.compilation_plan_for_profile(profile_id);
+    Arc::new(compilation_plan::include_buffers_for_plan(db, &plan))
+}
+
+fn macro_reference_index_for_profile(
+    db: &dyn SourceRootDb,
+    profile_id: Option<CompilationProfileId>,
+) -> Arc<crate::preproc::MacroReferenceIndex> {
+    Arc::new(crate::preproc::build_macro_reference_index(db, profile_id))
+}
+
+fn semantic_diagnostics(db: &dyn SourceRootDb, file_id: FileId) -> Arc<[SyntaxDiagnostic]> {
+    Arc::from(
+        db.source_root_semantic_diagnostics(file_id)
+            .iter()
+            .filter_map(|(diag_file_id, diag)| (*diag_file_id == file_id).then_some(diag.clone()))
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn file_compilation_diagnostics(
+    db: &dyn SourceRootDb,
+    file_id: FileId,
+) -> Arc<[CompilationDiagnostic]> {
+    let source_root_id = db.source_root_id(file_id);
+    let config = db.diagnostics_config();
+    if !config.enabled || !config.semantic.enabled || db.file_is_project_ignored(file_id) {
+        return Arc::from(Vec::<CompilationDiagnostic>::new());
+    }
+
+    let project_config = db.project_config();
+    let Some(profile_id) = project_config.profile_for_root(source_root_id) else {
+        return Arc::from(Vec::<CompilationDiagnostic>::new());
+    };
+    db.compilation_profile_diagnostics(profile_id)
+}
+
+fn compilation_profile_diagnostics(
+    db: &dyn SourceRootDb,
+    profile_id: CompilationProfileId,
+) -> Arc<[CompilationDiagnostic]> {
+    let config = db.diagnostics_config();
+    if !config.enabled || !config.semantic.enabled {
+        return Arc::from(Vec::<CompilationDiagnostic>::new());
+    }
+    db.compilation_profile_analysis(Some(profile_id)).diagnostics.clone()
 }
 
 fn source_root_semantic_diagnostics(
@@ -761,6 +794,24 @@ mod tests {
 
         assert_eq!(kind, SourceFileKind::SystemVerilog);
         assert!(kind.is_slang_parse_unit());
+    }
+
+    #[test]
+    fn compilation_profile_parse_exposes_a_root_syntax_tree() {
+        let mut db = db_with_root_file();
+        db.set_project_config_with_durability(Arc::new(ProjectConfig::default()), Durability::LOW);
+        db.set_file_preprocess_config_with_durability(
+            TOP,
+            Arc::new(PreprocessConfig::default()),
+            Durability::LOW,
+        );
+        let tree = db.parse_src_for_compilation(TOP);
+        let root = tree.root().expect("compilation parse should have a root");
+        assert!(root.children().next().is_some());
+
+        let profile_analysis = db.compilation_profile_analysis(None);
+        assert_eq!(profile_analysis.parsed_units.len(), 1);
+        assert!(profile_analysis.parsed_units[0].1.syntax_tree.root().is_some());
     }
 
     #[test]

--- a/crates/hir/src/base_db/source_db.rs
+++ b/crates/hir/src/base_db/source_db.rs
@@ -62,12 +62,6 @@ pub trait SourceDb: FileLoader + std::fmt::Debug {
 
     #[salsa::input]
     fn project_config(&self) -> Arc<ProjectConfig>;
-
-    /// Monotonic document revision owned by the analysis host. Keeping this as
-    /// an input makes every compilation context part of the same salsa state
-    /// as the text it describes.
-    #[salsa::input]
-    fn document_revision(&self) -> u64;
 }
 
 struct SourceFileIdentity {
@@ -396,7 +390,7 @@ fn compilation_context(
         plan.predefines.clone(),
         library_maps,
         plan.top_modules.clone(),
-        db.document_revision(),
+        0,
     ))
 }
 

--- a/crates/hir/src/base_db/source_db.rs
+++ b/crates/hir/src/base_db/source_db.rs
@@ -54,8 +54,6 @@ pub trait SourceDb: FileLoader + std::fmt::Debug {
     #[salsa::input]
     fn file_preprocess_config(&self, file_id: FileId) -> Arc<PreprocessConfig>;
 
-    fn parse_src(&self, file_id: FileId) -> SyntaxTree;
-
     #[salsa::input]
     fn files(&self) -> Box<FxHashSet<FileId>>;
 
@@ -70,35 +68,6 @@ pub trait SourceDb: FileLoader + std::fmt::Debug {
     /// as the text it describes.
     #[salsa::input]
     fn document_revision(&self) -> u64;
-}
-
-fn parse_src(db: &dyn SourceDb, file_id: FileId) -> SyntaxTree {
-    let _span = tracing::info_span!("slang.parse_src", ?file_id).entered();
-    let text = db.file_text(file_id);
-
-    match db.file_kind(file_id) {
-        SourceFileKind::SystemVerilog | SourceFileKind::IncludeHeader => {
-            // HIR source maps are local to the queried file; project-aware
-            // include expansion belongs to parse_src_for_compilation.
-            let preprocess = db.file_preprocess_config(file_id);
-            let include_paths = preprocess.include_dir_strings();
-            let options = syntax::SyntaxTreeOptions {
-                predefines: preprocess.predefine_strings(),
-                include_paths,
-                ..syntax::SyntaxTreeOptions::without_include_expansion()
-            };
-            let _span = tracing::info_span!(
-                "slang.syntax_tree.from_text",
-                ?file_id,
-                bytes = text.len(),
-                include_buffer_count = 0usize
-            )
-            .entered();
-            SyntaxTree::from_text_with_options(&text, "", "", &options)
-        }
-        SourceFileKind::LibraryMap => SyntaxTree::from_library_map_text(&text, "", ""),
-        SourceFileKind::ProjectManifest => SyntaxTree::from_text("", "", ""),
-    }
 }
 
 struct SourceFileIdentity {
@@ -160,7 +129,7 @@ fn syntax_tree_options_for_file(
 ) -> syntax::SyntaxTreeOptions {
     let _span = tracing::info_span!("slang.syntax_tree_options.file", ?file_id).entered();
     let profile_id = db.file_compilation_profile(file_id);
-    let context = db.compilation_context(profile_id);
+    let context = db.compilation_context_for_file(file_id);
     let include_buffers = db.include_buffers_for_profile(profile_id).as_ref().clone();
     syntax::SyntaxTreeOptions {
         predefines: context.predefines.to_vec(),
@@ -325,6 +294,7 @@ pub trait SourceRootDb: SourceDb {
         &self,
         profile_id: Option<CompilationProfileId>,
     ) -> Arc<CompilationContext>;
+    fn compilation_context_for_file(&self, file_id: FileId) -> Arc<CompilationContext>;
     /// Diagnostics produced by one slang compilation profile. This is the
     /// semantic diagnostics path, but it also returns parse diagnostics from
     /// the same syntax trees so one request does not parse the same roots
@@ -430,6 +400,21 @@ fn compilation_context(
     ))
 }
 
+fn compilation_context_for_file(db: &dyn SourceRootDb, file_id: FileId) -> Arc<CompilationContext> {
+    let profile_id = db.file_compilation_profile(file_id);
+    let context = db.compilation_context(profile_id);
+    let preprocess = db.file_preprocess_config(file_id);
+    Arc::new(CompilationContext::new(
+        context.profile,
+        context.roots.clone(),
+        preprocess.include_dirs.clone(),
+        preprocess.predefine_strings(),
+        context.library_maps.clone(),
+        context.top_modules.clone(),
+        context.document_revision,
+    ))
+}
+
 fn include_buffers_for_profile(
     db: &dyn SourceRootDb,
     profile_id: Option<CompilationProfileId>,
@@ -497,8 +482,6 @@ fn compilation_profile_diagnostics(
         include_buffer_count
     )
     .entered();
-    let compilation_options =
-        syntax_tree_options_for_profile(&context, compilation_include_buffers);
     let mut compilation = Compilation::new_with_top_modules(&context.top_modules);
     let mut buffer_file_ids = FxHashMap::default();
     let path_file_ids = path_file_ids(db);
@@ -515,6 +498,11 @@ fn compilation_profile_diagnostics(
             let identity = source_file_identity(db, file_id);
             let buffer_ids = match db.file_kind(file_id) {
                 SourceFileKind::SystemVerilog => {
+                    let file_context = db.compilation_context_for_file(file_id);
+                    let compilation_options = syntax_tree_options_for_profile(
+                        &file_context,
+                        compilation_include_buffers.clone(),
+                    );
                     let include_buffer_count = compilation_options.include_buffers.len();
                     let _span = tracing::info_span!(
                         "slang.semantic.add_root.from_text",

--- a/crates/hir/src/base_db/source_db.rs
+++ b/crates/hir/src/base_db/source_db.rs
@@ -399,7 +399,6 @@ fn compilation_context(
         plan.predefines.clone(),
         library_maps,
         plan.top_modules.clone(),
-        0,
     ))
 }
 
@@ -414,7 +413,6 @@ fn compilation_context_for_file(db: &dyn SourceRootDb, file_id: FileId) -> Arc<C
         preprocess.predefine_strings(),
         context.library_maps.clone(),
         context.top_modules.clone(),
-        context.document_revision,
     ))
 }
 

--- a/crates/hir/src/base_db/source_db/preproc/queries.rs
+++ b/crates/hir/src/base_db/source_db/preproc/queries.rs
@@ -66,7 +66,7 @@ pub(in crate::base_db::source_db) fn source_preproc_model(
     }
 
     let profile_id = db.file_compilation_profile(file_id);
-    let preprocess = db.file_preprocess_config(file_id);
+    let preprocess = db.project_config().preprocess_for_profile(profile_id);
     let options = syntax_tree_options_for_file(db, file_id);
     let Some(trace) = db.parsed_compilation_unit(file_id).preprocessor_trace.clone() else {
         return Arc::new(Err(SourcePreprocQueryError::TraceUnavailable));

--- a/crates/hir/src/hir_def/macro_file/tests.rs
+++ b/crates/hir/src/hir_def/macro_file/tests.rs
@@ -85,7 +85,6 @@ fn db_with_root_text(root_text: &str) -> TestDb {
     db.set_file_path_with_durability(TOP, Some(top_path), Durability::LOW);
     db.set_file_kind_with_durability(TOP, SourceFileKind::SystemVerilog, Durability::LOW);
     db.set_file_text_with_durability(TOP, Arc::from(root_text), Durability::LOW);
-    db.set_file_preprocess_config_with_durability(TOP, Arc::new(preprocess), Durability::LOW);
     db
 }
 

--- a/crates/hir/src/preproc/predefines.rs
+++ b/crates/hir/src/preproc/predefines.rs
@@ -10,12 +10,6 @@ pub(super) fn configured_predefine_names(db: &dyn SourceRootDb, file_id: FileId)
         }
     }
 
-    for predefine in &db.file_preprocess_config(file_id).predefines {
-        if let Some(name) = predefine_macro_name(predefine.as_str()) {
-            names.push_unique(name);
-        }
-    }
-
     names.into_vec()
 }
 
@@ -38,11 +32,6 @@ pub(super) fn configured_predefine_definitions_for_name(
             definitions.push_keyed(definition, MacroDefinitionKey::from_definition);
         }
     }
-    for predefine in &db.file_preprocess_config(context_file_id).predefines {
-        if let Some(definition) = configured_predefine_definition(db, predefine, name) {
-            definitions.push_keyed(definition, MacroDefinitionKey::from_definition);
-        }
-    }
     definitions.into_vec()
 }
 
@@ -57,13 +46,6 @@ pub(super) fn configured_predefine_definitions_at(
         let profile_id = db.file_compilation_profile(context_file_id);
         let project_preprocess = db.project_config().preprocess_for_profile(profile_id);
         for predefine in &project_preprocess.predefines {
-            if let Some(definition) =
-                configured_predefine_definition_at(db, predefine, file_id, offset)
-            {
-                definitions.push_keyed(definition, MacroDefinitionKey::from_definition);
-            }
-        }
-        for predefine in &db.file_preprocess_config(context_file_id).predefines {
             if let Some(definition) =
                 configured_predefine_definition_at(db, predefine, file_id, offset)
             {

--- a/crates/hir/src/preproc/tests.rs
+++ b/crates/hir/src/preproc/tests.rs
@@ -134,11 +134,6 @@ fn db_with_entries_and_predefine_entries(
             Durability::LOW,
         );
         db.set_file_text_with_durability(*file_id, Arc::from(*text), Durability::LOW);
-        db.set_file_preprocess_config_with_durability(
-            *file_id,
-            Arc::new(preprocess.clone()),
-            Durability::LOW,
-        );
     }
 
     db

--- a/crates/hir/src/scope.rs
+++ b/crates/hir/src/scope.rs
@@ -765,7 +765,6 @@ mod tests {
         db.set_file_path_with_durability(TOP, Some(top_path), Durability::LOW);
         db.set_file_kind_with_durability(TOP, SourceFileKind::SystemVerilog, Durability::LOW);
         db.set_file_text_with_durability(TOP, Arc::from(root_text), Durability::LOW);
-        db.set_file_preprocess_config_with_durability(TOP, Arc::new(preprocess), Durability::LOW);
         db
     }
 

--- a/crates/hir/src/semantics/pathres.rs
+++ b/crates/hir/src/semantics/pathres.rs
@@ -378,7 +378,6 @@ mod tests {
         db.set_file_path_with_durability(TOP, Some(top_path), Durability::LOW);
         db.set_file_kind_with_durability(TOP, SourceFileKind::SystemVerilog, Durability::LOW);
         db.set_file_text_with_durability(TOP, Arc::from(root_text), Durability::LOW);
-        db.set_file_preprocess_config_with_durability(TOP, Arc::new(preprocess), Durability::LOW);
         db
     }
 

--- a/crates/hir/src/type_infer.rs
+++ b/crates/hir/src/type_infer.rs
@@ -933,7 +933,6 @@ mod tests {
         db.set_file_path_with_durability(TOP, Some(top_path), Durability::LOW);
         db.set_file_kind_with_durability(TOP, SourceFileKind::SystemVerilog, Durability::LOW);
         db.set_file_text_with_durability(TOP, Arc::from(root_text), Durability::LOW);
-        db.set_file_preprocess_config_with_durability(TOP, Arc::new(preprocess), Durability::LOW);
         db
     }
 

--- a/crates/ide/src/analysis.rs
+++ b/crates/ide/src/analysis.rs
@@ -66,6 +66,13 @@ impl AnalysisSnapshot {
         &self.compilation_contexts
     }
 
+    pub fn document_revision(&self) -> u64 {
+        self.compilation_contexts
+            .first()
+            .map(|context| context.document_revision)
+            .unwrap_or_default()
+    }
+
     pub fn compilation_context(
         &self,
         profile: Option<CompilationProfileId>,
@@ -77,6 +84,7 @@ impl AnalysisSnapshot {
     where
         F: FnOnce(&RootDb) -> T + std::panic::UnwindSafe,
     {
+        let _span = tracing::debug_span!("ide.analysis", snapshot_id = ?self.snapshot_id).entered();
         Cancelled::catch(|| f(&self.db))
     }
 

--- a/crates/ide/src/analysis.rs
+++ b/crates/ide/src/analysis.rs
@@ -2,6 +2,7 @@ use std::ops::Range;
 
 use hir::base_db::{
     Cancelled,
+    analysis_snapshot::{AnalysisSnapshotId, CompilationContext},
     compilation_plan::CompilationPlan,
     project::CompilationProfileId,
     salsa,
@@ -47,11 +48,31 @@ use crate::{
 };
 
 #[derive(Debug)]
-pub struct Analysis {
+pub struct AnalysisSnapshot {
     pub(crate) db: salsa::Snapshot<RootDb>,
+    pub(crate) snapshot_id: AnalysisSnapshotId,
+    pub(crate) compilation_contexts: Arc<[CompilationContext]>,
 }
 
-impl Analysis {
+/// Backwards-compatible name for callers that only need an analysis view.
+pub type Analysis = AnalysisSnapshot;
+
+impl AnalysisSnapshot {
+    pub fn snapshot_id(&self) -> AnalysisSnapshotId {
+        self.snapshot_id
+    }
+
+    pub fn compilation_contexts(&self) -> &[CompilationContext] {
+        &self.compilation_contexts
+    }
+
+    pub fn compilation_context(
+        &self,
+        profile: Option<CompilationProfileId>,
+    ) -> Option<&CompilationContext> {
+        self.compilation_contexts.iter().find(|context| context.profile == profile)
+    }
+
     fn with_db<F, T>(&self, f: F) -> Cancellable<T>
     where
         F: FnOnce(&RootDb) -> T + std::panic::UnwindSafe,

--- a/crates/ide/src/analysis.rs
+++ b/crates/ide/src/analysis.rs
@@ -66,13 +66,6 @@ impl AnalysisSnapshot {
         &self.compilation_contexts
     }
 
-    pub fn document_revision(&self) -> u64 {
-        self.compilation_contexts
-            .first()
-            .map(|context| context.document_revision)
-            .unwrap_or_default()
-    }
-
     pub fn compilation_context(
         &self,
         profile: Option<CompilationProfileId>,

--- a/crates/ide/src/analysis.rs
+++ b/crates/ide/src/analysis.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 
 use hir::base_db::{
     Cancelled,
-    analysis_snapshot::{AnalysisSnapshotId, CompilationContext},
+    analysis_snapshot::AnalysisSnapshotId,
     compilation_plan::CompilationPlan,
     project::CompilationProfileId,
     salsa,
@@ -51,7 +51,6 @@ use crate::{
 pub struct AnalysisSnapshot {
     pub(crate) db: salsa::Snapshot<RootDb>,
     pub(crate) snapshot_id: AnalysisSnapshotId,
-    pub(crate) compilation_contexts: Arc<[CompilationContext]>,
 }
 
 /// Backwards-compatible name for callers that only need an analysis view.
@@ -60,17 +59,6 @@ pub type Analysis = AnalysisSnapshot;
 impl AnalysisSnapshot {
     pub fn snapshot_id(&self) -> AnalysisSnapshotId {
         self.snapshot_id
-    }
-
-    pub fn compilation_contexts(&self) -> &[CompilationContext] {
-        &self.compilation_contexts
-    }
-
-    pub fn compilation_context(
-        &self,
-        profile: Option<CompilationProfileId>,
-    ) -> Option<&CompilationContext> {
-        self.compilation_contexts.iter().find(|context| context.profile == profile)
     }
 
     fn with_db<F, T>(&self, f: F) -> Cancellable<T>

--- a/crates/ide/src/analysis.rs
+++ b/crates/ide/src/analysis.rs
@@ -106,13 +106,6 @@ impl AnalysisSnapshot {
         self.with_db(|db| diagnostics::compilation_profile_diagnostics(db, profile_id))
     }
 
-    pub fn compilation_profile_syntax_diagnostics(
-        &self,
-        profile_id: CompilationProfileId,
-    ) -> Cancellable<Vec<diagnostics::Diagnostic>> {
-        self.with_db(|db| diagnostics::compilation_profile_syntax_diagnostics(db, profile_id))
-    }
-
     pub fn parse_diagnostics(&self, file_id: FileId) -> Cancellable<Vec<diagnostics::Diagnostic>> {
         self.with_db(|db| diagnostics::parse_diagnostics(db, file_id))
     }

--- a/crates/ide/src/analysis_host.rs
+++ b/crates/ide/src/analysis_host.rs
@@ -1,22 +1,56 @@
-use hir::base_db::{change::Change, salsa::ParallelDatabase};
+use hir::base_db::{
+    analysis_snapshot::{AnalysisSnapshotId, CompilationContext},
+    change::Change,
+    project::CompilationProfileId,
+    salsa::ParallelDatabase,
+    source_db::{SourceDb, SourceFileKind, SourceRootDb},
+};
+use triomphe::Arc;
 
 use crate::{analysis::Analysis, db::root_db::RootDb};
 
 pub struct AnalysisHost {
     db: RootDb,
+    snapshot_id: AnalysisSnapshotId,
+    document_revision: u64,
 }
 
 impl AnalysisHost {
     pub fn new(lru_capacity: Option<usize>) -> AnalysisHost {
-        AnalysisHost { db: RootDb::new(lru_capacity) }
+        AnalysisHost {
+            db: RootDb::new(lru_capacity),
+            snapshot_id: AnalysisSnapshotId::default(),
+            document_revision: 0,
+        }
     }
 
     pub fn make_analysis(&self) -> Analysis {
-        Analysis { db: self.db.snapshot() }
+        let db = self.db.snapshot();
+        let compilation_contexts = self.compilation_contexts(&db);
+        Analysis {
+            db,
+            snapshot_id: self.snapshot_id,
+            compilation_contexts: Arc::from(compilation_contexts),
+        }
     }
 
     pub fn apply_change(&mut self, change: Change) {
         self.db.apply_change(change);
+        self.document_revision = self.document_revision.saturating_add(1);
+        self.snapshot_id = self.snapshot_id.next();
+    }
+
+    pub fn mark_changed(&mut self) {
+        self.document_revision = self.document_revision.saturating_add(1);
+        self.snapshot_id = self.snapshot_id.next();
+    }
+
+    pub fn snapshot_id(&self) -> AnalysisSnapshotId {
+        self.snapshot_id
+    }
+
+    pub fn document_revision(&self) -> u64 {
+        self.document_revision
     }
 
     pub fn raw_db(&self) -> &RootDb {
@@ -28,8 +62,60 @@ impl AnalysisHost {
     }
 }
 
+impl AnalysisHost {
+    fn compilation_contexts(&self, db: &RootDb) -> Vec<CompilationContext> {
+        let mut profiles = db.project_config().profile_ids();
+        profiles.insert(0, CompilationProfileId(u32::MAX));
+
+        profiles
+            .into_iter()
+            .map(|profile| {
+                let profile = (profile != CompilationProfileId(u32::MAX)).then_some(profile);
+                let plan = db.compilation_plan_for_profile(profile);
+                let library_maps = plan
+                    .roots
+                    .iter()
+                    .copied()
+                    .filter(|file_id| matches!(db.file_kind(*file_id), SourceFileKind::LibraryMap))
+                    .collect::<Vec<_>>();
+                CompilationContext::new(
+                    profile,
+                    plan.roots.clone(),
+                    plan.include_dirs.clone(),
+                    plan.predefines.clone(),
+                    library_maps,
+                    plan.top_modules.clone(),
+                    self.document_revision,
+                )
+            })
+            .collect()
+    }
+}
+
 impl Default for AnalysisHost {
     fn default() -> AnalysisHost {
         AnalysisHost::new(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_only_views_share_one_snapshot_identity() {
+        let mut host = AnalysisHost::default();
+        let first = host.make_analysis();
+        let second = host.make_analysis();
+
+        assert_eq!(first.snapshot_id(), second.snapshot_id());
+        assert_eq!(first.snapshot_id().get(), 0);
+        assert_eq!(first.compilation_contexts()[0].document_revision, 0);
+
+        drop((first, second));
+        host.apply_change(Change::new());
+        let changed = host.make_analysis();
+        assert_eq!(changed.snapshot_id().get(), 1);
+        assert_eq!(changed.compilation_contexts()[0].document_revision, 1);
     }
 }

--- a/crates/ide/src/analysis_host.rs
+++ b/crates/ide/src/analysis_host.rs
@@ -1,11 +1,9 @@
-#[cfg(test)]
-use hir::base_db::project::PreprocessConfig;
 use hir::base_db::{
-    analysis_snapshot::{AnalysisSnapshotId, CompilationContext},
+    analysis_snapshot::AnalysisSnapshotId,
     change::Change,
     diagnostics_config::DiagnosticsConfig,
     salsa::{Durability, ParallelDatabase},
-    source_db::{SourceDb, SourceRootDb},
+    source_db::SourceDb,
 };
 use triomphe::Arc;
 
@@ -23,12 +21,7 @@ impl AnalysisHost {
 
     pub fn make_analysis(&self) -> Analysis {
         let db = self.db.snapshot();
-        let compilation_contexts = self.compilation_contexts(&db);
-        Analysis {
-            db,
-            snapshot_id: self.snapshot_id,
-            compilation_contexts: Arc::from(compilation_contexts),
-        }
+        Analysis { db, snapshot_id: self.snapshot_id }
     }
 
     pub fn apply_change(&mut self, change: Change) {
@@ -38,16 +31,6 @@ impl AnalysisHost {
 
     pub fn set_diagnostics_config(&mut self, config: Arc<DiagnosticsConfig>) {
         self.db.set_diagnostics_config_with_durability(config, Durability::HIGH);
-        self.advance_revision();
-    }
-
-    #[cfg(test)]
-    pub(crate) fn set_file_preprocess_config(
-        &mut self,
-        file_id: vfs::FileId,
-        config: Arc<PreprocessConfig>,
-    ) {
-        self.db.set_file_preprocess_config_with_durability(file_id, config, Durability::LOW);
         self.advance_revision();
     }
 
@@ -61,17 +44,6 @@ impl AnalysisHost {
 
     pub fn raw_db(&self) -> &RootDb {
         &self.db
-    }
-}
-
-impl AnalysisHost {
-    fn compilation_contexts(&self, db: &RootDb) -> Vec<CompilationContext> {
-        let mut profiles = vec![None];
-        profiles.extend(db.project_config().profile_ids().into_iter().map(Some));
-        profiles
-            .into_iter()
-            .map(|profile| db.compilation_context(profile).as_ref().clone())
-            .collect()
     }
 }
 

--- a/crates/ide/src/analysis_host.rs
+++ b/crates/ide/src/analysis_host.rs
@@ -14,16 +14,11 @@ use crate::{analysis::Analysis, db::root_db::RootDb};
 pub struct AnalysisHost {
     db: RootDb,
     snapshot_id: AnalysisSnapshotId,
-    document_revision: u64,
 }
 
 impl AnalysisHost {
     pub fn new(lru_capacity: Option<usize>) -> AnalysisHost {
-        AnalysisHost {
-            db: RootDb::new(lru_capacity),
-            snapshot_id: AnalysisSnapshotId::default(),
-            document_revision: 0,
-        }
+        AnalysisHost { db: RootDb::new(lru_capacity), snapshot_id: AnalysisSnapshotId::default() }
     }
 
     pub fn make_analysis(&self) -> Analysis {
@@ -57,17 +52,11 @@ impl AnalysisHost {
     }
 
     fn advance_revision(&mut self) {
-        self.document_revision =
-            self.document_revision.checked_add(1).expect("document revision exhausted");
         self.snapshot_id = self.snapshot_id.next();
     }
 
     pub fn snapshot_id(&self) -> AnalysisSnapshotId {
         self.snapshot_id
-    }
-
-    pub fn document_revision(&self) -> u64 {
-        self.document_revision
     }
 
     pub fn raw_db(&self) -> &RootDb {
@@ -81,12 +70,7 @@ impl AnalysisHost {
         profiles.extend(db.project_config().profile_ids().into_iter().map(Some));
         profiles
             .into_iter()
-            .map(|profile| {
-                db.compilation_context(profile)
-                    .as_ref()
-                    .clone()
-                    .with_document_revision(self.document_revision)
-            })
+            .map(|profile| db.compilation_context(profile).as_ref().clone())
             .collect()
     }
 }
@@ -109,12 +93,10 @@ mod tests {
 
         assert_eq!(first.snapshot_id(), second.snapshot_id());
         assert_eq!(first.snapshot_id().get(), 0);
-        assert_eq!(first.compilation_contexts()[0].document_revision, 0);
 
         drop((first, second));
         host.apply_change(Change::new());
         let changed = host.make_analysis();
         assert_eq!(changed.snapshot_id().get(), 1);
-        assert_eq!(changed.compilation_contexts()[0].document_revision, 1);
     }
 }

--- a/crates/ide/src/analysis_host.rs
+++ b/crates/ide/src/analysis_host.rs
@@ -45,10 +45,6 @@ impl AnalysisHost {
     fn advance_revision(&mut self) {
         self.document_revision = self.document_revision.saturating_add(1);
         self.snapshot_id = self.snapshot_id.next();
-        self.db.set_document_revision_with_durability(
-            self.document_revision,
-            hir::base_db::salsa::Durability::HIGH,
-        );
     }
 
     pub fn snapshot_id(&self) -> AnalysisSnapshotId {
@@ -74,7 +70,12 @@ impl AnalysisHost {
         profiles.extend(db.project_config().profile_ids().into_iter().map(Some));
         profiles
             .into_iter()
-            .map(|profile| db.compilation_context(profile).as_ref().clone())
+            .map(|profile| {
+                db.compilation_context(profile)
+                    .as_ref()
+                    .clone()
+                    .with_document_revision(self.document_revision)
+            })
             .collect()
     }
 }

--- a/crates/ide/src/analysis_host.rs
+++ b/crates/ide/src/analysis_host.rs
@@ -1,9 +1,8 @@
 use hir::base_db::{
     analysis_snapshot::{AnalysisSnapshotId, CompilationContext},
     change::Change,
-    project::CompilationProfileId,
     salsa::ParallelDatabase,
-    source_db::{SourceDb, SourceFileKind, SourceRootDb},
+    source_db::{SourceDb, SourceRootDb},
 };
 use triomphe::Arc;
 
@@ -36,13 +35,20 @@ impl AnalysisHost {
 
     pub fn apply_change(&mut self, change: Change) {
         self.db.apply_change(change);
-        self.document_revision = self.document_revision.saturating_add(1);
-        self.snapshot_id = self.snapshot_id.next();
+        self.advance_revision();
     }
 
     pub fn mark_changed(&mut self) {
+        self.advance_revision();
+    }
+
+    fn advance_revision(&mut self) {
         self.document_revision = self.document_revision.saturating_add(1);
         self.snapshot_id = self.snapshot_id.next();
+        self.db.set_document_revision_with_durability(
+            self.document_revision,
+            hir::base_db::salsa::Durability::HIGH,
+        );
     }
 
     pub fn snapshot_id(&self) -> AnalysisSnapshotId {
@@ -64,30 +70,11 @@ impl AnalysisHost {
 
 impl AnalysisHost {
     fn compilation_contexts(&self, db: &RootDb) -> Vec<CompilationContext> {
-        let mut profiles = db.project_config().profile_ids();
-        profiles.insert(0, CompilationProfileId(u32::MAX));
-
+        let mut profiles = vec![None];
+        profiles.extend(db.project_config().profile_ids().into_iter().map(Some));
         profiles
             .into_iter()
-            .map(|profile| {
-                let profile = (profile != CompilationProfileId(u32::MAX)).then_some(profile);
-                let plan = db.compilation_plan_for_profile(profile);
-                let library_maps = plan
-                    .roots
-                    .iter()
-                    .copied()
-                    .filter(|file_id| matches!(db.file_kind(*file_id), SourceFileKind::LibraryMap))
-                    .collect::<Vec<_>>();
-                CompilationContext::new(
-                    profile,
-                    plan.roots.clone(),
-                    plan.include_dirs.clone(),
-                    plan.predefines.clone(),
-                    library_maps,
-                    plan.top_modules.clone(),
-                    self.document_revision,
-                )
-            })
+            .map(|profile| db.compilation_context(profile).as_ref().clone())
             .collect()
     }
 }

--- a/crates/ide/src/analysis_host.rs
+++ b/crates/ide/src/analysis_host.rs
@@ -1,7 +1,10 @@
+#[cfg(test)]
+use hir::base_db::project::PreprocessConfig;
 use hir::base_db::{
     analysis_snapshot::{AnalysisSnapshotId, CompilationContext},
     change::Change,
-    salsa::ParallelDatabase,
+    diagnostics_config::DiagnosticsConfig,
+    salsa::{Durability, ParallelDatabase},
     source_db::{SourceDb, SourceRootDb},
 };
 use triomphe::Arc;
@@ -38,12 +41,24 @@ impl AnalysisHost {
         self.advance_revision();
     }
 
-    pub fn mark_changed(&mut self) {
+    pub fn set_diagnostics_config(&mut self, config: Arc<DiagnosticsConfig>) {
+        self.db.set_diagnostics_config_with_durability(config, Durability::HIGH);
+        self.advance_revision();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_file_preprocess_config(
+        &mut self,
+        file_id: vfs::FileId,
+        config: Arc<PreprocessConfig>,
+    ) {
+        self.db.set_file_preprocess_config_with_durability(file_id, config, Durability::LOW);
         self.advance_revision();
     }
 
     fn advance_revision(&mut self) {
-        self.document_revision = self.document_revision.saturating_add(1);
+        self.document_revision =
+            self.document_revision.checked_add(1).expect("document revision exhausted");
         self.snapshot_id = self.snapshot_id.next();
     }
 
@@ -57,10 +72,6 @@ impl AnalysisHost {
 
     pub fn raw_db(&self) -> &RootDb {
         &self.db
-    }
-
-    pub fn raw_db_mut(&mut self) -> &mut RootDb {
-        &mut self.db
     }
 }
 

--- a/crates/ide/src/db/root_db.rs
+++ b/crates/ide/src/db/root_db.rs
@@ -6,8 +6,8 @@ use hir::{
         project::ProjectConfig,
         salsa::{self, Durability},
         source_db::{
-            FileLoader, ParseSrcForCompilationQuery, SourceDb, SourceDbStorage, SourceRootDb,
-            SourceRootDbStorage,
+            FileLoader, ParseSrcForCompilationQuery, ParsedProfileQuery, SourceDb, SourceDbStorage,
+            SourceRootDb, SourceRootDbStorage,
         },
     },
     db::{
@@ -77,6 +77,7 @@ impl RootDb {
     pub fn update_parse_query_lru_capacity(&mut self, lru_capacity: Option<usize>) {
         let lru_capacity = lru_capacity.unwrap_or(DEFAULT_PARSE_LRU_CAP);
         ParseSrcForCompilationQuery.in_db_mut(self).set_lru_capacity(lru_capacity);
+        ParsedProfileQuery.in_db_mut(self).set_lru_capacity(lru_capacity);
         HirFileWithSourceMapQuery.in_db_mut(self).set_lru_capacity(lru_capacity);
         ModuleWithSourceMapQuery.in_db_mut(self).set_lru_capacity(lru_capacity);
         BlockWithSourceMapQuery.in_db_mut(self).set_lru_capacity(lru_capacity);

--- a/crates/ide/src/db/root_db.rs
+++ b/crates/ide/src/db/root_db.rs
@@ -70,6 +70,7 @@ impl RootDb {
             Durability::HIGH,
         );
         db.set_project_config_with_durability(Arc::new(ProjectConfig::default()), Durability::HIGH);
+        db.set_document_revision_with_durability(0, Durability::HIGH);
         db.update_parse_query_lru_capacity(lru_capacity);
         db
     }

--- a/crates/ide/src/db/root_db.rs
+++ b/crates/ide/src/db/root_db.rs
@@ -70,7 +70,6 @@ impl RootDb {
             Durability::HIGH,
         );
         db.set_project_config_with_durability(Arc::new(ProjectConfig::default()), Durability::HIGH);
-        db.set_document_revision_with_durability(0, Durability::HIGH);
         db.update_parse_query_lru_capacity(lru_capacity);
         db
     }

--- a/crates/ide/src/db/root_db.rs
+++ b/crates/ide/src/db/root_db.rs
@@ -6,8 +6,8 @@ use hir::{
         project::ProjectConfig,
         salsa::{self, Durability},
         source_db::{
-            FileLoader, ParseSrcForCompilationQuery, ParseSrcQuery, SourceDb, SourceDbStorage,
-            SourceRootDb, SourceRootDbStorage,
+            FileLoader, ParseSrcForCompilationQuery, SourceDb, SourceDbStorage, SourceRootDb,
+            SourceRootDbStorage,
         },
     },
     db::{
@@ -77,7 +77,6 @@ impl RootDb {
 
     pub fn update_parse_query_lru_capacity(&mut self, lru_capacity: Option<usize>) {
         let lru_capacity = lru_capacity.unwrap_or(DEFAULT_PARSE_LRU_CAP);
-        ParseSrcQuery.in_db_mut(self).set_lru_capacity(lru_capacity);
         ParseSrcForCompilationQuery.in_db_mut(self).set_lru_capacity(lru_capacity);
         HirFileWithSourceMapQuery.in_db_mut(self).set_lru_capacity(lru_capacity);
         ModuleWithSourceMapQuery.in_db_mut(self).set_lru_capacity(lru_capacity);

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -167,7 +167,7 @@ pub(crate) fn compilation_profile_diagnostics(
     diagnostics.extend(
         compilation_profile_file_ids(db, profile_id)
             .into_iter()
-            .flat_map(|file_id| inactive_preprocessor_branch_diagnostics(db, file_id)),
+            .flat_map(|file_id| vide_diagnostics(db, file_id)),
     );
     diagnostics
 }
@@ -643,6 +643,30 @@ mod tests {
         assert!(
             diagnostics.iter().all(|diag| diag.source != DiagnosticSource::Vide),
             "vide ambiguity warning should not duplicate active slang semantic diagnostics: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn compilation_profile_diagnostics_include_vide_diagnostics() {
+        let mut db = db_with_files(
+            &[
+                ("/project/a/child.sv", "module child; endmodule\n"),
+                ("/project/a/top.sv", "module top; child u(); endmodule\n"),
+                ("/project/b/child.sv", "module child; endmodule\n"),
+            ],
+            true,
+        );
+        disable_semantic_diagnostics(&mut db);
+
+        let diagnostics = compilation_profile_diagnostics(&db, CompilationProfileId(0));
+
+        assert!(
+            diagnostics.iter().any(|diagnostic| {
+                diagnostic.file_id == FileId(1)
+                    && diagnostic.source == DiagnosticSource::Vide
+                    && diagnostic.name == AMBIGUOUS_MODULE_INSTANTIATION.name
+            }),
+            "profile diagnostics should include Vide diagnostics: {diagnostics:?}"
         );
     }
 

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -662,7 +662,7 @@ mod tests {
 
         assert!(
             diagnostics.iter().any(|diagnostic| {
-                diagnostic.file_id == FileId(1)
+                diagnostic.file_id == FileId::from_raw(1)
                     && diagnostic.source == DiagnosticSource::Vide
                     && diagnostic.name == AMBIGUOUS_MODULE_INSTANTIATION.name
             }),

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -159,6 +159,7 @@ pub(crate) fn compilation_profile_diagnostics(
 ) -> Vec<Diagnostic> {
     let mut diagnostics = db
         .compilation_profile_diagnostics(profile_id)
+        .diagnostics
         .iter()
         .map(|diag| slang_diagnostic(diag.file_id, diag.source, &diag.diagnostic))
         .collect::<Vec<_>>();

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -172,16 +172,6 @@ pub(crate) fn compilation_profile_diagnostics(
     diagnostics
 }
 
-pub(crate) fn compilation_profile_syntax_diagnostics(
-    db: &RootDb,
-    profile_id: CompilationProfileId,
-) -> Vec<Diagnostic> {
-    compilation_profile_file_ids(db, profile_id)
-        .into_iter()
-        .flat_map(|file_id| syntax_diagnostics(db, file_id))
-        .collect()
-}
-
 fn compilation_profile_file_ids(db: &RootDb, profile_id: CompilationProfileId) -> Vec<FileId> {
     let plan = db.compilation_plan_for_profile(Some(profile_id));
     let mut file_ids = plan.roots.clone();

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -1,7 +1,10 @@
 #![feature(try_blocks)]
 #![feature(decl_macro)]
 
-pub use hir::base_db::Cancelled;
+pub use hir::base_db::{
+    Cancelled,
+    analysis_snapshot::{AnalysisSnapshotId, CompilationContext},
+};
 pub use range::{ErasedFileAstId, FilePosition, FileRange, RangeInfo};
 use syntax::{SyntaxKind, ast, match_ast_kind};
 pub type Cancellable<T> = Result<T, Cancelled>;

--- a/crates/ide/src/module_resolution.rs
+++ b/crates/ide/src/module_resolution.rs
@@ -329,7 +329,7 @@ mod tests {
     use std::path::Path;
 
     use hir::{
-        base_db::{change::Change, source_db::SourceDb, source_root::SourceRoot},
+        base_db::{change::Change, source_root::SourceRoot},
         semantics::pathres::PathResolution,
         symbol::DefLoc,
     };
@@ -486,7 +486,7 @@ mod tests {
             }
             Query::NamedPort => {
                 let offset = fixture.offset.expect("named_port query requires /*caret*/");
-                let tree = db.parse_src(fixture.focus);
+                let tree = db.parse_src_for_compilation(fixture.focus);
                 let root = tree.root().expect("test source should parse");
                 let port_conn = root
                     .find_node_at_offset::<ast::NamedPortConnection>(offset)
@@ -504,7 +504,7 @@ mod tests {
             }
             Query::NamedParam => {
                 let offset = fixture.offset.expect("named_param query requires /*caret*/");
-                let tree = db.parse_src(fixture.focus);
+                let tree = db.parse_src_for_compilation(fixture.focus);
                 let root = tree.root().expect("test source should parse");
                 let param_assign = root
                     .find_node_at_offset::<ast::NamedParamAssignment>(offset)

--- a/crates/ide/src/semantic_index.rs
+++ b/crates/ide/src/semantic_index.rs
@@ -446,7 +446,7 @@ fn instantiation_name_range(
     file_id: FileId,
     src: hir::hir_def::module::instantiation::InstantiationSrc,
 ) -> Option<TextRange> {
-    let tree = db.parse_src(file_id);
+    let tree = db.parse_src_for_compilation(file_id);
     let root = tree.root()?;
     let instantiation_range = src.range();
     let mut offset = instantiation_range.start();

--- a/crates/ide/src/verilog_2005.rs
+++ b/crates/ide/src/verilog_2005.rs
@@ -1102,7 +1102,7 @@ endmodule
 }
 
 #[test]
-fn file_preprocess_config_selects_same_ifdef_branch_for_diagnostics_and_navigation() {
+fn project_profile_selects_same_ifdef_branch_for_diagnostics_and_navigation() {
     let text = r#"
 module ifdef_nav(
   input logic clk_i,
@@ -1116,9 +1116,8 @@ module ifdef_nav(
 `endif
 endmodule
 "#;
-    let (mut host, file_id, _clean_text, markers) =
+    let (host, file_id, _clean_text, markers) =
         setup_marked_with_predefines(text, vec!["SOMETHING=1".to_owned()]);
-    host.set_file_preprocess_config(file_id, Arc::new(PreprocessConfig::default()));
 
     let analysis = host.make_analysis();
     let range_at = |marker: &str, len: TextSize| {

--- a/crates/ide/src/verilog_2005.rs
+++ b/crates/ide/src/verilog_2005.rs
@@ -12,7 +12,7 @@ use hir::{
             ProjectConfig,
         },
         salsa::Durability,
-        source_db::SourceDb,
+        source_db::{SourceDb, SourceRootDb},
         source_root::{SourceRoot, SourceRootId},
     },
     preproc::{IncludeTarget, include_directive_at},
@@ -157,8 +157,8 @@ fn parsed_file_nodes_survive_parse_lru_eviction() {
     let child_count = root.child_count();
     assert!(child_count > 0);
 
-    let _ = db.parse_src(FileId::from_raw(1));
-    let _ = db.parse_src(FileId::from_raw(2));
+    let _ = db.parse_src_for_compilation(FileId::from_raw(1));
+    let _ = db.parse_src_for_compilation(FileId::from_raw(2));
 
     assert_eq!(root.child_count(), child_count);
     assert!(root.first_token().is_some());

--- a/crates/ide/src/verilog_2005.rs
+++ b/crates/ide/src/verilog_2005.rs
@@ -11,7 +11,7 @@ use hir::{
             CompilationProfile, CompilationProfileId, Predefine, PredefineSource, PreprocessConfig,
             ProjectConfig,
         },
-        source_db::{SourceDb, SourceRootDb},
+        source_db::SourceRootDb,
         source_root::{SourceRoot, SourceRootId},
     },
     preproc::{IncludeTarget, include_directive_at},

--- a/crates/ide/src/verilog_2005.rs
+++ b/crates/ide/src/verilog_2005.rs
@@ -1134,23 +1134,27 @@ endmodule
         .find(|diagnostic| diagnostic.name == "inactive-preprocessor-branch")
         .expect("expected inactive branch diagnostic");
     assert!(
-        inactive.range.intersect(if_branch).is_some(),
-        "file-level preprocess should mark the if branch inactive: {diagnostics:?}"
+        inactive.range.intersect(else_branch).is_some(),
+        "project profile preprocess should mark the else branch inactive: {diagnostics:?}"
     );
     assert!(
-        inactive.range.intersect(else_branch).is_none(),
-        "file-level preprocess should keep the else branch semantically active: {diagnostics:?}"
+        inactive.range.intersect(if_branch).is_none(),
+        "project profile preprocess should keep the if branch semantically active: {diagnostics:?}"
     );
 
     assert!(
-        analysis.goto_definition(position(file_id, &markers, "if_ref")).unwrap().is_none(),
-        "inactive if branch should not drive semantic navigation"
+        analysis.goto_definition(position(file_id, &markers, "if_ref")).unwrap().is_some(),
+        "active if branch should drive semantic navigation"
     );
 
+    assert!(
+        analysis.goto_definition(position(file_id, &markers, "else_ref")).unwrap().is_none(),
+        "inactive else branch should not drive semantic navigation"
+    );
     let nav = analysis
-        .goto_definition(position(file_id, &markers, "else_ref"))
+        .goto_definition(position(file_id, &markers, "if_ref"))
         .unwrap()
-        .expect("active else branch should navigate");
+        .expect("active if branch should navigate");
     assert!(
         nav.info.iter().any(|target| target.focus_range == Some(d_i_range)),
         "active else branch should resolve d_i to the port definition: {nav:?}"

--- a/crates/ide/src/verilog_2005.rs
+++ b/crates/ide/src/verilog_2005.rs
@@ -11,7 +11,6 @@ use hir::{
             CompilationProfile, CompilationProfileId, Predefine, PredefineSource, PreprocessConfig,
             ProjectConfig,
         },
-        salsa::Durability,
         source_db::{SourceDb, SourceRootDb},
         source_root::{SourceRoot, SourceRootId},
     },
@@ -1119,11 +1118,7 @@ endmodule
 "#;
     let (mut host, file_id, _clean_text, markers) =
         setup_marked_with_predefines(text, vec!["SOMETHING=1".to_owned()]);
-    host.raw_db_mut().set_file_preprocess_config_with_durability(
-        file_id,
-        Arc::new(PreprocessConfig::default()),
-        Durability::LOW,
-    );
+    host.set_file_preprocess_config(file_id, Arc::new(PreprocessConfig::default()));
 
     let analysis = host.make_analysis();
     let range_at = |marker: &str, len: TextSize| {

--- a/crates/slang/bindings/rust/ffi.rs
+++ b/crates/slang/bindings/rust/ffi.rs
@@ -545,6 +545,7 @@ mod slang_ffi {
 
         #[namespace = "wrapper::syntax"]
         fn SyntaxTree_buffer_id(tree: &SyntaxTree) -> u32;
+        fn SyntaxTree_buffer_ids(tree: &SyntaxTree) -> RawSyntaxTreeBufferIds;
     }
 
     impl SharedPtr<SyntaxTree> {}
@@ -572,6 +573,25 @@ mod slang_ffi {
             compilation: Pin<&mut Compilation>,
             tree: SharedPtr<SyntaxTree>,
         );
+
+        #[namespace = "wrapper::ast"]
+        fn Compilation_parse_syntax_tree_from_text(
+            compilation: Pin<&mut Compilation>,
+            text: CxxSV,
+            name: CxxSV,
+            path: CxxSV,
+            predefines: Vec<String>,
+            include_paths: Vec<String>,
+            include_buffers: Vec<RawSourceBuffer>,
+        ) -> SharedPtr<SyntaxTree>;
+
+        #[namespace = "wrapper::ast"]
+        fn Compilation_parse_library_map_syntax_tree_from_text(
+            compilation: Pin<&mut Compilation>,
+            text: CxxSV,
+            name: CxxSV,
+            path: CxxSV,
+        ) -> SharedPtr<SyntaxTree>;
 
         #[namespace = "wrapper::ast"]
         fn Compilation_add_syntax_tree_from_text(
@@ -782,6 +802,8 @@ impl_functions! {
         fn system_function_names() -> Vec<String> |> Compilation_system_function_names;
         fn system_task_names() -> Vec<String> |> Compilation_system_task_names;
         fn add_syntax_tree(self_: Pin<&mut Compilation>, tree: SharedPtr<SyntaxTree>) -> () |> Compilation_add_syntax_tree;
+        fn parse_syntax_tree_from_text(self_: Pin<&mut Compilation>, text: CxxSV, name: CxxSV, path: CxxSV, predefines: Vec<String>, include_paths: Vec<String>, include_buffers: Vec<RawSourceBuffer>) -> SharedPtr<SyntaxTree> |> Compilation_parse_syntax_tree_from_text;
+        fn parse_library_map_syntax_tree_from_text(self_: Pin<&mut Compilation>, text: CxxSV, name: CxxSV, path: CxxSV) -> SharedPtr<SyntaxTree> |> Compilation_parse_library_map_syntax_tree_from_text;
         fn add_syntax_tree_from_text(self_: Pin<&mut Compilation>, text: CxxSV, name: CxxSV, path: CxxSV, predefines: Vec<String>, include_paths: Vec<String>, include_buffers: Vec<RawSourceBuffer>, expand_includes: bool) -> RawSyntaxTreeBufferIds |> Compilation_add_syntax_tree_from_text;
         fn add_library_map_syntax_tree_from_text(self_: Pin<&mut Compilation>, text: CxxSV, name: CxxSV, path: CxxSV) -> RawSyntaxTreeBufferIds |> Compilation_add_library_map_syntax_tree_from_text;
         fn semantic_diagnostics(&self) -> Vec<RawSyntaxDiagnostic> |> Compilation_semantic_diagnostics;

--- a/crates/slang/bindings/rust/ffi.rs
+++ b/crates/slang/bindings/rust/ffi.rs
@@ -594,6 +594,13 @@ mod slang_ffi {
         ) -> RawSyntaxTreeBufferIds;
 
         #[namespace = "wrapper::ast"]
+        fn Compilation_syntax_tree_count(compilation: &Compilation) -> usize;
+        fn Compilation_syntax_tree(
+            compilation: &Compilation,
+            index: usize,
+        ) -> SharedPtr<SyntaxTree>;
+
+        #[namespace = "wrapper::ast"]
         fn Compilation_semantic_diagnostics(compilation: &Compilation) -> Vec<RawSyntaxDiagnostic>;
 
         #[namespace = "wrapper::ast"]
@@ -784,6 +791,8 @@ impl_functions! {
         fn add_syntax_tree(self_: Pin<&mut Compilation>, tree: SharedPtr<SyntaxTree>) -> () |> Compilation_add_syntax_tree;
         fn add_syntax_tree_from_text(self_: Pin<&mut Compilation>, text: CxxSV, name: CxxSV, path: CxxSV, predefines: Vec<String>, include_paths: Vec<String>, include_buffers: Vec<RawSourceBuffer>, expand_includes: bool) -> RawSyntaxTreeBufferIds |> Compilation_add_syntax_tree_from_text;
         fn add_library_map_syntax_tree_from_text(self_: Pin<&mut Compilation>, text: CxxSV, name: CxxSV, path: CxxSV) -> RawSyntaxTreeBufferIds |> Compilation_add_library_map_syntax_tree_from_text;
+        fn syntax_tree_count(&self) -> usize |> Compilation_syntax_tree_count;
+        fn syntax_tree(&self, index: usize) -> SharedPtr<SyntaxTree> |> Compilation_syntax_tree;
         fn semantic_diagnostics(&self) -> Vec<RawSyntaxDiagnostic> |> Compilation_semantic_diagnostics;
         fn parse_diagnostics_with_options(&self, warning_options: Vec<String>) -> Vec<RawSyntaxDiagnostic> |> Compilation_parse_diagnostics_with_options;
         fn semantic_diagnostics_with_options(&self, warning_options: Vec<String>) -> Vec<RawSyntaxDiagnostic> |> Compilation_semantic_diagnostics_with_options;

--- a/crates/slang/bindings/rust/ffi.rs
+++ b/crates/slang/bindings/rust/ffi.rs
@@ -594,13 +594,6 @@ mod slang_ffi {
         ) -> RawSyntaxTreeBufferIds;
 
         #[namespace = "wrapper::ast"]
-        fn Compilation_syntax_tree_count(compilation: &Compilation) -> usize;
-        fn Compilation_syntax_tree(
-            compilation: &Compilation,
-            index: usize,
-        ) -> SharedPtr<SyntaxTree>;
-
-        #[namespace = "wrapper::ast"]
         fn Compilation_semantic_diagnostics(compilation: &Compilation) -> Vec<RawSyntaxDiagnostic>;
 
         #[namespace = "wrapper::ast"]
@@ -791,8 +784,6 @@ impl_functions! {
         fn add_syntax_tree(self_: Pin<&mut Compilation>, tree: SharedPtr<SyntaxTree>) -> () |> Compilation_add_syntax_tree;
         fn add_syntax_tree_from_text(self_: Pin<&mut Compilation>, text: CxxSV, name: CxxSV, path: CxxSV, predefines: Vec<String>, include_paths: Vec<String>, include_buffers: Vec<RawSourceBuffer>, expand_includes: bool) -> RawSyntaxTreeBufferIds |> Compilation_add_syntax_tree_from_text;
         fn add_library_map_syntax_tree_from_text(self_: Pin<&mut Compilation>, text: CxxSV, name: CxxSV, path: CxxSV) -> RawSyntaxTreeBufferIds |> Compilation_add_library_map_syntax_tree_from_text;
-        fn syntax_tree_count(&self) -> usize |> Compilation_syntax_tree_count;
-        fn syntax_tree(&self, index: usize) -> SharedPtr<SyntaxTree> |> Compilation_syntax_tree;
         fn semantic_diagnostics(&self) -> Vec<RawSyntaxDiagnostic> |> Compilation_semantic_diagnostics;
         fn parse_diagnostics_with_options(&self, warning_options: Vec<String>) -> Vec<RawSyntaxDiagnostic> |> Compilation_parse_diagnostics_with_options;
         fn semantic_diagnostics_with_options(&self, warning_options: Vec<String>) -> Vec<RawSyntaxDiagnostic> |> Compilation_semantic_diagnostics_with_options;

--- a/crates/slang/bindings/rust/ffi/wrapper.cc
+++ b/crates/slang/bindings/rust/ffi/wrapper.cc
@@ -1499,6 +1499,31 @@ std::shared_ptr<syntax::SyntaxTree> Compilation::parseLibraryMapSyntaxTreeFromTe
   return sourceSession->parseLibraryMapText(text, name, path);
 }
 
+std::shared_ptr<syntax::SyntaxTree> Compilation_parse_syntax_tree_from_text(
+    Compilation& compilation,
+    std::string_view text,
+    std::string_view name,
+    std::string_view path,
+    rust::Vec<rust::String> predefines,
+    rust::Vec<rust::String> includePaths,
+    rust::Vec<::RawSourceBuffer> includeBuffers) {
+  return compilation.parseSyntaxTreeFromText(
+      text,
+      name,
+      path,
+      std::move(predefines),
+      std::move(includePaths),
+      std::move(includeBuffers));
+}
+
+std::shared_ptr<syntax::SyntaxTree> Compilation_parse_library_map_syntax_tree_from_text(
+    Compilation& compilation,
+    std::string_view text,
+    std::string_view name,
+    std::string_view path) {
+  return compilation.parseLibraryMapSyntaxTreeFromText(text, name, path);
+}
+
 ::RawSyntaxTreeBufferIds Compilation::addSyntaxTreeFromText(
     std::string_view text,
     std::string_view name,

--- a/crates/slang/bindings/rust/ffi/wrapper.cc
+++ b/crates/slang/bindings/rust/ffi/wrapper.cc
@@ -66,6 +66,7 @@ struct SyntaxTreeSourceInfo {
   const slang::SourceManager* sourceManager;
   const slang::parsing::PreprocessorTraceSnapshot* preprocessorTrace;
   slang::SourceLocation rootLocation;
+  size_t owners = 1;
 };
 
 struct LexedTokenAtOffset {
@@ -1152,10 +1153,12 @@ SyntaxTree::SyntaxTree(std::shared_ptr<::slang::syntax::SyntaxTree> tree,
     return;
 
   std::lock_guard lock(syntaxTreeSourceInfoMutex);
-  syntaxTreeSourceInfo.emplace(
+  auto [it, inserted] = syntaxTreeSourceInfo.emplace(
       &root,
       SyntaxTreeSourceInfo{
           &innerTree->sourceManager(), innerTree->getPreprocessorTrace(), rootLocation});
+  if (!inserted)
+    it->second.owners++;
 }
 
 SyntaxTree::~SyntaxTree() {
@@ -1163,7 +1166,14 @@ SyntaxTree::~SyntaxTree() {
     return;
 
   std::lock_guard lock(syntaxTreeSourceInfoMutex);
-  syntaxTreeSourceInfo.erase(&innerTree->root());
+  auto it = syntaxTreeSourceInfo.find(&innerTree->root());
+  if (it == syntaxTreeSourceInfo.end())
+    return;
+  if (it->second.owners > 1) {
+    it->second.owners--;
+    return;
+  }
+  syntaxTreeSourceInfo.erase(it);
 }
 
 SourceSession::SourceSession() : sourceManager(std::make_shared<slang::SourceManager>()) {}

--- a/crates/slang/bindings/rust/ffi/wrapper.cc
+++ b/crates/slang/bindings/rust/ffi/wrapper.cc
@@ -66,7 +66,6 @@ struct SyntaxTreeSourceInfo {
   const slang::SourceManager* sourceManager;
   const slang::parsing::PreprocessorTraceSnapshot* preprocessorTrace;
   slang::SourceLocation rootLocation;
-  size_t owners = 1;
 };
 
 struct LexedTokenAtOffset {
@@ -1153,12 +1152,10 @@ SyntaxTree::SyntaxTree(std::shared_ptr<::slang::syntax::SyntaxTree> tree,
     return;
 
   std::lock_guard lock(syntaxTreeSourceInfoMutex);
-  auto [it, inserted] = syntaxTreeSourceInfo.emplace(
+  syntaxTreeSourceInfo.emplace(
       &root,
       SyntaxTreeSourceInfo{
           &innerTree->sourceManager(), innerTree->getPreprocessorTrace(), rootLocation});
-  if (!inserted)
-    it->second.owners++;
 }
 
 SyntaxTree::~SyntaxTree() {
@@ -1166,14 +1163,7 @@ SyntaxTree::~SyntaxTree() {
     return;
 
   std::lock_guard lock(syntaxTreeSourceInfoMutex);
-  auto it = syntaxTreeSourceInfo.find(&innerTree->root());
-  if (it == syntaxTreeSourceInfo.end())
-    return;
-  if (it->second.owners > 1) {
-    it->second.owners--;
-    return;
-  }
-  syntaxTreeSourceInfo.erase(it);
+  syntaxTreeSourceInfo.erase(&innerTree->root());
 }
 
 SourceSession::SourceSession() : sourceManager(std::make_shared<slang::SourceManager>()) {}
@@ -1495,8 +1485,7 @@ namespace ast {
       std::move(includePaths),
       std::move(includeBuffers),
       std::nullopt,
-      expandIncludes,
-      true);
+      expandIncludes);
   auto bufferIds = collectSyntaxTreeBufferIds(*tree);
   addSyntaxTree(std::move(tree));
   return bufferIds;
@@ -1510,17 +1499,6 @@ namespace ast {
   auto bufferIds = collectSyntaxTreeBufferIds(*tree);
   addSyntaxTree(std::move(tree));
   return bufferIds;
-}
-
-size_t Compilation::syntaxTreeCount() const {
-  return innerCompilation->getSyntaxTrees().size();
-}
-
-std::shared_ptr<syntax::SyntaxTree> Compilation::syntaxTree(size_t index) const {
-  auto trees = innerCompilation->getSyntaxTrees();
-  if (index >= trees.size())
-    return nullptr;
-  return std::make_shared<syntax::SyntaxTree>(trees[index], sourceSession);
 }
 
 ::RawSyntaxTreeBufferIds Compilation_add_syntax_tree_from_text(
@@ -1548,16 +1526,6 @@ std::shared_ptr<syntax::SyntaxTree> Compilation::syntaxTree(size_t index) const 
     std::string_view name,
     std::string_view path) {
   return compilation.addLibraryMapSyntaxTreeFromText(text, name, path);
-}
-
-size_t Compilation_syntax_tree_count(const Compilation& compilation) {
-  return compilation.syntaxTreeCount();
-}
-
-std::shared_ptr<syntax::SyntaxTree> Compilation_syntax_tree(
-    const Compilation& compilation,
-    size_t index) {
-  return compilation.syntaxTree(index);
 }
 
 rust::Vec<::RawSyntaxDiagnostic> Compilation_semantic_diagnostics(const Compilation& compilation) {

--- a/crates/slang/bindings/rust/ffi/wrapper.cc
+++ b/crates/slang/bindings/rust/ffi/wrapper.cc
@@ -1136,6 +1136,10 @@ rust::Vec<::RawExpectedSyntax> collect_expected_syntax(
 
 namespace syntax {
 
+::RawSyntaxTreeBufferIds SyntaxTree_buffer_ids(const SyntaxTree& tree) {
+  return collectSyntaxTreeBufferIds(tree);
+}
+
 SyntaxTree::SyntaxTree(std::shared_ptr<::slang::syntax::SyntaxTree> tree,
                        std::shared_ptr<SourceSession> sourceSession) :
     innerTree(std::move(tree)), sourceSession(std::move(sourceSession)) {
@@ -1468,6 +1472,32 @@ std::unique_ptr<SourceRange> SyntaxToken_rangeWithContext(
 } // namespace syntax
 
 namespace ast {
+
+std::shared_ptr<syntax::SyntaxTree> Compilation::parseSyntaxTreeFromText(
+    std::string_view text,
+    std::string_view name,
+    std::string_view path,
+    rust::Vec<rust::String> predefines,
+    rust::Vec<rust::String> includePaths,
+    rust::Vec<::RawSourceBuffer> includeBuffers) {
+  return sourceSession->parseText(
+      text,
+      name,
+      path,
+      std::move(predefines),
+      std::move(includePaths),
+      std::move(includeBuffers),
+      std::nullopt,
+      true,
+      true);
+}
+
+std::shared_ptr<syntax::SyntaxTree> Compilation::parseLibraryMapSyntaxTreeFromText(
+    std::string_view text,
+    std::string_view name,
+    std::string_view path) {
+  return sourceSession->parseLibraryMapText(text, name, path);
+}
 
 ::RawSyntaxTreeBufferIds Compilation::addSyntaxTreeFromText(
     std::string_view text,

--- a/crates/slang/bindings/rust/ffi/wrapper.cc
+++ b/crates/slang/bindings/rust/ffi/wrapper.cc
@@ -1485,7 +1485,8 @@ namespace ast {
       std::move(includePaths),
       std::move(includeBuffers),
       std::nullopt,
-      expandIncludes);
+      expandIncludes,
+      true);
   auto bufferIds = collectSyntaxTreeBufferIds(*tree);
   addSyntaxTree(std::move(tree));
   return bufferIds;
@@ -1499,6 +1500,17 @@ namespace ast {
   auto bufferIds = collectSyntaxTreeBufferIds(*tree);
   addSyntaxTree(std::move(tree));
   return bufferIds;
+}
+
+size_t Compilation::syntaxTreeCount() const {
+  return innerCompilation->getSyntaxTrees().size();
+}
+
+std::shared_ptr<syntax::SyntaxTree> Compilation::syntaxTree(size_t index) const {
+  auto trees = innerCompilation->getSyntaxTrees();
+  if (index >= trees.size())
+    return nullptr;
+  return std::make_shared<syntax::SyntaxTree>(trees[index], sourceSession);
 }
 
 ::RawSyntaxTreeBufferIds Compilation_add_syntax_tree_from_text(
@@ -1526,6 +1538,16 @@ namespace ast {
     std::string_view name,
     std::string_view path) {
   return compilation.addLibraryMapSyntaxTreeFromText(text, name, path);
+}
+
+size_t Compilation_syntax_tree_count(const Compilation& compilation) {
+  return compilation.syntaxTreeCount();
+}
+
+std::shared_ptr<syntax::SyntaxTree> Compilation_syntax_tree(
+    const Compilation& compilation,
+    size_t index) {
+  return compilation.syntaxTree(index);
 }
 
 rust::Vec<::RawSyntaxDiagnostic> Compilation_semantic_diagnostics(const Compilation& compilation) {

--- a/crates/slang/bindings/rust/ffi/wrapper.h
+++ b/crates/slang/bindings/rust/ffi/wrapper.h
@@ -131,7 +131,6 @@ namespace wrapper {
       const slang::ast::Compilation& inner() const { return *innerCompilation; }
 
       void addSyntaxTree(std::shared_ptr<syntax::SyntaxTree> tree) {
-        syntaxTreeWrapperStorage.push_back(tree);
         syntaxTreeStorage.push_back(tree);
         innerCompilation->addSyntaxTree(tree->sharedInner());
       }
@@ -149,12 +148,8 @@ namespace wrapper {
                                                                std::string_view name,
                                                                std::string_view path);
 
-      size_t syntaxTreeCount() const;
-      std::shared_ptr<syntax::SyntaxTree> syntaxTree(size_t index) const;
-
     private:
       std::vector<std::string> topModuleStorage;
-      std::vector<std::shared_ptr<syntax::SyntaxTree>> syntaxTreeWrapperStorage;
       std::vector<std::shared_ptr<syntax::SyntaxTree>> syntaxTreeStorage;
       std::shared_ptr<syntax::SourceSession> sourceSession =
           std::make_shared<syntax::SourceSession>();
@@ -631,11 +626,6 @@ namespace wrapper {
         std::string_view text,
         std::string_view name,
         std::string_view path);
-
-    size_t Compilation_syntax_tree_count(const Compilation& compilation);
-    std::shared_ptr<syntax::SyntaxTree> Compilation_syntax_tree(
-        const Compilation& compilation,
-        size_t index);
 
     rust::Vec<::RawSyntaxDiagnostic> Compilation_semantic_diagnostics(const Compilation& compilation);
     rust::Vec<::RawSyntaxDiagnostic> Compilation_parse_diagnostics_with_options(

--- a/crates/slang/bindings/rust/ffi/wrapper.h
+++ b/crates/slang/bindings/rust/ffi/wrapper.h
@@ -131,6 +131,7 @@ namespace wrapper {
       const slang::ast::Compilation& inner() const { return *innerCompilation; }
 
       void addSyntaxTree(std::shared_ptr<syntax::SyntaxTree> tree) {
+        syntaxTreeWrapperStorage.push_back(tree);
         syntaxTreeStorage.push_back(tree);
         innerCompilation->addSyntaxTree(tree->sharedInner());
       }
@@ -153,6 +154,7 @@ namespace wrapper {
 
     private:
       std::vector<std::string> topModuleStorage;
+      std::vector<std::shared_ptr<syntax::SyntaxTree>> syntaxTreeWrapperStorage;
       std::vector<std::shared_ptr<syntax::SyntaxTree>> syntaxTreeStorage;
       std::shared_ptr<syntax::SourceSession> sourceSession =
           std::make_shared<syntax::SourceSession>();

--- a/crates/slang/bindings/rust/ffi/wrapper.h
+++ b/crates/slang/bindings/rust/ffi/wrapper.h
@@ -148,6 +148,9 @@ namespace wrapper {
                                                                std::string_view name,
                                                                std::string_view path);
 
+      size_t syntaxTreeCount() const;
+      std::shared_ptr<syntax::SyntaxTree> syntaxTree(size_t index) const;
+
     private:
       std::vector<std::string> topModuleStorage;
       std::vector<std::shared_ptr<syntax::SyntaxTree>> syntaxTreeStorage;
@@ -626,6 +629,11 @@ namespace wrapper {
         std::string_view text,
         std::string_view name,
         std::string_view path);
+
+    size_t Compilation_syntax_tree_count(const Compilation& compilation);
+    std::shared_ptr<syntax::SyntaxTree> Compilation_syntax_tree(
+        const Compilation& compilation,
+        size_t index);
 
     rust::Vec<::RawSyntaxDiagnostic> Compilation_semantic_diagnostics(const Compilation& compilation);
     rust::Vec<::RawSyntaxDiagnostic> Compilation_parse_diagnostics_with_options(

--- a/crates/slang/bindings/rust/ffi/wrapper.h
+++ b/crates/slang/bindings/rust/ffi/wrapper.h
@@ -135,6 +135,19 @@ namespace wrapper {
         innerCompilation->addSyntaxTree(tree->sharedInner());
       }
 
+      std::shared_ptr<syntax::SyntaxTree> parseSyntaxTreeFromText(
+          std::string_view text,
+          std::string_view name,
+          std::string_view path,
+          rust::Vec<rust::String> predefines,
+          rust::Vec<rust::String> includePaths,
+          rust::Vec<::RawSourceBuffer> includeBuffers);
+
+      std::shared_ptr<syntax::SyntaxTree> parseLibraryMapSyntaxTreeFromText(
+          std::string_view text,
+          std::string_view name,
+          std::string_view path);
+
       ::RawSyntaxTreeBufferIds addSyntaxTreeFromText(
           std::string_view text,
           std::string_view name,
@@ -485,6 +498,8 @@ namespace wrapper {
       return tree.inner().root().sourceRange().start().buffer().getId();
     }
 
+    ::RawSyntaxTreeBufferIds SyntaxTree_buffer_ids(const SyntaxTree& tree);
+
     std::unique_ptr<SourceRange> SyntaxNode_range(const SyntaxNode& node);
 
     std::unique_ptr<SourceRange> SyntaxNode_rangeWithContext(
@@ -610,6 +625,21 @@ namespace wrapper {
     inline static void Compilation_add_syntax_tree(Compilation& compilation, std::shared_ptr<syntax::SyntaxTree> tree) {
         compilation.addSyntaxTree(std::move(tree));
     }
+
+    std::shared_ptr<syntax::SyntaxTree> Compilation_parse_syntax_tree_from_text(
+        Compilation& compilation,
+        std::string_view text,
+        std::string_view name,
+        std::string_view path,
+        rust::Vec<rust::String> predefines,
+        rust::Vec<rust::String> includePaths,
+        rust::Vec<::RawSourceBuffer> includeBuffers);
+
+    std::shared_ptr<syntax::SyntaxTree> Compilation_parse_library_map_syntax_tree_from_text(
+        Compilation& compilation,
+        std::string_view text,
+        std::string_view name,
+        std::string_view path);
 
     ::RawSyntaxTreeBufferIds Compilation_add_syntax_tree_from_text(
         Compilation& compilation,

--- a/crates/slang/bindings/rust/syntax_tree.rs
+++ b/crates/slang/bindings/rust/syntax_tree.rs
@@ -503,6 +503,10 @@ impl SyntaxTree {
         }
     }
 
+    pub fn preprocessor_trace(&self) -> Option<Trace> {
+        Trace::from_raw(self._ptr.preprocessorTraceFromParsed())
+    }
+
     #[inline]
     pub fn root(&self) -> Option<SyntaxNode<'_>> {
         SyntaxNode::from_raw_ptr(self._ptr.root())
@@ -867,6 +871,12 @@ impl Compilation {
             CxxSV::new(name),
             CxxSV::new(path),
         ))
+    }
+
+    pub fn syntax_trees(&self) -> Vec<SyntaxTree> {
+        (0..ffi::Compilation::syntax_tree_count(&self._ptr))
+            .map(|index| SyntaxTree { _ptr: ffi::Compilation::syntax_tree(&self._ptr, index) })
+            .collect()
     }
 
     pub fn semantic_diagnostics(&self) -> Vec<SyntaxDiagnostic> {

--- a/crates/slang/bindings/rust/syntax_tree.rs
+++ b/crates/slang/bindings/rust/syntax_tree.rs
@@ -503,6 +503,10 @@ impl SyntaxTree {
         }
     }
 
+    pub fn preprocessor_trace(&self) -> Option<Trace> {
+        Trace::from_raw(self._ptr.preprocessorTraceFromParsed())
+    }
+
     #[inline]
     pub fn root(&self) -> Option<SyntaxNode<'_>> {
         SyntaxNode::from_raw_ptr(self._ptr.root())
@@ -604,6 +608,10 @@ impl SyntaxTree {
 
     pub fn buffer_id(&self) -> u32 {
         self._ptr.buffer_id()
+    }
+
+    pub fn buffer_ids(&self) -> SyntaxTreeBufferIds {
+        SyntaxTreeBufferIds::from_raw(ffi::SyntaxTree_buffer_ids(&self._ptr))
     }
 }
 
@@ -827,6 +835,49 @@ impl Compilation {
 
     pub fn add_syntax_tree(&mut self, tree: SyntaxTree) {
         ffi::Compilation::add_syntax_tree(self._ptr.as_mut().unwrap(), tree._ptr);
+    }
+
+    pub fn parse_syntax_tree_from_text(
+        &mut self,
+        text: &str,
+        name: &str,
+        path: &str,
+        options: &SyntaxTreeOptions,
+    ) -> SyntaxTree {
+        SyntaxTree {
+            _ptr: ffi::Compilation::parse_syntax_tree_from_text(
+                self._ptr.as_mut().unwrap(),
+                CxxSV::new(text),
+                CxxSV::new(name),
+                CxxSV::new(path),
+                options.predefines.clone(),
+                options.include_paths.clone(),
+                options
+                    .include_buffers
+                    .iter()
+                    .map(|buffer| ffi::RawSourceBuffer {
+                        path: buffer.path.clone(),
+                        text: buffer.text.clone(),
+                    })
+                    .collect(),
+            ),
+        }
+    }
+
+    pub fn parse_library_map_syntax_tree_from_text(
+        &mut self,
+        text: &str,
+        name: &str,
+        path: &str,
+    ) -> SyntaxTree {
+        SyntaxTree {
+            _ptr: ffi::Compilation::parse_library_map_syntax_tree_from_text(
+                self._ptr.as_mut().unwrap(),
+                CxxSV::new(text),
+                CxxSV::new(name),
+                CxxSV::new(path),
+            ),
+        }
     }
 
     pub fn add_syntax_tree_from_text(

--- a/crates/slang/bindings/rust/syntax_tree.rs
+++ b/crates/slang/bindings/rust/syntax_tree.rs
@@ -503,10 +503,6 @@ impl SyntaxTree {
         }
     }
 
-    pub fn preprocessor_trace(&self) -> Option<Trace> {
-        Trace::from_raw(self._ptr.preprocessorTraceFromParsed())
-    }
-
     #[inline]
     pub fn root(&self) -> Option<SyntaxNode<'_>> {
         SyntaxNode::from_raw_ptr(self._ptr.root())
@@ -871,12 +867,6 @@ impl Compilation {
             CxxSV::new(name),
             CxxSV::new(path),
         ))
-    }
-
-    pub fn syntax_trees(&self) -> Vec<SyntaxTree> {
-        (0..ffi::Compilation::syntax_tree_count(&self._ptr))
-            .map(|index| SyntaxTree { _ptr: ffi::Compilation::syntax_tree(&self._ptr, index) })
-            .collect()
     }
 
     pub fn semantic_diagnostics(&self) -> Vec<SyntaxDiagnostic> {

--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -22,8 +22,6 @@ use std::{sync::Arc as StdArc, time::Instant};
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use hir::base_db::{
     project::{CompilationProfileId, ProjectConfig, SharedProjectConfig},
-    salsa::Durability,
-    source_db::SourceDb,
     source_root::SourceRootConfig,
 };
 use ide::analysis_host::AnalysisHost;
@@ -158,9 +156,7 @@ impl GlobalState {
 
         let mut analysis_host = AnalysisHost::new(None);
         let diagnostics_config = Arc::new(config.diagnostics_config());
-        analysis_host
-            .raw_db_mut()
-            .set_diagnostics_config_with_durability(diagnostics_config, Durability::HIGH);
+        analysis_host.set_diagnostics_config(diagnostics_config);
 
         let qihe_diagnostics = qihe::QiheDiagnostics::new();
         let qihe = qihe::Qihe::new(qihe_diagnostics);

--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -136,6 +136,59 @@ fn spawn_vfs_loader(
     }
 }
 
+pub(super) fn diagnostic_publish_freshness(
+    analysis: &AnalysisState,
+    diagnostics: &DiagnosticsState,
+    workspace: &WorkspaceState,
+) -> DiagnosticPublishFreshness {
+    let snapshot_id = analysis.analysis_host.snapshot_id();
+    let freshness = DiagnosticPublishFreshness::new(
+        snapshot_id,
+        diagnostics.diagnostics_revision,
+        diagnostics.diagnostic_target_revision,
+        workspace.workspace_vfs.diagnostic_readiness_revision(),
+    );
+    assert_eq!(
+        snapshot_id,
+        freshness.commit().snapshot_id(),
+        "analysis snapshot and diagnostic freshness must agree"
+    );
+    freshness
+}
+
+pub(super) fn make_snapshot(
+    config: &Arc<Config>,
+    workspaces: &Arc<Vec<Workspace>>,
+    analysis_state: &AnalysisState,
+    vfs: &Arc<RwLock<(Vfs, IntMap<FileId, LineEnding>)>>,
+    external_sources: &[StdArc<dyn DiagnosticSource>],
+    diagnostics: &DiagnosticsState,
+    workspace: &WorkspaceState,
+    cancellation: CancellationToken,
+) -> GlobalStateSnapshot {
+    let analysis = analysis_state.analysis_host.make_analysis();
+    let diagnostic_publish_freshness =
+        diagnostic_publish_freshness(analysis_state, diagnostics, workspace);
+    assert_eq!(
+        analysis.snapshot_id(),
+        diagnostic_publish_freshness.commit().snapshot_id(),
+        "analysis snapshot and diagnostic freshness must agree"
+    );
+    GlobalStateSnapshot {
+        config: Arc::clone(config),
+        workspaces: Arc::clone(workspaces),
+        analysis,
+        vfs: Arc::clone(vfs),
+        mem_docs: analysis_state.mem_docs.clone(),
+        sema_tokens_cache: Arc::clone(&analysis_state.semantic_tokens_cache),
+        external_sources: external_sources.to_vec(),
+        diagnostic_publish_freshness,
+        diagnostic_file_revisions: diagnostics.diagnostic_file_revisions.clone(),
+        cancellation,
+        accepted_response_effects: Default::default(),
+    }
+}
+
 impl GlobalState {
     pub(crate) fn new(
         sender: Sender<lsp_server::Message>,
@@ -161,11 +214,8 @@ impl GlobalState {
         let qihe_diagnostics = qihe::QiheDiagnostics::new();
         let qihe = qihe::Qihe::new(qihe_diagnostics);
         let qihe_source: StdArc<dyn DiagnosticSource> = StdArc::new(qihe.diagnostics_snapshot());
-        let semantic_diagnostics = semantic_compiler::SemanticDiagnostics::new();
-        let semantic_compiler = semantic_compiler::SemanticCompiler::new(semantic_diagnostics);
-        let semantic_source: StdArc<dyn DiagnosticSource> =
-            StdArc::new(semantic_compiler.diagnostics_snapshot());
-        let external_sources = vec![qihe_source, semantic_source];
+        let semantic_compiler = semantic_compiler::SemanticCompiler::new();
+        let external_sources = vec![qihe_source];
 
         GlobalState {
             client: ClientState {
@@ -215,28 +265,20 @@ impl GlobalState {
         &self,
         cancellation: CancellationToken,
     ) -> GlobalStateSnapshot {
-        GlobalStateSnapshot {
-            config: Arc::clone(&self.config_state.config),
-            workspaces: Arc::clone(&self.workspace.workspaces),
-            analysis: self.analysis.analysis_host.make_analysis(),
-            vfs: Arc::clone(&self.workspace.vfs),
-            mem_docs: self.analysis.mem_docs.clone(),
-            sema_tokens_cache: Arc::clone(&self.analysis.semantic_tokens_cache),
-            external_sources: self.external_sources.clone(),
-            diagnostic_publish_freshness: self.diagnostic_publish_freshness(),
-            diagnostic_file_revisions: self.diagnostics.diagnostic_file_revisions.clone(),
+        make_snapshot(
+            &self.config_state.config,
+            &self.workspace.workspaces,
+            &self.analysis,
+            &self.workspace.vfs,
+            &self.external_sources,
+            &self.diagnostics,
+            &self.workspace,
             cancellation,
-            accepted_response_effects: Default::default(),
-        }
+        )
     }
 
     pub(crate) fn diagnostic_publish_freshness(&self) -> DiagnosticPublishFreshness {
-        DiagnosticPublishFreshness::new(
-            self.analysis.analysis_host.snapshot_id(),
-            self.diagnostics.diagnostics_revision,
-            self.diagnostics.diagnostic_target_revision,
-            self.workspace.workspace_vfs.diagnostic_readiness_revision(),
-        )
+        diagnostic_publish_freshness(&self.analysis, &self.diagnostics, &self.workspace)
     }
 
     pub(crate) fn spawn_qihe_analysis(&mut self, params: RunQiheAnalysisParams) {

--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -156,6 +156,7 @@ pub(super) fn diagnostic_publish_freshness(
     freshness
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn make_snapshot(
     config: &Arc<Config>,
     workspaces: &Arc<Vec<Workspace>>,

--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -236,6 +236,7 @@ impl GlobalState {
 
     pub(crate) fn diagnostic_publish_freshness(&self) -> DiagnosticPublishFreshness {
         DiagnosticPublishFreshness::new(
+            self.analysis.analysis_host.snapshot_id(),
             self.diagnostics.diagnostics_revision,
             self.diagnostics.diagnostic_target_revision,
             self.workspace.workspace_vfs.diagnostic_readiness_revision(),

--- a/src/global_state/diagnostics.rs
+++ b/src/global_state/diagnostics.rs
@@ -191,6 +191,7 @@ pub(crate) struct DiagnosticSnapshotKey {
 }
 
 impl DiagnosticSnapshotKey {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_with_snapshot_id(
         snapshot_id: AnalysisSnapshotId,
         owner: DiagnosticOwner,
@@ -268,7 +269,7 @@ mod tests {
     #[test]
     fn diagnostic_result_identity_includes_analysis_snapshot() {
         let uri = Url::parse("file:///workspace/top.sv").unwrap();
-        let owner = DiagnosticOwner::File(FileId(7));
+        let owner = DiagnosticOwner::File(FileId::from_raw(7));
         let first = DiagnosticSnapshotKey::new_with_snapshot_id(
             AnalysisSnapshotId::new(10),
             owner,

--- a/src/global_state/diagnostics.rs
+++ b/src/global_state/diagnostics.rs
@@ -1,19 +1,30 @@
-use hir::base_db::{project::CompilationProfileId, source_root::SourceRootId};
+use hir::base_db::{
+    analysis_snapshot::AnalysisSnapshotId, project::CompilationProfileId, source_root::SourceRootId,
+};
 use lsp_types::Url;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use vfs::FileId;
 
 pub(crate) mod publisher;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(crate) struct DiagnosticCommitFreshness {
+    snapshot_id: AnalysisSnapshotId,
     diagnostics_revision: u64,
     readiness_revision: u64,
 }
 
 impl DiagnosticCommitFreshness {
-    pub(crate) fn new(diagnostics_revision: u64, readiness_revision: u64) -> Self {
-        Self { diagnostics_revision, readiness_revision }
+    pub(crate) fn for_snapshot(
+        snapshot_id: AnalysisSnapshotId,
+        diagnostics_revision: u64,
+        readiness_revision: u64,
+    ) -> Self {
+        Self { snapshot_id, diagnostics_revision, readiness_revision }
+    }
+
+    pub(crate) fn snapshot_id(self) -> AnalysisSnapshotId {
+        self.snapshot_id
     }
 
     pub(crate) fn readiness_revision(self) -> u64 {
@@ -68,12 +79,17 @@ pub(crate) struct DiagnosticPublishFreshness {
 
 impl DiagnosticPublishFreshness {
     pub(crate) fn new(
+        snapshot_id: AnalysisSnapshotId,
         diagnostics_revision: u64,
         target_revision: u64,
         readiness_revision: u64,
     ) -> Self {
         Self {
-            commit: DiagnosticCommitFreshness::new(diagnostics_revision, readiness_revision),
+            commit: DiagnosticCommitFreshness::for_snapshot(
+                snapshot_id,
+                diagnostics_revision,
+                readiness_revision,
+            ),
             target_revision,
         }
     }
@@ -165,6 +181,7 @@ impl DiagnosticFileRevision {
 
 #[derive(Debug, Clone)]
 pub(crate) struct DiagnosticSnapshotKey {
+    snapshot_id: AnalysisSnapshotId,
     owner: DiagnosticOwner,
     readiness_revision: u64,
     diagnostics_config_revision: u64,
@@ -174,7 +191,8 @@ pub(crate) struct DiagnosticSnapshotKey {
 }
 
 impl DiagnosticSnapshotKey {
-    pub(crate) fn new(
+    pub(crate) fn new_with_snapshot_id(
+        snapshot_id: AnalysisSnapshotId,
         owner: DiagnosticOwner,
         readiness_revision: u64,
         diagnostics_config_revision: u64,
@@ -186,6 +204,7 @@ impl DiagnosticSnapshotKey {
         dependency_revisions.sort_unstable();
         external_revisions.sort_by_key(|revision| revision.result_id_fragment());
         Self {
+            snapshot_id,
             owner,
             readiness_revision,
             diagnostics_config_revision,
@@ -211,7 +230,8 @@ impl DiagnosticSnapshotKey {
             .collect::<Vec<_>>()
             .join(",");
         format!(
-            "diag:config:{}:ready:{}:owner:{}:target:{}:deps:{}:external:{}",
+            "diag:snapshot:{}:config:{}:ready:{}:owner:{}:target:{}:deps:{}:external:{}",
+            self.snapshot_id.get(),
             self.diagnostics_config_revision,
             self.readiness_revision,
             self.owner.result_id_fragment(),
@@ -219,6 +239,25 @@ impl DiagnosticSnapshotKey {
             dependency_revisions,
             external_revisions
         )
+    }
+}
+
+/// Semantic diagnostics produced from one immutable analysis snapshot and one
+/// compilation profile.
+#[derive(Debug)]
+pub(crate) struct DiagnosticResult {
+    pub(crate) snapshot_id: AnalysisSnapshotId,
+    pub(crate) profile_id: CompilationProfileId,
+    pub(crate) diagnostics: FxHashMap<FileId, Vec<ide::diagnostics::Diagnostic>>,
+}
+
+impl DiagnosticResult {
+    pub(crate) fn new(
+        snapshot_id: AnalysisSnapshotId,
+        profile_id: CompilationProfileId,
+        diagnostics: FxHashMap<FileId, Vec<ide::diagnostics::Diagnostic>>,
+    ) -> Self {
+        Self { snapshot_id, profile_id, diagnostics }
     }
 }
 
@@ -238,5 +277,42 @@ impl DiagnosticTargetIdentity {
             Some(version) => format!("{}:{version}", self.uri),
             None => self.uri.clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diagnostic_result_identity_includes_analysis_snapshot() {
+        let uri = Url::parse("file:///workspace/top.sv").unwrap();
+        let owner = DiagnosticOwner::File(FileId(7));
+        let first = DiagnosticSnapshotKey::new_with_snapshot_id(
+            AnalysisSnapshotId::new(10),
+            owner,
+            0,
+            0,
+            &uri,
+            None,
+            Vec::new(),
+            Vec::new(),
+        )
+        .result_id();
+        let second = DiagnosticSnapshotKey::new_with_snapshot_id(
+            AnalysisSnapshotId::new(11),
+            owner,
+            0,
+            0,
+            &uri,
+            None,
+            Vec::new(),
+            Vec::new(),
+        )
+        .result_id();
+
+        assert_ne!(first, second);
+        assert!(first.contains("diag:snapshot:10:"));
+        assert!(second.contains("diag:snapshot:11:"));
     }
 }

--- a/src/global_state/diagnostics.rs
+++ b/src/global_state/diagnostics.rs
@@ -2,7 +2,7 @@ use hir::base_db::{
     analysis_snapshot::AnalysisSnapshotId, project::CompilationProfileId, source_root::SourceRootId,
 };
 use lsp_types::Url;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 use vfs::FileId;
 
 pub(crate) mod publisher;
@@ -239,25 +239,6 @@ impl DiagnosticSnapshotKey {
             dependency_revisions,
             external_revisions
         )
-    }
-}
-
-/// Semantic diagnostics produced from one immutable analysis snapshot and one
-/// compilation profile.
-#[derive(Debug)]
-pub(crate) struct DiagnosticResult {
-    pub(crate) snapshot_id: AnalysisSnapshotId,
-    pub(crate) profile_id: CompilationProfileId,
-    pub(crate) diagnostics: FxHashMap<FileId, Vec<ide::diagnostics::Diagnostic>>,
-}
-
-impl DiagnosticResult {
-    pub(crate) fn new(
-        snapshot_id: AnalysisSnapshotId,
-        profile_id: CompilationProfileId,
-        diagnostics: FxHashMap<FileId, Vec<ide::diagnostics::Diagnostic>>,
-    ) -> Self {
-        Self { snapshot_id, profile_id, diagnostics }
     }
 }
 

--- a/src/global_state/main_loop.rs
+++ b/src/global_state/main_loop.rs
@@ -309,7 +309,7 @@ mod tests {
 
         state.publish_diagnostics_tasks(PublishDiagnosticsBatch::from_tasks(
             vec![PublishDiagnosticsTask::for_test(file_id, uri, None, vec![diagnostic])],
-            DiagnosticPublishFreshness::new(1, 0, 0),
+            DiagnosticPublishFreshness::new(state.analysis.analysis_host.snapshot_id(), 1, 0, 0),
         ));
 
         assert!(client.receiver.recv_timeout(Duration::from_millis(50)).is_err());

--- a/src/global_state/main_loop.rs
+++ b/src/global_state/main_loop.rs
@@ -148,8 +148,11 @@ mod tests {
         panic!("expected work-done progress notification");
     }
 
-    fn publish_batch(tasks: Vec<PublishDiagnosticsTask>) -> PublishDiagnosticsBatch {
-        PublishDiagnosticsBatch::from_tasks(tasks, DiagnosticPublishFreshness::default())
+    fn publish_batch(
+        state: &GlobalState,
+        tasks: Vec<PublishDiagnosticsTask>,
+    ) -> PublishDiagnosticsBatch {
+        PublishDiagnosticsBatch::from_tasks(tasks, state.diagnostic_publish_freshness())
     }
 
     #[test]
@@ -185,22 +188,28 @@ mod tests {
             ..Diagnostic::default()
         };
 
-        state.publish_diagnostics_tasks(publish_batch(vec![PublishDiagnosticsTask::for_test(
-            file_id,
-            primary_uri.clone(),
-            None,
-            vec![diagnostic.clone()],
-        )]));
+        state.publish_diagnostics_tasks(publish_batch(
+            &state,
+            vec![PublishDiagnosticsTask::for_test(
+                file_id,
+                primary_uri.clone(),
+                None,
+                vec![diagnostic.clone()],
+            )],
+        ));
         let first = recv_publish(&client);
         assert_eq!(first.uri, primary_uri);
         assert_eq!(first.diagnostics, vec![diagnostic.clone()]);
 
-        state.publish_diagnostics_tasks(publish_batch(vec![PublishDiagnosticsTask::for_test(
-            file_id,
-            alias_uri.clone(),
-            Some(7),
-            vec![diagnostic.clone()],
-        )]));
+        state.publish_diagnostics_tasks(publish_batch(
+            &state,
+            vec![PublishDiagnosticsTask::for_test(
+                file_id,
+                alias_uri.clone(),
+                Some(7),
+                vec![diagnostic.clone()],
+            )],
+        ));
 
         let clear_primary = recv_publish(&client);
         assert_eq!(clear_primary.uri, primary_uri);
@@ -248,12 +257,15 @@ mod tests {
             ..Diagnostic::default()
         };
 
-        state.publish_diagnostics_tasks(publish_batch(vec![PublishDiagnosticsTask::for_test(
-            file_id,
-            alias_uri.clone(),
-            Some(9),
-            vec![diagnostic],
-        )]));
+        state.publish_diagnostics_tasks(publish_batch(
+            &state,
+            vec![PublishDiagnosticsTask::for_test(
+                file_id,
+                alias_uri.clone(),
+                Some(9),
+                vec![diagnostic],
+            )],
+        ));
         let published = recv_publish(&client);
         assert_eq!(published.uri, alias_uri);
         assert!(!published.diagnostics.is_empty());
@@ -261,7 +273,7 @@ mod tests {
         state.publish_diagnostics_tasks(PublishDiagnosticsBatch::for_touched_files(
             FxHashSet::from_iter([file_id]),
             Vec::new(),
-            DiagnosticPublishFreshness::default(),
+            state.diagnostic_publish_freshness(),
         ));
 
         let cleared = recv_publish(&client);

--- a/src/global_state/qihe.rs
+++ b/src/global_state/qihe.rs
@@ -442,6 +442,7 @@ pub(super) struct QiheGlobalCtx<'a> {
 impl QiheGlobalCtx<'_> {
     fn diagnostic_publish_freshness(&self) -> DiagnosticPublishFreshness {
         DiagnosticPublishFreshness::new(
+            self.analysis.analysis_host.snapshot_id(),
             self.diagnostics.diagnostics_revision,
             self.diagnostics.diagnostic_target_revision,
             self.workspace.workspace_vfs.diagnostic_readiness_revision(),

--- a/src/global_state/qihe.rs
+++ b/src/global_state/qihe.rs
@@ -441,12 +441,7 @@ pub(super) struct QiheGlobalCtx<'a> {
 
 impl QiheGlobalCtx<'_> {
     fn diagnostic_publish_freshness(&self) -> DiagnosticPublishFreshness {
-        DiagnosticPublishFreshness::new(
-            self.analysis.analysis_host.snapshot_id(),
-            self.diagnostics.diagnostics_revision,
-            self.diagnostics.diagnostic_target_revision,
-            self.workspace.workspace_vfs.diagnostic_readiness_revision(),
-        )
+        super::diagnostic_publish_freshness(self.analysis, self.diagnostics, self.workspace)
     }
 
     fn send(&self, message: lsp_server::Message) {
@@ -505,19 +500,16 @@ impl QiheCtx for QiheGlobalCtx<'_> {
     }
 
     fn make_snapshot(&self, cancellation: CancellationToken) -> GlobalStateSnapshot {
-        GlobalStateSnapshot {
-            config: Arc::clone(&self.config_state.config),
-            workspaces: Arc::clone(&self.workspace.workspaces),
-            analysis: self.analysis.analysis_host.make_analysis(),
-            vfs: Arc::clone(&self.workspace.vfs),
-            mem_docs: self.analysis.mem_docs.clone(),
-            sema_tokens_cache: Arc::clone(&self.analysis.semantic_tokens_cache),
-            external_sources: self.external_sources.to_vec(),
-            diagnostic_publish_freshness: self.diagnostic_publish_freshness(),
-            diagnostic_file_revisions: self.diagnostics.diagnostic_file_revisions.clone(),
+        super::make_snapshot(
+            &self.config_state.config,
+            &self.workspace.workspaces,
+            self.analysis,
+            &self.workspace.vfs,
+            self.external_sources,
+            self.diagnostics,
+            self.workspace,
             cancellation,
-            accepted_response_effects: Default::default(),
-        }
+        )
     }
 
     fn spawn_qihe_task<F>(&mut self, task: F)

--- a/src/global_state/reload.rs
+++ b/src/global_state/reload.rs
@@ -215,6 +215,7 @@ impl GlobalState {
                 Arc::new(diagnostics_config),
                 Durability::HIGH,
             );
+            self.analysis.analysis_host.mark_changed();
             self.diagnostics.diagnostics_revision += 1;
             self.invalidate_diagnostics(DiagnosticInvalidation::WorkspaceChanged);
         }

--- a/src/global_state/reload.rs
+++ b/src/global_state/reload.rs
@@ -1,6 +1,6 @@
 use std::panic::{self, AssertUnwindSafe};
 
-use hir::base_db::{change::Change, salsa::Durability, source_db::SourceDb};
+use hir::base_db::change::Change;
 use itertools::Itertools;
 use project_model::{ProjectModel, Workspace, get_workspace_folder, project_manifest};
 use triomphe::Arc;
@@ -211,11 +211,7 @@ impl GlobalState {
         let _old_config = std::mem::replace(&mut self.config_state.config, Arc::new(config));
 
         if diagnostics_config_changed {
-            self.analysis.analysis_host.raw_db_mut().set_diagnostics_config_with_durability(
-                Arc::new(diagnostics_config),
-                Durability::HIGH,
-            );
-            self.analysis.analysis_host.mark_changed();
+            self.analysis.analysis_host.set_diagnostics_config(Arc::new(diagnostics_config));
             self.diagnostics.diagnostics_revision += 1;
             self.invalidate_diagnostics(DiagnosticInvalidation::WorkspaceChanged);
         }

--- a/src/global_state/semantic_compiler.rs
+++ b/src/global_state/semantic_compiler.rs
@@ -5,9 +5,7 @@ use std::{
 
 use anyhow::Result;
 use hir::base_db::project::CompilationProfileId;
-use parking_lot::{Mutex, MutexGuard};
-use rustc_hash::{FxHashMap, FxHashSet};
-use triomphe::Arc;
+use rustc_hash::FxHashSet;
 use utils::{
     cancellation::{CancellationError, CancellationToken},
     thread::ThreadIntent,
@@ -18,21 +16,19 @@ use super::{
     AnalysisState, ClientState, ConfigState, DEFAULT_REQ_HANDLER, DiagnosticsState, GlobalState,
     TaskState, WorkspaceState,
     diagnostics::{
-        DiagnosticCommitFreshness, DiagnosticExternalRevision, DiagnosticOwner,
-        DiagnosticPublishFreshness, DiagnosticResult, DiagnosticSource,
+        DiagnosticPublishFreshness, DiagnosticSource,
         publisher::{DiagnosticsPublisher, PublishDiagnosticsBatch, PublishDiagnosticsTask},
     },
     snapshot::GlobalStateSnapshot,
     task::{SemanticCompilerTask, Task},
 };
 
-const SLANG_SEMANTIC: &str = "slang-semantic";
-
 #[derive(Debug)]
 pub(crate) struct SemanticCompilerUpdate {
-    results: Vec<DiagnosticResult>,
+    snapshot: GlobalStateSnapshot,
     touched_files: FxHashSet<FileId>,
-    freshness: DiagnosticCommitFreshness,
+    diagnostic_count: usize,
+    freshness: DiagnosticPublishFreshness,
 }
 
 impl SemanticCompilerUpdate {
@@ -41,63 +37,7 @@ impl SemanticCompilerUpdate {
     }
 
     pub(crate) fn diagnostic_count(&self) -> usize {
-        self.results
-            .iter()
-            .map(|result| result.diagnostics.values().map(Vec::len).sum::<usize>())
-            .sum()
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct SemanticDiagnostics {
-    states: Arc<Mutex<FxHashMap<FileId, SemanticDiagnosticState>>>,
-}
-
-impl SemanticDiagnostics {
-    pub(crate) fn new() -> Self {
-        Self { states: Arc::new(Mutex::new(FxHashMap::default())) }
-    }
-
-    fn lock(&self) -> MutexGuard<'_, FxHashMap<FileId, SemanticDiagnosticState>> {
-        self.states.lock()
-    }
-}
-
-impl DiagnosticSource for SemanticDiagnostics {
-    fn diagnostics(
-        &self,
-        file_id: FileId,
-        freshness: &DiagnosticCommitFreshness,
-    ) -> Vec<ide::diagnostics::Diagnostic> {
-        self.lock()
-            .get(&file_id)
-            .filter(|state| state.freshness == *freshness)
-            .map(|state| state.diagnostics.clone())
-            .unwrap_or_default()
-    }
-
-    fn external_revision(
-        &self,
-        file_id: FileId,
-        freshness: &DiagnosticCommitFreshness,
-    ) -> Option<DiagnosticExternalRevision> {
-        self.lock().get(&file_id).filter(|state| state.freshness == *freshness).map(|state| {
-            DiagnosticExternalRevision::new(
-                DiagnosticOwner::External { source: SLANG_SEMANTIC, file: file_id },
-                state.generation,
-            )
-        })
-    }
-
-    fn remove_deleted(&self, files: &FxHashSet<FileId>) {
-        if files.is_empty() {
-            return;
-        }
-
-        let mut diagnostics = self.lock();
-        for file_id in files {
-            diagnostics.remove(file_id);
-        }
+        self.diagnostic_count
     }
 }
 
@@ -114,21 +54,15 @@ pub(crate) struct SemanticCompiler {
     run_generation: SemanticCompilerRunId,
     active_cancel_token: Option<CancellationToken>,
     pending_profiles: FxHashSet<CompilationProfileId>,
-    diagnostics: SemanticDiagnostics,
 }
 
 impl SemanticCompiler {
-    pub(crate) fn new(diagnostics: SemanticDiagnostics) -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             run_generation: SemanticCompilerRunId::default(),
             active_cancel_token: None,
             pending_profiles: FxHashSet::default(),
-            diagnostics,
         }
-    }
-
-    pub(crate) fn diagnostics_snapshot(&self) -> SemanticDiagnostics {
-        self.diagnostics.clone()
     }
 
     pub(crate) fn schedule<C: SemanticCompilerCtx>(
@@ -172,7 +106,7 @@ impl SemanticCompiler {
                 }
 
                 self.active_cancel_token = None;
-                let current_freshness = ctx.diagnostic_commit_freshness();
+                let current_freshness = ctx.diagnostic_publish_freshness();
                 if update.freshness != current_freshness {
                     tracing::debug!(
                         ?run_id,
@@ -184,8 +118,8 @@ impl SemanticCompiler {
                     return;
                 }
 
-                let changed_files = self.replace_diagnostics(update);
-                self.publish_diagnostics(changed_files, ctx);
+                let SemanticCompilerUpdate { snapshot, touched_files, .. } = update;
+                self.publish_diagnostics(snapshot, touched_files, ctx);
                 self.start_pending(ctx);
             }
             SemanticCompilerTask::Cancelled { run_id } => {
@@ -257,71 +191,26 @@ impl SemanticCompiler {
 
     fn publish_diagnostics<C: SemanticCompilerCtx>(
         &mut self,
+        snapshot: GlobalStateSnapshot,
         changed_files: FxHashSet<FileId>,
         ctx: &mut C,
     ) {
-        ctx.publish_semantic_diagnostics(changed_files);
+        ctx.publish_semantic_diagnostics(snapshot, changed_files);
     }
-
-    fn replace_diagnostics(&mut self, update: SemanticCompilerUpdate) -> FxHashSet<FileId> {
-        let SemanticCompilerUpdate { results, mut touched_files, freshness } = update;
-        let mut by_file = FxHashMap::default();
-        for result in results {
-            assert_eq!(
-                result.snapshot_id,
-                freshness.snapshot_id(),
-                "semantic diagnostic result must belong to its commit snapshot"
-            );
-            tracing::debug!(
-                snapshot_id = ?result.snapshot_id,
-                profile_id = ?result.profile_id,
-                diagnostic_count = result.diagnostics.values().map(Vec::len).sum::<usize>(),
-                "semantic diagnostic result committed"
-            );
-            for (file_id, diagnostics) in result.diagnostics {
-                by_file.entry(file_id).or_insert_with(Vec::new).extend(diagnostics);
-            }
-        }
-        touched_files.extend(by_file.keys().copied());
-
-        let mut cache = self.diagnostics.lock();
-        let mut changed_files = touched_files
-            .iter()
-            .filter_map(|file_id| {
-                cache
-                    .get(file_id)
-                    .is_some_and(|state| !state.diagnostics.is_empty())
-                    .then_some(*file_id)
-            })
-            .collect::<FxHashSet<_>>();
-        changed_files.extend(by_file.keys().copied());
-
-        for file_id in touched_files {
-            let diagnostics = by_file.remove(&file_id).unwrap_or_default();
-            let generation =
-                cache.get(&file_id).map_or(1, |state| state.generation.saturating_add(1));
-            cache.insert(file_id, SemanticDiagnosticState { freshness, generation, diagnostics });
-        }
-
-        changed_files
-    }
-}
-
-#[derive(Debug, Clone, Default)]
-struct SemanticDiagnosticState {
-    freshness: DiagnosticCommitFreshness,
-    generation: u64,
-    diagnostics: Vec<ide::diagnostics::Diagnostic>,
 }
 
 pub(crate) trait SemanticCompilerCtx {
-    fn diagnostic_commit_freshness(&self) -> DiagnosticCommitFreshness;
+    fn diagnostic_publish_freshness(&self) -> DiagnosticPublishFreshness;
     fn make_snapshot(&self, cancellation: CancellationToken) -> GlobalStateSnapshot;
     fn spawn_semantic_compiler_task<F>(&mut self, task: F)
     where
         F: FnOnce(crossbeam_channel::Sender<Task>) + Send + 'static;
     fn task_cancel_token(&self) -> CancellationToken;
-    fn publish_semantic_diagnostics(&mut self, changed_files: FxHashSet<FileId>);
+    fn publish_semantic_diagnostics(
+        &mut self,
+        snapshot: GlobalStateSnapshot,
+        changed_files: FxHashSet<FileId>,
+    );
 }
 
 pub(super) struct SemanticCompilerGlobalCtx<'a> {
@@ -335,15 +224,6 @@ pub(super) struct SemanticCompilerGlobalCtx<'a> {
 }
 
 impl SemanticCompilerGlobalCtx<'_> {
-    fn diagnostic_publish_freshness(&self) -> DiagnosticPublishFreshness {
-        DiagnosticPublishFreshness::new(
-            self.analysis.analysis_host.snapshot_id(),
-            self.diagnostics.diagnostics_revision,
-            self.diagnostics.diagnostic_target_revision,
-            self.workspace.workspace_vfs.diagnostic_readiness_revision(),
-        )
-    }
-
     fn send(&self, message: lsp_server::Message) {
         if self.client.sender.send(message).is_err() {
             tracing::debug!("LSP message dropped because client connection is closed");
@@ -380,24 +260,21 @@ impl SemanticCompilerGlobalCtx<'_> {
 }
 
 impl SemanticCompilerCtx for SemanticCompilerGlobalCtx<'_> {
-    fn diagnostic_commit_freshness(&self) -> DiagnosticCommitFreshness {
-        self.diagnostic_publish_freshness().commit()
+    fn diagnostic_publish_freshness(&self) -> DiagnosticPublishFreshness {
+        super::diagnostic_publish_freshness(self.analysis, self.diagnostics, self.workspace)
     }
 
     fn make_snapshot(&self, cancellation: CancellationToken) -> GlobalStateSnapshot {
-        GlobalStateSnapshot {
-            config: Arc::clone(&self.config_state.config),
-            workspaces: Arc::clone(&self.workspace.workspaces),
-            analysis: self.analysis.analysis_host.make_analysis(),
-            vfs: Arc::clone(&self.workspace.vfs),
-            mem_docs: self.analysis.mem_docs.clone(),
-            sema_tokens_cache: Arc::clone(&self.analysis.semantic_tokens_cache),
-            external_sources: self.external_sources.to_vec(),
-            diagnostic_publish_freshness: self.diagnostic_publish_freshness(),
-            diagnostic_file_revisions: self.diagnostics.diagnostic_file_revisions.clone(),
+        super::make_snapshot(
+            &self.config_state.config,
+            &self.workspace.workspaces,
+            self.analysis,
+            &self.workspace.vfs,
+            self.external_sources,
+            self.diagnostics,
+            self.workspace,
             cancellation,
-            accepted_response_effects: Default::default(),
-        }
+        )
     }
 
     fn spawn_semantic_compiler_task<F>(&mut self, task: F)
@@ -411,7 +288,11 @@ impl SemanticCompilerCtx for SemanticCompilerGlobalCtx<'_> {
         self.tasks.task_pool.handle.task_token()
     }
 
-    fn publish_semantic_diagnostics(&mut self, changed_files: FxHashSet<FileId>) {
+    fn publish_semantic_diagnostics(
+        &mut self,
+        snapshot: GlobalStateSnapshot,
+        changed_files: FxHashSet<FileId>,
+    ) {
         if changed_files.is_empty() {
             return;
         }
@@ -421,7 +302,6 @@ impl SemanticCompilerCtx for SemanticCompilerGlobalCtx<'_> {
             return;
         }
 
-        let snapshot = self.make_snapshot(self.task_cancel_token());
         let mut publish_tasks = Vec::with_capacity(changed_files.len());
         let mut touched_file_ids = FxHashSet::default();
         for file_id in changed_files.iter().copied() {
@@ -503,7 +383,7 @@ fn run_semantic_compiler_task(
     run_id: SemanticCompilerRunId,
     cancellation: CancellationToken,
 ) -> SemanticCompilerTask {
-    match collect_semantic_diagnostics(&snapshot, profile_ids, &cancellation) {
+    match collect_semantic_diagnostics(snapshot, profile_ids, &cancellation) {
         Ok(update) => SemanticCompilerTask::Finished { run_id, update },
         Err(err) if err.is::<CancellationError>() => SemanticCompilerTask::Cancelled { run_id },
         Err(err) => SemanticCompilerTask::Failed { run_id, message: err.to_string() },
@@ -511,33 +391,32 @@ fn run_semantic_compiler_task(
 }
 
 fn collect_semantic_diagnostics(
-    snapshot: &GlobalStateSnapshot,
+    snapshot: GlobalStateSnapshot,
     profile_ids: Vec<CompilationProfileId>,
     cancellation: &CancellationToken,
 ) -> Result<SemanticCompilerUpdate> {
-    let freshness = snapshot.diagnostic_commit_freshness();
-    let snapshot_id = snapshot.analysis.snapshot_id();
-    let mut results = Vec::with_capacity(profile_ids.len());
+    let freshness = snapshot.diagnostic_publish_freshness;
     let mut touched_files = FxHashSet::default();
+    let mut diagnostic_count = 0;
+    let profile_count = profile_ids.len();
 
     for profile_id in profile_ids {
         cancellation.check()?;
         touched_files.extend(snapshot.analysis.compilation_profile_file_ids(profile_id)?);
-        let mut by_file = FxHashMap::default();
         let diagnostics = snapshot.analysis.compilation_profile_diagnostics(profile_id)?;
-        for diagnostic in diagnostics {
-            cancellation.check()?;
-            if diagnostic.source != ide::diagnostics::DiagnosticSource::SlangSemantic {
-                continue;
-            }
-            let file_id = diagnostic.file_id;
-            by_file.entry(file_id).or_insert_with(Vec::new).push(diagnostic);
-        }
-        results.push(DiagnosticResult::new(snapshot_id, profile_id, by_file));
+        diagnostic_count += diagnostics.len();
+        cancellation.check()?;
     }
     cancellation.check()?;
 
-    Ok(SemanticCompilerUpdate { results, touched_files, freshness })
+    tracing::debug!(
+        snapshot_id = ?snapshot.analysis_snapshot_id(),
+        profile_count,
+        root_file_count = touched_files.len(),
+        diagnostic_count,
+        "semantic compiler prewarmed profile diagnostics"
+    );
+    Ok(SemanticCompilerUpdate { snapshot, touched_files, diagnostic_count, freshness })
 }
 
 fn normalize_profile_ids(mut profile_ids: Vec<CompilationProfileId>) -> Vec<CompilationProfileId> {

--- a/src/global_state/semantic_compiler.rs
+++ b/src/global_state/semantic_compiler.rs
@@ -19,7 +19,7 @@ use super::{
     TaskState, WorkspaceState,
     diagnostics::{
         DiagnosticCommitFreshness, DiagnosticExternalRevision, DiagnosticOwner,
-        DiagnosticPublishFreshness, DiagnosticSource,
+        DiagnosticPublishFreshness, DiagnosticResult, DiagnosticSource,
         publisher::{DiagnosticsPublisher, PublishDiagnosticsBatch, PublishDiagnosticsTask},
     },
     snapshot::GlobalStateSnapshot,
@@ -30,7 +30,7 @@ const SLANG_SEMANTIC: &str = "slang-semantic";
 
 #[derive(Debug)]
 pub(crate) struct SemanticCompilerUpdate {
-    by_file: FxHashMap<FileId, Vec<ide::diagnostics::Diagnostic>>,
+    results: Vec<DiagnosticResult>,
     touched_files: FxHashSet<FileId>,
     freshness: DiagnosticCommitFreshness,
 }
@@ -41,7 +41,10 @@ impl SemanticCompilerUpdate {
     }
 
     pub(crate) fn diagnostic_count(&self) -> usize {
-        self.by_file.values().map(Vec::len).sum()
+        self.results
+            .iter()
+            .map(|result| result.diagnostics.values().map(Vec::len).sum::<usize>())
+            .sum()
     }
 }
 
@@ -181,7 +184,7 @@ impl SemanticCompiler {
                     return;
                 }
 
-                let changed_files = self.replace_diagnostics(update, current_freshness);
+                let changed_files = self.replace_diagnostics(update);
                 self.publish_diagnostics(changed_files, ctx);
                 self.start_pending(ctx);
             }
@@ -260,12 +263,25 @@ impl SemanticCompiler {
         ctx.publish_semantic_diagnostics(changed_files);
     }
 
-    fn replace_diagnostics(
-        &mut self,
-        update: SemanticCompilerUpdate,
-        freshness: DiagnosticCommitFreshness,
-    ) -> FxHashSet<FileId> {
-        let SemanticCompilerUpdate { mut by_file, mut touched_files, freshness: _ } = update;
+    fn replace_diagnostics(&mut self, update: SemanticCompilerUpdate) -> FxHashSet<FileId> {
+        let SemanticCompilerUpdate { results, mut touched_files, freshness } = update;
+        let mut by_file = FxHashMap::default();
+        for result in results {
+            assert_eq!(
+                result.snapshot_id,
+                freshness.snapshot_id(),
+                "semantic diagnostic result must belong to its commit snapshot"
+            );
+            tracing::debug!(
+                snapshot_id = ?result.snapshot_id,
+                profile_id = ?result.profile_id,
+                diagnostic_count = result.diagnostics.values().map(Vec::len).sum::<usize>(),
+                "semantic diagnostic result committed"
+            );
+            for (file_id, diagnostics) in result.diagnostics {
+                by_file.entry(file_id).or_insert_with(Vec::new).extend(diagnostics);
+            }
+        }
         touched_files.extend(by_file.keys().copied());
 
         let mut cache = self.diagnostics.lock();
@@ -321,6 +337,7 @@ pub(super) struct SemanticCompilerGlobalCtx<'a> {
 impl SemanticCompilerGlobalCtx<'_> {
     fn diagnostic_publish_freshness(&self) -> DiagnosticPublishFreshness {
         DiagnosticPublishFreshness::new(
+            self.analysis.analysis_host.snapshot_id(),
             self.diagnostics.diagnostics_revision,
             self.diagnostics.diagnostic_target_revision,
             self.workspace.workspace_vfs.diagnostic_readiness_revision(),
@@ -499,12 +516,14 @@ fn collect_semantic_diagnostics(
     cancellation: &CancellationToken,
 ) -> Result<SemanticCompilerUpdate> {
     let freshness = snapshot.diagnostic_commit_freshness();
-    let mut by_file = FxHashMap::default();
+    let snapshot_id = snapshot.analysis.snapshot_id();
+    let mut results = Vec::with_capacity(profile_ids.len());
     let mut touched_files = FxHashSet::default();
 
     for profile_id in profile_ids {
         cancellation.check()?;
         touched_files.extend(snapshot.analysis.compilation_profile_file_ids(profile_id)?);
+        let mut by_file = FxHashMap::default();
         let diagnostics = snapshot.analysis.compilation_profile_diagnostics(profile_id)?;
         for diagnostic in diagnostics {
             cancellation.check()?;
@@ -514,10 +533,11 @@ fn collect_semantic_diagnostics(
             let file_id = diagnostic.file_id;
             by_file.entry(file_id).or_insert_with(Vec::new).push(diagnostic);
         }
+        results.push(DiagnosticResult::new(snapshot_id, profile_id, by_file));
     }
     cancellation.check()?;
 
-    Ok(SemanticCompilerUpdate { by_file, touched_files, freshness })
+    Ok(SemanticCompilerUpdate { results, touched_files, freshness })
 }
 
 fn normalize_profile_ids(mut profile_ids: Vec<CompilationProfileId>) -> Vec<CompilationProfileId> {

--- a/src/global_state/semantic_compiler.rs
+++ b/src/global_state/semantic_compiler.rs
@@ -3,7 +3,7 @@ use std::{
     sync::Arc as StdArc,
 };
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use hir::base_db::project::CompilationProfileId;
 use rustc_hash::FxHashSet;
 use utils::{
@@ -25,10 +25,16 @@ use super::{
 
 #[derive(Debug)]
 pub(crate) struct SemanticCompilerUpdate {
-    snapshot: GlobalStateSnapshot,
+    delivery: SemanticDiagnosticsDelivery,
     touched_files: FxHashSet<FileId>,
     diagnostic_count: usize,
     freshness: DiagnosticPublishFreshness,
+}
+
+#[derive(Debug)]
+enum SemanticDiagnosticsDelivery {
+    PullRefresh,
+    Push(PublishDiagnosticsBatch),
 }
 
 impl SemanticCompilerUpdate {
@@ -118,8 +124,15 @@ impl SemanticCompiler {
                     return;
                 }
 
-                let SemanticCompilerUpdate { snapshot, touched_files, .. } = update;
-                self.publish_diagnostics(snapshot, touched_files, ctx);
+                let SemanticCompilerUpdate { delivery, touched_files, .. } = update;
+                match delivery {
+                    SemanticDiagnosticsDelivery::PullRefresh => {
+                        ctx.refresh_semantic_diagnostics(touched_files);
+                    }
+                    SemanticDiagnosticsDelivery::Push(batch) => {
+                        ctx.publish_semantic_diagnostics(batch);
+                    }
+                }
                 self.start_pending(ctx);
             }
             SemanticCompilerTask::Cancelled { run_id } => {
@@ -188,15 +201,6 @@ impl SemanticCompiler {
             self.start_run(profile_ids, ctx);
         }
     }
-
-    fn publish_diagnostics<C: SemanticCompilerCtx>(
-        &mut self,
-        snapshot: GlobalStateSnapshot,
-        changed_files: FxHashSet<FileId>,
-        ctx: &mut C,
-    ) {
-        ctx.publish_semantic_diagnostics(snapshot, changed_files);
-    }
 }
 
 pub(crate) trait SemanticCompilerCtx {
@@ -206,11 +210,8 @@ pub(crate) trait SemanticCompilerCtx {
     where
         F: FnOnce(crossbeam_channel::Sender<Task>) + Send + 'static;
     fn task_cancel_token(&self) -> CancellationToken;
-    fn publish_semantic_diagnostics(
-        &mut self,
-        snapshot: GlobalStateSnapshot,
-        changed_files: FxHashSet<FileId>,
-    );
+    fn refresh_semantic_diagnostics(&mut self, changed_files: FxHashSet<FileId>);
+    fn publish_semantic_diagnostics(&mut self, batch: PublishDiagnosticsBatch);
 }
 
 pub(super) struct SemanticCompilerGlobalCtx<'a> {
@@ -288,52 +289,15 @@ impl SemanticCompilerCtx for SemanticCompilerGlobalCtx<'_> {
         self.tasks.task_pool.handle.task_token()
     }
 
-    fn publish_semantic_diagnostics(
-        &mut self,
-        snapshot: GlobalStateSnapshot,
-        changed_files: FxHashSet<FileId>,
-    ) {
-        if changed_files.is_empty() {
+    fn refresh_semantic_diagnostics(&mut self, changed_files: FxHashSet<FileId>) {
+        self.refresh_pull_diagnostics(changed_files);
+    }
+
+    fn publish_semantic_diagnostics(&mut self, batch: PublishDiagnosticsBatch) {
+        if batch.touched_file_count() == 0 {
             return;
         }
 
-        if self.config_state.config.cli_pull_diagnostics_support() {
-            self.refresh_pull_diagnostics(changed_files);
-            return;
-        }
-
-        let mut publish_tasks = Vec::with_capacity(changed_files.len());
-        let mut touched_file_ids = FxHashSet::default();
-        for file_id in changed_files.iter().copied() {
-            let targets = match snapshot.diagnostic_publish_targets(file_id) {
-                Ok(targets) => targets,
-                Err(error) => {
-                    tracing::debug!(
-                        ?file_id,
-                        "skipping semantic diagnostics for file without URI: {error:#}"
-                    );
-                    continue;
-                }
-            };
-            let diagnostics = match snapshot.lsp_diagnostics(file_id) {
-                Ok(diagnostics) => diagnostics,
-                Err(error) if error.is::<ide::Cancelled>() => {
-                    tracing::debug!(?file_id, "semantic diagnostic publish cancelled");
-                    continue;
-                }
-                Err(error) => {
-                    tracing::debug!(?file_id, "semantic diagnostic publish failed: {error:#}");
-                    continue;
-                }
-            };
-            touched_file_ids.insert(file_id);
-
-            publish_tasks.extend(
-                targets
-                    .into_iter()
-                    .map(|target| PublishDiagnosticsTask::from_target(target, diagnostics.clone())),
-            );
-        }
         let current_freshness = self.diagnostic_publish_freshness();
         DiagnosticsPublisher::new(
             &self.config_state.config,
@@ -342,11 +306,7 @@ impl SemanticCompilerCtx for SemanticCompilerGlobalCtx<'_> {
             &self.client.sender,
             current_freshness,
         )
-        .publish(PublishDiagnosticsBatch::for_touched_files(
-            touched_file_ids,
-            publish_tasks,
-            snapshot.diagnostic_publish_freshness,
-        ));
+        .publish(batch);
     }
 }
 
@@ -416,7 +376,56 @@ fn collect_semantic_diagnostics(
         diagnostic_count,
         "semantic compiler prewarmed profile diagnostics"
     );
-    Ok(SemanticCompilerUpdate { snapshot, touched_files, diagnostic_count, freshness })
+
+    let delivery = if snapshot.config.cli_pull_diagnostics_support() {
+        SemanticDiagnosticsDelivery::PullRefresh
+    } else {
+        SemanticDiagnosticsDelivery::Push(materialize_semantic_publish_batch(
+            &snapshot,
+            &touched_files,
+            cancellation,
+        )?)
+    };
+    drop(snapshot);
+
+    Ok(SemanticCompilerUpdate { delivery, touched_files, diagnostic_count, freshness })
+}
+
+fn materialize_semantic_publish_batch(
+    snapshot: &GlobalStateSnapshot,
+    changed_files: &FxHashSet<FileId>,
+    cancellation: &CancellationToken,
+) -> Result<PublishDiagnosticsBatch> {
+    let mut publish_tasks = Vec::with_capacity(changed_files.len());
+    let mut touched_file_ids = FxHashSet::default();
+    for file_id in changed_files.iter().copied() {
+        cancellation.check()?;
+        let targets = snapshot
+            .diagnostic_publish_targets(file_id)
+            .with_context(|| format!("failed to resolve diagnostic targets for {file_id:?}"))?;
+        let diagnostics = match snapshot.lsp_diagnostics(file_id) {
+            Ok(diagnostics) => diagnostics,
+            Err(error) if error.is::<ide::Cancelled>() => return Err(CancellationError.into()),
+            Err(error) => {
+                return Err(error.context(format!(
+                    "failed to materialize semantic diagnostics for {file_id:?}"
+                )));
+            }
+        };
+        touched_file_ids.insert(file_id);
+        publish_tasks.extend(
+            targets
+                .into_iter()
+                .map(|target| PublishDiagnosticsTask::from_target(target, diagnostics.clone())),
+        );
+    }
+    cancellation.check()?;
+
+    Ok(PublishDiagnosticsBatch::for_touched_files(
+        touched_file_ids,
+        publish_tasks,
+        snapshot.diagnostic_publish_freshness,
+    ))
 }
 
 fn normalize_profile_ids(mut profile_ids: Vec<CompilationProfileId>) -> Vec<CompilationProfileId> {
@@ -430,4 +439,69 @@ fn panic_message(panic: &(dyn std::any::Any + Send)) -> Option<&str> {
         .downcast_ref::<String>()
         .map(String::as_str)
         .or_else(|| panic.downcast_ref::<&str>().copied())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use hir::base_db::change::Change;
+    use lsp_server::Connection;
+    use lsp_types::{ClientCapabilities, TraceValue};
+    use utils::test_support::TestDir;
+
+    use super::*;
+    use crate::{
+        Opt,
+        config::{self, user_config::UserConfig},
+        i18n::I18n,
+    };
+
+    #[test]
+    fn semantic_compiler_task_does_not_retain_analysis_snapshot() {
+        let root = TestDir::new("semantic-compiler-snapshot-lifetime");
+        let root_path = root.path().to_path_buf();
+        let config = config::Config::new(
+            Opt {
+                process_name: "vide-test".to_owned(),
+                log: "error".to_owned(),
+                log_filename: None,
+                profile_trace: None,
+            },
+            root_path.clone(),
+            ClientCapabilities::default(),
+            vec![root_path],
+            I18n::default(),
+            UserConfig::default(),
+            Vec::new(),
+        );
+        let (server, _client) = Connection::memory();
+        let mut state = GlobalState::new(server.sender, config, TraceValue::Off);
+        let cancellation = CancellationToken::new();
+        let snapshot = state.make_snapshot_with_cancel(cancellation.clone());
+        let task = run_semantic_compiler_task(
+            snapshot,
+            Vec::new(),
+            SemanticCompilerRunId::default(),
+            cancellation,
+        );
+
+        let mut analysis_host = std::mem::take(&mut state.analysis.analysis_host);
+        let (finished_tx, finished_rx) = crossbeam_channel::bounded(1);
+        let writer = std::thread::spawn(move || {
+            analysis_host.apply_change(Change::new());
+            finished_tx.send(()).unwrap();
+            analysis_host
+        });
+
+        let completed_while_task_was_retained =
+            finished_rx.recv_timeout(Duration::from_secs(1)).is_ok();
+        drop(task);
+        state.analysis.analysis_host = writer.join().unwrap();
+
+        assert!(
+            completed_while_task_was_retained,
+            "semantic compiler task retained an analysis snapshot and blocked the next change"
+        );
+    }
 }

--- a/src/global_state/snapshot.rs
+++ b/src/global_state/snapshot.rs
@@ -233,7 +233,8 @@ impl GlobalStateSnapshot {
             .filter_map(|source| source.external_revision(file_id, &freshness))
             .collect();
         Some(
-            DiagnosticSnapshotKey::new(
+            DiagnosticSnapshotKey::new_with_snapshot_id(
+                freshness.snapshot_id(),
                 owner,
                 self.diagnostic_publish_freshness.commit().readiness_revision(),
                 self.config.diagnostics_config().revision,

--- a/src/global_state/snapshot.rs
+++ b/src/global_state/snapshot.rs
@@ -78,6 +78,16 @@ pub(crate) struct GlobalStateSnapshot {
     pub(crate) workspaces: Arc<Vec<Workspace>>,
 }
 
+impl std::fmt::Debug for GlobalStateSnapshot {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("GlobalStateSnapshot")
+            .field("snapshot_id", &self.analysis_snapshot_id())
+            .field("diagnostic_publish_freshness", &self.diagnostic_publish_freshness)
+            .finish()
+    }
+}
+
 impl std::panic::UnwindSafe for GlobalStateSnapshot {}
 
 impl GlobalStateSnapshot {
@@ -142,6 +152,13 @@ impl GlobalStateSnapshot {
 
         if self.open_file_syntax_diagnostics_for_disabled_root(file_id) {
             return self.analysis.parse_diagnostics(file_id);
+        }
+
+        if let Some(DiagnosticOwner::CompilationProfile(profile_id)) =
+            self.diagnostic_owner(file_id, DiagnosticRequestScope::Document)
+        {
+            let diagnostics = self.analysis.compilation_profile_diagnostics(profile_id)?;
+            return Ok(diagnostics.into_iter().filter(|diag| diag.file_id == file_id).collect());
         }
 
         self.analysis.diagnostics(file_id)
@@ -391,7 +408,7 @@ impl GlobalStateSnapshot {
     ) -> Cancellable<Vec<ide::diagnostics::Diagnostic>> {
         match producer.owner() {
             DiagnosticOwner::CompilationProfile(profile_id) => {
-                self.analysis.compilation_profile_syntax_diagnostics(profile_id)
+                self.analysis.compilation_profile_diagnostics(profile_id)
             }
             DiagnosticOwner::SourceRoot(_) => {
                 self.analysis.source_root_diagnostics(producer.representative_file_id())

--- a/src/global_state/snapshot.rs
+++ b/src/global_state/snapshot.rs
@@ -1,7 +1,7 @@
 use std::{path::Path, sync::Arc as StdArc};
 
 use hir::base_db::source_root::{SourceRootDiagnosticScope, SourceRootRole};
-use ide::{Cancellable, analysis::Analysis};
+use ide::{Cancellable, analysis::AnalysisSnapshot};
 use lsp_types::Url;
 use nohash_hasher::IntMap;
 use parking_lot::{MappedRwLockReadGuard, Mutex, RwLock, RwLockReadGuard};
@@ -64,7 +64,7 @@ impl DiagnosticPublishTarget {
 // immutable
 pub(crate) struct GlobalStateSnapshot {
     pub(crate) config: Arc<Config>,
-    pub(crate) analysis: Analysis,
+    pub(crate) analysis: AnalysisSnapshot,
     // pub(crate) check_fixes: CheckFixes,
     pub(crate) sema_tokens_cache: Arc<Mutex<FxHashMap<Url, lsp_types::SemanticTokens>>>,
     pub(crate) external_sources: Vec<StdArc<dyn DiagnosticSource>>,
@@ -81,6 +81,12 @@ pub(crate) struct GlobalStateSnapshot {
 impl std::panic::UnwindSafe for GlobalStateSnapshot {}
 
 impl GlobalStateSnapshot {
+    pub(crate) fn analysis_snapshot_id(
+        &self,
+    ) -> hir::base_db::analysis_snapshot::AnalysisSnapshotId {
+        self.analysis.snapshot_id()
+    }
+
     fn vfs_read(&self) -> MappedRwLockReadGuard<'_, Vfs> {
         RwLockReadGuard::map(self.vfs.read(), |(it, _)| it)
     }
@@ -145,6 +151,11 @@ impl GlobalStateSnapshot {
         &self,
         file_id: FileId,
     ) -> anyhow::Result<Vec<lsp_types::Diagnostic>> {
+        tracing::debug!(
+            snapshot_id = ?self.analysis_snapshot_id(),
+            ?file_id,
+            "resolve diagnostics for analysis snapshot"
+        );
         if !self.document_diagnostics_enabled(file_id) {
             return Ok(Vec::new());
         }

--- a/src/tests/diagnostics.rs
+++ b/src/tests/diagnostics.rs
@@ -1735,7 +1735,7 @@ fn syntax_only_document_result_id_changes_when_include_dependency_changes() {
 }
 
 #[test]
-fn document_diagnostic_result_id_ignores_unrelated_profile_changes() {
+fn document_diagnostic_result_id_tracks_unrelated_profile_snapshot() {
     let pull_caps = ClientCapabilities {
         text_document: Some(TextDocumentClientCapabilities {
             diagnostic: Some(DiagnosticClientCapabilities::default()),
@@ -1800,10 +1800,10 @@ fn document_diagnostic_result_id_ignores_unrelated_profile_changes() {
         2,
         Some(first_result_id.clone()),
     );
-    assert_eq!(
+    assert_ne!(
         second_result_id.as_deref(),
         Some(first_result_id.as_str()),
-        "edits in a different semantic profile must not invalidate this result id"
+        "edits in a different semantic profile advance the authoritative analysis snapshot id"
     );
     assert!(
         second_items.is_empty(),

--- a/src/tests/diagnostics.rs
+++ b/src/tests/diagnostics.rs
@@ -1438,7 +1438,11 @@ fn document_diagnostic_result_id_tracks_diagnostics_config_revision() {
         &client,
         uri.clone(),
         1,
-        |result_id, items| items.is_empty() && result_id.is_some(),
+        |result_id, items| {
+            items.is_empty()
+                && result_id
+                    .is_some_and(|result_id| result_id.contains("owner:compilation-profile:0"))
+        },
         "initial empty semantic diagnostics result id",
     );
     let first_result_id = first_result_id.expect("expected first diagnostic result id");

--- a/src/tests/diagnostics.rs
+++ b/src/tests/diagnostics.rs
@@ -1438,10 +1438,7 @@ fn document_diagnostic_result_id_tracks_diagnostics_config_revision() {
         &client,
         uri.clone(),
         1,
-        |result_id, items| {
-            items.is_empty()
-                && result_id.is_some_and(|result_id| result_id.contains("external-slang-semantic"))
-        },
+        |result_id, items| items.is_empty() && result_id.is_some(),
         "initial empty semantic diagnostics result id",
     );
     let first_result_id = first_result_id.expect("expected first diagnostic result id");


### PR DESCRIPTION
Unify profile compilation parsing around analysis snapshot context, so parsing, semantic compilation, and diagnostics share one consistent snapshot lifecycle. This removes redundant document revisions and standalone source parsing, reuses cached profile analysis and syntax trees, and adds the Slang FFI access needed to retain source metadata without keeping unnecessary syntax trees alive.

Diagnostics are now owned by the active analysis snapshot and preserve profile `vide` diagnostics across updates, ensuring results always correspond to the snapshot that produced them. The change also updates coverage for parse reuse, preprocessing behavior, and snapshot freshness, and adds tracing for profile-root parsing.