### PR TITLE
docs(vscode): document VSIX installation

### DIFF
--- a/docs/src/content/docs/en/user-guide/vscode-installation.mdx
+++ b/docs/src/content/docs/en/user-guide/vscode-installation.mdx
@@ -3,25 +3,26 @@ title: VS Code Installation
 description: Install the Vide extension and confirm that the language service has started in VS Code.
 ---
 
-import ThinLinkCard from '../../../../components/ThinLinkCard.astro';
-
 This page walks you through installing the Vide VS Code extension and verifying that Vide is working correctly. If you have not installed VS Code yet, download it from the [VS Code website](https://code.visualstudio.com/).
 
 ## 1. Install the Extension
 
-For regular use, simply install the stable version published on the VS Code Marketplace. The card below links to the Marketplace:
+Because Vide may not be available from the VS Code Marketplace, download the VSIX that matches your operating system and architecture from the GitHub Release:
 
-<ThinLinkCard
-  href="https://marketplace.visualstudio.com/items?itemName=pascal-lab.vide-ide"
-  title="Visual Studio Marketplace"
-  action="Open"
->
-  Install stable Vide, extension ID: <code>pascal-lab.vide-ide</code>
-</ThinLinkCard>
+| System | Architecture | VSIX |
+| --- | --- | --- |
+| Linux | x64 | [Download `vide-vscode-linux-x64.vsix`](https://github.com/pascal-lab/vide/releases/latest/download/vide-vscode-linux-x64.vsix) |
+| Linux | arm64 | [Download `vide-vscode-linux-arm64.vsix`](https://github.com/pascal-lab/vide/releases/latest/download/vide-vscode-linux-arm64.vsix) |
+| Alpine Linux / musl | x64 | [Download `vide-vscode-alpine-x64.vsix`](https://github.com/pascal-lab/vide/releases/latest/download/vide-vscode-alpine-x64.vsix) |
+| macOS | Apple Silicon (arm64) | [Download `vide-vscode-darwin-arm64.vsix`](https://github.com/pascal-lab/vide/releases/latest/download/vide-vscode-darwin-arm64.vsix) |
+| Windows | x64 | [Download `vide-vscode-win32-x64.vsix`](https://github.com/pascal-lab/vide/releases/latest/download/vide-vscode-win32-x64.vsix) |
 
-You can also search for the display name `Vide` or the extension ID `pascal-lab.vide-ide` in the VS Code Extensions view.
+After downloading it, install the extension in VS Code:
 
-![vide in extension market](../../assets/en/quick-start/extension-marketplace.png)
+1. Open the Extensions view (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>, or <kbd>⌘</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd> on macOS).
+2. Click the three dots (`...`) in the top-right corner of the Extensions view.
+3. Select `Install from VSIX...`.
+4. Select the downloaded `vide-vscode-*.vsix` file.
 
 ## 2. Open an RTL Project Directory
 

--- a/docs/src/content/docs/user-guide/vscode-installation.mdx
+++ b/docs/src/content/docs/user-guide/vscode-installation.mdx
@@ -3,25 +3,26 @@ title: VS Code 安装
 description: 安装 Vide 扩展并确认 VS Code 中的语言服务已经启动。
 ---
 
-import ThinLinkCard from '../../../components/ThinLinkCard.astro';
-
 这一页带你安装 Vide 的 VS Code 扩展并验证 Vide 正在正确工作。如果你还没有安装 VS Code，可以先到 [VS Code 官网](https://code.visualstudio.com/)下载安装。
 
 ## 1. 安装扩展
 
-常规使用只需要安装 VS Code 扩展市场发布的稳定版。以下卡片可以跳转到 VS Code 扩展市场：
+由于未知原因，VS Code 扩展市场中的 Vide 无法正常访问，请从 GitHub Release 下载与你的系统和架构匹配的 VSIX：
 
-<ThinLinkCard
-  href="https://marketplace.visualstudio.com/items?itemName=pascal-lab.vide-ide"
-  title="Visual Studio Marketplace"
-  action="打开"
->
-  安装稳定版 Vide，扩展 ID：<code>pascal-lab.vide-ide</code>
-</ThinLinkCard>
+| 系统 | 架构 | VSIX |
+| --- | --- | --- |
+| Linux | x64 | [下载 `vide-vscode-linux-x64.vsix`](https://github.com/pascal-lab/vide/releases/latest/download/vide-vscode-linux-x64.vsix) |
+| Linux | arm64 | [下载 `vide-vscode-linux-arm64.vsix`](https://github.com/pascal-lab/vide/releases/latest/download/vide-vscode-linux-arm64.vsix) |
+| Alpine Linux / musl | x64 | [下载 `vide-vscode-alpine-x64.vsix`](https://github.com/pascal-lab/vide/releases/latest/download/vide-vscode-alpine-x64.vsix) |
+| macOS | Apple Silicon (arm64) | [下载 `vide-vscode-darwin-arm64.vsix`](https://github.com/pascal-lab/vide/releases/latest/download/vide-vscode-darwin-arm64.vsix) |
+| Windows | x64 | [下载 `vide-vscode-win32-x64.vsix`](https://github.com/pascal-lab/vide/releases/latest/download/vide-vscode-win32-x64.vsix) |
 
-也可以在 VS Code 的扩展面板搜索显示名 `Vide`，或搜索扩展 ID `pascal-lab.vide-ide`。
+下载后，在 VS Code 中按以下步骤安装：
 
-![vide in extension market](../assets/quick-start/extension-marketplace.png)
+1. 打开扩展面板（<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>，macOS 使用 <kbd>⌘</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>）。
+2. 点击扩展面板右上角的三个点（`...`）。
+3. 选择「从 VSIX 安装…」。
+4. 选择刚下载的 `vide-vscode-*.vsix` 文件。
 
 ## 2. 打开 RTL 工程目录
 


### PR DESCRIPTION
## Summary

- Replace the VS Code Marketplace card in the Chinese and English VS Code installation guides with architecture-specific GitHub Release VSIX links.
- Document the Extensions view flow: open the `...` menu and choose `Install from VSIX...`.
- Remove the stale Marketplace screenshot and component imports.

## Why

The Vide extension is unavailable from the VS Code Marketplace for unknown reasons, so the quick-start installation flow now uses the published VSIX release assets directly.

## Validation

- `npx astro build`
- `npm run postbuild:404`
- `npm run check:links`
- Verified the five listed VSIX download URLs return HTTP 200.

The full `npm run build` remains blocked by the existing missing `playground/public/wasm/vide-lsp.js` prerequisite; the Astro build and link checks pass when run after the generated playground assets are available.
