### PR TITLE
ci(website): reinstall platform dependencies from clean tree

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -375,11 +375,12 @@ jobs:
           cache: npm
           cache-dependency-path: website/package-lock.json
 
-      # TODO: Remove this `npm install` workaround once npm reliably restores platform optional
-      # dependencies from package-lock.json. see <https://github.com/npm/cli/issues/4828>.
+      # npm prunes platform-specific optional dependencies from package-lock.json when
+      # node_modules exists. Reinstall from a clean tree until npm/cli#7961 is fixed.
       - name: Install dependencies
         run: |
           npm ci
+          rm -rf node_modules
           npm install --no-save
         working-directory: website
 

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -121,11 +121,12 @@ jobs:
           node-version: 22
           cache: npm
           cache-dependency-path: website/package-lock.json
-      # TODO: Remove this `npm install` workaround once npm reliably restores platform optional
-      # dependencies from package-lock.json. see <https://github.com/npm/cli/issues/4828>.
+      # npm prunes platform-specific optional dependencies from package-lock.json when
+      # node_modules exists. Reinstall from a clean tree until npm/cli#7961 is fixed.
       - name: Install dependencies
         run: |
           npm ci
+          rm -rf node_modules
           npm install --no-save
         working-directory: website
 


### PR DESCRIPTION
## Summary

- Reinstall website dependencies from a clean `node_modules` tree in docs preview and deployment workflows.
- Keep the existing lockfile validation while ensuring the runner resolves platform-specific native optional dependencies.

## Root cause

The docs job failed because npm did not install `@rolldown/binding-linux-x64-gnu`. npm can prune platform-specific optional dependencies when `node_modules` already exists, so the existing `npm ci` followed by `npm install --no-save` did not repair the dependency tree.

## Validation

- `actionlint .github/workflows/docs-preview.yml .github/workflows/deploy-docs.yml` (no YAML errors; existing ShellCheck warnings remain in `deploy-docs.yml`).
- `npm ci --ignore-scripts` in `website`.
- `npm --prefix playground run build:embed` passed.
- Full `npm run build` reached the expected WASM asset check but could not continue locally because CI-generated `website/playground/public/wasm/vide-lsp.js` was not present.