### PR TITLE
fix(hir): preserve macro expansion failures

### DIFF
--- a/crates/hir/src/db.rs
+++ b/crates/hir/src/db.rs
@@ -16,7 +16,9 @@ use crate::{
             declarator::DeclId,
         },
         file::{self, FileSourceMap, HirFile},
-        macro_file::{self, ExpansionInfo, MacroCallId, MacroCallLoc, MacroFileId, MacroFileLoc},
+        macro_file::{
+            self, ExpandResult, ExpansionInfo, MacroCallId, MacroCallLoc, MacroFileId, MacroFileLoc,
+        },
         module::{
             self, Module, ModuleId, ModuleSourceMap, PackageId,
             clocking::ClockingBlockId,
@@ -81,7 +83,7 @@ pub trait HirDb: InternDb {
     fn parse(&self, file_id: HirFileId) -> SyntaxTree;
 
     #[salsa::invoke(macro_file::macro_expansion_query)]
-    fn macro_expansion(&self, macro_file: MacroFileId) -> Arc<ExpansionInfo>;
+    fn macro_expansion(&self, macro_file: MacroFileId) -> Arc<ExpandResult<ExpansionInfo>>;
 
     #[salsa::invoke(file::hir_file_with_source_map_query)]
     fn hir_file_with_source_map(&self, file_id: HirFileId) -> (Arc<HirFile>, Arc<FileSourceMap>);
@@ -166,7 +168,7 @@ pub trait HirDb: InternDb {
 fn parse(db: &dyn HirDb, file_id: HirFileId) -> SyntaxTree {
     match file_id {
         HirFileId::File(file_id) => db.parse_src_for_compilation(file_id),
-        HirFileId::Macro(macro_file) => db.macro_expansion(macro_file).parse.clone(),
+        HirFileId::Macro(macro_file) => db.macro_expansion(macro_file).value.parse.clone(),
     }
 }
 

--- a/crates/hir/src/hir_def/macro_file.rs
+++ b/crates/hir/src/hir_def/macro_file.rs
@@ -202,35 +202,30 @@ fn macro_expansion(db: &dyn HirDb, macro_file: MacroFileId) -> ExpandResult<Expa
         }
     };
     let emitted_range = expansion.emitted_token_range;
-    let ExpandResult { value: text, err } = expansion_text_for_range(&mapped.model, emitted_range);
-    if let Some(err) = err {
-        return expansion_info(text, ExpansionSourceMap::empty(), Some(err));
-    }
+    let text = expansion_text_for_range(&mapped.model, emitted_range);
     let parsed = db.parsed_compilation_unit(call_loc.model_file);
-    let Some(trace) = parsed.preprocessor_trace.as_ref() else {
-        return expansion_error(
-            text,
+    let source_map = match parsed.preprocessor_trace.as_ref() {
+        Some(trace) => ExpansionSourceMap::from_trace_range(
+            db,
+            call_loc.model_file,
+            trace,
+            &mapped.source_map,
+            emitted_range,
+        ),
+        None => ExpandResult::new(
             ExpansionSourceMap::empty(),
-            ExpandErrorKind::TraceUnavailable,
-        );
+            ExpandError::new(ExpandErrorKind::TraceUnavailable),
+        ),
     };
-    let source_map = match ExpansionSourceMap::from_trace_range(
-        db,
-        call_loc.model_file,
-        trace,
-        &mapped.source_map,
-        emitted_range,
-    ) {
-        Ok(source_map) => source_map,
-        Err(err) => {
-            return expansion_error(
-                text,
-                ExpansionSourceMap::empty(),
-                ExpandErrorKind::SourceMap(err),
-            );
-        }
-    };
-    expansion_info(text, source_map, None)
+    expansion_info_from_parts(text, source_map)
+}
+
+fn expansion_info_from_parts(
+    text: ExpandResult<String>,
+    source_map: ExpandResult<ExpansionSourceMap>,
+) -> ExpandResult<ExpansionInfo> {
+    let err = text.err.or(source_map.err);
+    expansion_info(text.value, source_map.value, err)
 }
 
 fn expansion_error(
@@ -304,7 +299,17 @@ fn expansion_text_for_range(
     emitted_range: SourceEmittedTokenRange,
 ) -> ExpandResult<String> {
     let mut text = String::new();
-    let Some(end) = emitted_range.start.raw().checked_add(emitted_range.len) else {
+    let start = emitted_range.start.raw();
+    if start > model.emitted_tokens().len() {
+        return ExpandResult::new(
+            text,
+            ExpandError::new(ExpandErrorKind::InvalidEmittedTokenRange {
+                start: emitted_range.start,
+                len: emitted_range.len,
+            }),
+        );
+    }
+    let Some(end) = start.checked_add(emitted_range.len) else {
         return ExpandResult::new(
             text,
             ExpandError::new(ExpandErrorKind::InvalidEmittedTokenRange {
@@ -313,7 +318,7 @@ fn expansion_text_for_range(
             }),
         );
     };
-    for raw in emitted_range.start.raw()..end {
+    for raw in start..end {
         let token = SourceEmittedTokenId::new(raw);
         let Some(token_data) = model.emitted_tokens().get(token) else {
             return ExpandResult::new(

--- a/crates/hir/src/hir_def/macro_file.rs
+++ b/crates/hir/src/hir_def/macro_file.rs
@@ -1,6 +1,6 @@
 use ::preproc::source::{
     SourceEmittedTokenRange, SourceMacroCall, SourceMacroCallId, SourceMacroExpansion,
-    SourceMacroExpansionDefinition, SourcePreprocModel,
+    SourceMacroExpansionDefinition, SourcePreprocModel, SourcePreprocUnavailable,
 };
 use smol_str::SmolStr;
 use syntax::{SyntaxTree, preproc::MacroCallId as TraceMacroCallId};
@@ -9,7 +9,10 @@ use utils::line_index::{TextRange, TextSize};
 use vfs::FileId;
 
 use crate::{
-    base_db::{salsa, source_db::MappedSourcePreprocModel},
+    base_db::{
+        salsa,
+        source_db::{MappedSourcePreprocModel, SourcePreprocQueryError},
+    },
     db::HirDb,
     preproc::{MacroDefinition, map_macro_definition},
 };
@@ -19,7 +22,7 @@ mod source_map;
 mod tests;
 
 pub use ::preproc::source::SourceEmittedTokenId;
-pub use source_map::{ExpansionSourceHit, ExpansionSourceMap, Origin};
+pub use source_map::{ExpansionSourceHit, ExpansionSourceMap, ExpansionSourceMapError, Origin};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct MacroCallId(pub salsa::InternId);
@@ -43,6 +46,52 @@ pub struct ExpansionInfo {
     pub text: String,
     pub parse: SyntaxTree,
     pub source_map: ExpansionSourceMap,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpandResult<T> {
+    pub value: T,
+    pub err: Option<ExpandError>,
+}
+
+impl<T> ExpandResult<T> {
+    pub fn ok(value: T) -> Self {
+        Self { value, err: None }
+    }
+
+    pub fn new(value: T, err: ExpandError) -> Self {
+        Self { value, err: Some(err) }
+    }
+
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> ExpandResult<U> {
+        ExpandResult { value: f(self.value), err: self.err }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpandError {
+    kind: ExpandErrorKind,
+}
+
+impl ExpandError {
+    pub fn new(kind: ExpandErrorKind) -> Self {
+        Self { kind }
+    }
+
+    pub fn kind(&self) -> &ExpandErrorKind {
+        &self.kind
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExpandErrorKind {
+    SourcePreprocModel(SourcePreprocQueryError),
+    MissingTraceCall { trace_call: TraceMacroCallId },
+    ExpansionUnavailable(SourcePreprocUnavailable),
+    InvalidEmittedTokenRange { start: SourceEmittedTokenId, len: usize },
+    MissingEmittedToken { token: SourceEmittedTokenId },
+    TraceUnavailable,
+    SourceMap(ExpansionSourceMapError),
 }
 
 /// Information about one macro expansion at the call site, exposed to the IDE.
@@ -106,7 +155,7 @@ pub fn macro_file_expansion(db: &dyn HirDb, macro_file: MacroFileId) -> Option<M
     let mapped = db.source_preproc_model(call_loc.model_file);
     let mapped = mapped.as_ref().as_ref().ok()?;
     let call = source_call_for_trace_call(&mapped.model, call_loc.trace_call)?;
-    let expansion = source_expansion_for_call(&mapped.model, call.id)?;
+    let expansion = source_expansion_for_call(&mapped.model, call.id).ok()?;
     Some(MacroFileExpansion {
         call_file_id: mapped.source_map.file_id(call.call_range.source).ok()?,
         call_range: mapped.source_map.map_range(call.call_range).ok()?,
@@ -114,37 +163,91 @@ pub fn macro_file_expansion(db: &dyn HirDb, macro_file: MacroFileId) -> Option<M
     })
 }
 
-pub(crate) fn macro_expansion_query(db: &dyn HirDb, macro_file: MacroFileId) -> Arc<ExpansionInfo> {
+pub(crate) fn macro_expansion_query(
+    db: &dyn HirDb,
+    macro_file: MacroFileId,
+) -> Arc<ExpandResult<ExpansionInfo>> {
+    Arc::new(macro_expansion(db, macro_file))
+}
+
+fn macro_expansion(db: &dyn HirDb, macro_file: MacroFileId) -> ExpandResult<ExpansionInfo> {
     let loc = db.lookup_intern_macro_file(macro_file);
     let call_loc = db.lookup_intern_macro_call(loc.call);
     let mapped = db.source_preproc_model(call_loc.model_file);
-    let expansion = mapped.as_ref().as_ref().ok().and_then(|mapped| {
-        source_call_for_trace_call(&mapped.model, call_loc.trace_call)
-            .and_then(|call| emitted_range_for_call(&mapped.model, call.id))
-            .map(|range| (mapped, range))
-    });
-    let (text, source_map) = expansion
-        .map(|(mapped, emitted_range)| {
-            let text = expansion_text_for_range(&mapped.model, emitted_range).unwrap_or_default();
-            let source_map = db
-                .parsed_compilation_unit(call_loc.model_file)
-                .preprocessor_trace
-                .as_ref()
-                .map(|trace| {
-                    ExpansionSourceMap::from_trace_range(
-                        db,
-                        call_loc.model_file,
-                        trace,
-                        &mapped.source_map,
-                        emitted_range,
-                    )
-                })
-                .unwrap_or_else(ExpansionSourceMap::empty);
-            (text, source_map)
-        })
-        .unwrap_or_else(|| (String::new(), ExpansionSourceMap::empty()));
+    let mapped = match mapped.as_ref() {
+        Ok(mapped) => mapped,
+        Err(err) => {
+            return expansion_error(
+                String::new(),
+                ExpansionSourceMap::empty(),
+                ExpandErrorKind::SourcePreprocModel(err.clone()),
+            );
+        }
+    };
+    let Some(call) = source_call_for_trace_call(&mapped.model, call_loc.trace_call) else {
+        return expansion_error(
+            String::new(),
+            ExpansionSourceMap::empty(),
+            ExpandErrorKind::MissingTraceCall { trace_call: call_loc.trace_call },
+        );
+    };
+    let expansion = match source_expansion_for_call(&mapped.model, call.id) {
+        Ok(expansion) => expansion,
+        Err(err) => {
+            return expansion_error(
+                String::new(),
+                ExpansionSourceMap::empty(),
+                ExpandErrorKind::ExpansionUnavailable(err),
+            );
+        }
+    };
+    let emitted_range = expansion.emitted_token_range;
+    let ExpandResult { value: text, err } = expansion_text_for_range(&mapped.model, emitted_range);
+    if let Some(err) = err {
+        return expansion_info(text, ExpansionSourceMap::empty(), Some(err));
+    }
+    let parsed = db.parsed_compilation_unit(call_loc.model_file);
+    let Some(trace) = parsed.preprocessor_trace.as_ref() else {
+        return expansion_error(
+            text,
+            ExpansionSourceMap::empty(),
+            ExpandErrorKind::TraceUnavailable,
+        );
+    };
+    let source_map = match ExpansionSourceMap::from_trace_range(
+        db,
+        call_loc.model_file,
+        trace,
+        &mapped.source_map,
+        emitted_range,
+    ) {
+        Ok(source_map) => source_map,
+        Err(err) => {
+            return expansion_error(
+                text,
+                ExpansionSourceMap::empty(),
+                ExpandErrorKind::SourceMap(err),
+            );
+        }
+    };
+    expansion_info(text, source_map, None)
+}
+
+fn expansion_error(
+    text: String,
+    source_map: ExpansionSourceMap,
+    kind: ExpandErrorKind,
+) -> ExpandResult<ExpansionInfo> {
+    expansion_info(text, source_map, Some(ExpandError::new(kind)))
+}
+
+fn expansion_info(
+    text: String,
+    source_map: ExpansionSourceMap,
+    err: Option<ExpandError>,
+) -> ExpandResult<ExpansionInfo> {
     let parse = SyntaxTree::from_text(&text, "macro-expansion", "");
-    Arc::new(ExpansionInfo { text, parse, source_map })
+    ExpandResult { value: ExpansionInfo { text, parse, source_map }, err }
 }
 
 fn macro_call_for_source_call(
@@ -175,7 +278,7 @@ fn emitted_range_for_call(
     model: &SourcePreprocModel,
     call: SourceMacroCallId,
 ) -> Option<SourceEmittedTokenRange> {
-    source_expansion_for_call(model, call).map(|expansion| expansion.emitted_token_range)
+    source_expansion_for_call(model, call).ok().map(|expansion| expansion.emitted_token_range)
 }
 
 fn source_call_for_trace_call(
@@ -188,23 +291,37 @@ fn source_call_for_trace_call(
 fn source_expansion_for_call(
     model: &SourcePreprocModel,
     call: SourceMacroCallId,
-) -> Option<&SourceMacroExpansion> {
-    let expansion = match model.immediate_macro_expansion(call) {
-        Ok(expansion) => model.macro_expansions().get(expansion)?,
-        Err(_) => return None,
-    };
-    Some(expansion)
+) -> Result<&SourceMacroExpansion, SourcePreprocUnavailable> {
+    let expansion = model.immediate_macro_expansion(call)?;
+    model
+        .macro_expansions()
+        .get(expansion)
+        .ok_or(SourcePreprocUnavailable::MissingMacroExpansion { call })
 }
 
 fn expansion_text_for_range(
     model: &SourcePreprocModel,
     emitted_range: SourceEmittedTokenRange,
-) -> Option<String> {
+) -> ExpandResult<String> {
     let mut text = String::new();
-    let end = emitted_range.start.raw().checked_add(emitted_range.len)?;
+    let Some(end) = emitted_range.start.raw().checked_add(emitted_range.len) else {
+        return ExpandResult::new(
+            text,
+            ExpandError::new(ExpandErrorKind::InvalidEmittedTokenRange {
+                start: emitted_range.start,
+                len: emitted_range.len,
+            }),
+        );
+    };
     for raw in emitted_range.start.raw()..end {
-        let token = model.emitted_tokens().get(SourceEmittedTokenId::new(raw))?;
-        text.push_str(token.display.as_str());
+        let token = SourceEmittedTokenId::new(raw);
+        let Some(token_data) = model.emitted_tokens().get(token) else {
+            return ExpandResult::new(
+                text,
+                ExpandError::new(ExpandErrorKind::MissingEmittedToken { token }),
+            );
+        };
+        text.push_str(token_data.display.as_str());
     }
-    Some(text)
+    ExpandResult::ok(text)
 }

--- a/crates/hir/src/hir_def/macro_file/source_map.rs
+++ b/crates/hir/src/hir_def/macro_file/source_map.rs
@@ -13,7 +13,7 @@ use syntax::{
 use utils::line_index::{TextRange, TextSize};
 use vfs::FileId;
 
-use super::{MacroCallId, MacroCallLoc};
+use super::{ExpandError, ExpandErrorKind, ExpandResult, MacroCallId, MacroCallLoc};
 use crate::{base_db::source_db::PreprocSourceMap, db::HirDb};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -106,32 +106,46 @@ impl ExpansionSourceMap {
         trace: &Trace,
         source_map: &PreprocSourceMap,
         emitted_range: SourceEmittedTokenRange,
-    ) -> Result<Self, ExpansionSourceMapError> {
-        let Some(end) = emitted_range.start.raw().checked_add(emitted_range.len) else {
-            return Err(ExpansionSourceMapError::InvalidEmittedTokenRange {
-                start: emitted_range.start,
-                len: emitted_range.len,
-            });
+    ) -> ExpandResult<Self> {
+        let start = emitted_range.start.raw();
+        if start > trace.emitted_tokens.len() {
+            return source_map_error(
+                Self::empty(),
+                ExpansionSourceMapError::InvalidEmittedTokenRange {
+                    start: emitted_range.start,
+                    len: emitted_range.len,
+                },
+            );
+        }
+        let Some(end) = start.checked_add(emitted_range.len) else {
+            return source_map_error(
+                Self::empty(),
+                ExpansionSourceMapError::InvalidEmittedTokenRange {
+                    start: emitted_range.start,
+                    len: emitted_range.len,
+                },
+            );
         };
         let operation_sources = OperationSourceResolver::new(trace);
-        let origins = (emitted_range.start.raw()..end)
-            .map(|raw| {
-                let emitted_token = SourceEmittedTokenId::new(raw);
-                let token = trace
-                    .emitted_tokens
-                    .get(raw)
-                    .ok_or(ExpansionSourceMapError::MissingTraceToken { token: emitted_token })?;
-                Ok(origin_slot_from_token_origin(
-                    db,
-                    model_file,
-                    emitted_token,
-                    &token.origin,
-                    source_map,
-                    Some(&operation_sources),
-                ))
-            })
-            .collect::<Result<_, _>>()?;
-        Ok(Self { origins })
+        let mut origins = Vec::new();
+        for raw in start..end {
+            let emitted_token = SourceEmittedTokenId::new(raw);
+            let Some(token) = trace.emitted_tokens.get(raw) else {
+                return source_map_error(
+                    Self { origins },
+                    ExpansionSourceMapError::MissingTraceToken { token: emitted_token },
+                );
+            };
+            origins.push(origin_slot_from_token_origin(
+                db,
+                model_file,
+                emitted_token,
+                &token.origin,
+                source_map,
+                Some(&operation_sources),
+            ));
+        }
+        ExpandResult::ok(Self { origins })
     }
 
     #[cfg(test)]
@@ -158,6 +172,13 @@ impl ExpansionSourceMap {
                 .collect(),
         }
     }
+}
+
+fn source_map_error(
+    value: ExpansionSourceMap,
+    error: ExpansionSourceMapError,
+) -> ExpandResult<ExpansionSourceMap> {
+    ExpandResult::new(value, ExpandError::new(ExpandErrorKind::SourceMap(error)))
 }
 
 struct OperationSourceResolver<'a> {

--- a/crates/hir/src/hir_def/macro_file/source_map.rs
+++ b/crates/hir/src/hir_def/macro_file/source_map.rs
@@ -45,6 +45,12 @@ struct OriginSource {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExpansionSourceMapError {
+    InvalidEmittedTokenRange { start: SourceEmittedTokenId, len: usize },
+    MissingTraceToken { token: SourceEmittedTokenId },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExpansionSourceHit {
     pub emitted_token: SourceEmittedTokenId,
     pub expanded_token_index: usize,
@@ -100,27 +106,32 @@ impl ExpansionSourceMap {
         trace: &Trace,
         source_map: &PreprocSourceMap,
         emitted_range: SourceEmittedTokenRange,
-    ) -> Self {
+    ) -> Result<Self, ExpansionSourceMapError> {
         let Some(end) = emitted_range.start.raw().checked_add(emitted_range.len) else {
-            return Self::empty();
+            return Err(ExpansionSourceMapError::InvalidEmittedTokenRange {
+                start: emitted_range.start,
+                len: emitted_range.len,
+            });
         };
         let operation_sources = OperationSourceResolver::new(trace);
         let origins = (emitted_range.start.raw()..end)
             .map(|raw| {
                 let emitted_token = SourceEmittedTokenId::new(raw);
-                trace.emitted_tokens.get(raw).and_then(|token| {
-                    origin_slot_from_token_origin(
-                        db,
-                        model_file,
-                        emitted_token,
-                        &token.origin,
-                        source_map,
-                        Some(&operation_sources),
-                    )
-                })
+                let token = trace
+                    .emitted_tokens
+                    .get(raw)
+                    .ok_or(ExpansionSourceMapError::MissingTraceToken { token: emitted_token })?;
+                Ok(origin_slot_from_token_origin(
+                    db,
+                    model_file,
+                    emitted_token,
+                    &token.origin,
+                    source_map,
+                    Some(&operation_sources),
+                ))
             })
-            .collect();
-        Self { origins }
+            .collect::<Result<_, _>>()?;
+        Ok(Self { origins })
     }
 
     #[cfg(test)]

--- a/crates/hir/src/hir_def/macro_file/tests.rs
+++ b/crates/hir/src/hir_def/macro_file/tests.rs
@@ -321,14 +321,144 @@ fn expansion_source_map_reports_missing_trace_token() {
     let trace = parsed.preprocessor_trace.as_ref().expect("preprocessor trace should be available");
     let missing = SourceEmittedTokenId::new(trace.emitted_tokens.len());
 
-    let err = ExpansionSourceMap::from_trace_range(
+    let expansion = ExpansionSourceMap::from_trace_range(
         &db,
         TOP,
         trace,
         &mapped.source_map,
         SourceEmittedTokenRange { start: missing, len: 1 },
-    )
-    .expect_err("a missing trace token should fail source-map construction");
+    );
 
-    assert_eq!(err, ExpansionSourceMapError::MissingTraceToken { token: missing });
+    assert!(expansion.value.is_empty());
+    assert_eq!(
+        expansion.err.as_ref().map(ExpandError::kind),
+        Some(&ExpandErrorKind::SourceMap(ExpansionSourceMapError::MissingTraceToken {
+            token: missing,
+        }))
+    );
+}
+
+#[test]
+fn expansion_text_validates_zero_length_range_start() {
+    let db = db_with_root_text("`define EMPTY\n`EMPTY\n");
+    let mapped = db.source_preproc_model(TOP);
+    let mapped = mapped.as_ref().as_ref().expect("preproc model should be available");
+    let table_len = mapped.model.emitted_tokens().len();
+    let valid_start = SourceEmittedTokenId::new(table_len);
+
+    let valid = expansion_text_for_range(
+        &mapped.model,
+        SourceEmittedTokenRange { start: valid_start, len: 0 },
+    );
+
+    assert_eq!(valid, ExpandResult::ok(String::new()));
+
+    let invalid_start = SourceEmittedTokenId::new(table_len + 1);
+    let invalid = expansion_text_for_range(
+        &mapped.model,
+        SourceEmittedTokenRange { start: invalid_start, len: 0 },
+    );
+
+    assert_eq!(invalid.value, "");
+    assert_eq!(
+        invalid.err.as_ref().map(ExpandError::kind),
+        Some(&ExpandErrorKind::InvalidEmittedTokenRange { start: invalid_start, len: 0 })
+    );
+}
+
+#[test]
+fn expansion_source_map_validates_zero_length_range_start() {
+    let db = db_with_root_text("`define EMPTY\n`EMPTY\n");
+    let mapped = db.source_preproc_model(TOP);
+    let mapped = mapped.as_ref().as_ref().expect("preproc model should be available");
+    let parsed = db.parsed_compilation_unit(TOP);
+    let trace = parsed.preprocessor_trace.as_ref().expect("preprocessor trace should be available");
+    let table_len = trace.emitted_tokens.len();
+    let valid_start = SourceEmittedTokenId::new(table_len);
+
+    let valid = ExpansionSourceMap::from_trace_range(
+        &db,
+        TOP,
+        trace,
+        &mapped.source_map,
+        SourceEmittedTokenRange { start: valid_start, len: 0 },
+    );
+
+    assert_eq!(valid, ExpandResult::ok(ExpansionSourceMap::empty()));
+
+    let invalid_start = SourceEmittedTokenId::new(table_len + 1);
+    let invalid = ExpansionSourceMap::from_trace_range(
+        &db,
+        TOP,
+        trace,
+        &mapped.source_map,
+        SourceEmittedTokenRange { start: invalid_start, len: 0 },
+    );
+
+    assert_eq!(invalid.value, ExpansionSourceMap::empty());
+    assert_eq!(
+        invalid.err.as_ref().map(ExpandError::kind),
+        Some(&ExpandErrorKind::SourceMap(ExpansionSourceMapError::InvalidEmittedTokenRange {
+            start: invalid_start,
+            len: 0,
+        }))
+    );
+}
+
+#[test]
+fn expansion_source_map_preserves_valid_prefix_before_missing_trace_token() {
+    let db = db_with_root_text("`define ONE 1\n`ONE\n");
+    let mapped = db.source_preproc_model(TOP);
+    let mapped = mapped.as_ref().as_ref().expect("preproc model should be available");
+    let parsed = db.parsed_compilation_unit(TOP);
+    let trace = parsed.preprocessor_trace.as_ref().expect("preprocessor trace should be available");
+    let table_len = trace.emitted_tokens.len();
+    assert!(table_len > 0, "fixture should emit at least one token");
+    let missing = SourceEmittedTokenId::new(table_len);
+
+    let expansion = ExpansionSourceMap::from_trace_range(
+        &db,
+        TOP,
+        trace,
+        &mapped.source_map,
+        SourceEmittedTokenRange { start: SourceEmittedTokenId::new(0), len: table_len + 1 },
+    );
+
+    assert!(!expansion.value.is_empty());
+    assert_eq!(
+        expansion.err.as_ref().map(ExpandError::kind),
+        Some(&ExpandErrorKind::SourceMap(ExpansionSourceMapError::MissingTraceToken {
+            token: missing,
+        }))
+    );
+}
+
+#[test]
+fn expansion_info_preserves_source_map_when_text_extraction_fails() {
+    let db = db_with_root_text("`define ONE 1\n`ONE\n");
+    let mapped = db.source_preproc_model(TOP);
+    let mapped = mapped.as_ref().as_ref().expect("preproc model should be available");
+    let parsed = db.parsed_compilation_unit(TOP);
+    let trace = parsed.preprocessor_trace.as_ref().expect("preprocessor trace should be available");
+    assert!(!trace.emitted_tokens.is_empty(), "fixture should emit at least one token");
+    let source_map = ExpansionSourceMap::from_trace_range(
+        &db,
+        TOP,
+        trace,
+        &mapped.source_map,
+        SourceEmittedTokenRange { start: SourceEmittedTokenId::new(0), len: 1 },
+    );
+    let missing = SourceEmittedTokenId::new(mapped.model.emitted_tokens().len());
+    let text = ExpandResult::new(
+        String::new(),
+        ExpandError::new(ExpandErrorKind::MissingEmittedToken { token: missing }),
+    );
+
+    let expansion = expansion_info_from_parts(text, source_map);
+
+    assert!(!expansion.value.source_map.is_empty());
+    assert_eq!(
+        expansion.err.as_ref().map(ExpandError::kind),
+        Some(&ExpandErrorKind::MissingEmittedToken { token: missing })
+    );
 }

--- a/crates/hir/src/hir_def/macro_file/tests.rs
+++ b/crates/hir/src/hir_def/macro_file/tests.rs
@@ -21,8 +21,8 @@ use crate::{
         project::{CompilationProfile, CompilationProfileId, PreprocessConfig, ProjectConfig},
         salsa::{self, Durability},
         source_db::{
-            FileLoader, PreprocSourceMap, SourceDb, SourceDbStorage, SourceFileKind, SourceRootDb,
-            SourceRootDbStorage,
+            FileLoader, PreprocSourceMap, SourceDb, SourceDbStorage, SourceFileKind,
+            SourcePreprocQueryError, SourceRootDb, SourceRootDbStorage,
         },
         source_root::{SourceRoot, SourceRootId},
     },
@@ -232,9 +232,9 @@ fn macro_file_expansion_parses_emitted_tokens_and_maps_origins() {
     let macro_file = db.intern_macro_file(MacroFileLoc { call: macro_call });
     let expansion = db.macro_expansion(macro_file);
 
-    assert!(expansion.text.contains("module"));
-    assert!(expansion.text.contains("from_macro"));
-    assert!(matches!(expansion.source_map.map_up(0), Some(Origin::MacroBody { .. })));
+    assert!(expansion.value.text.contains("module"));
+    assert!(expansion.value.text.contains("from_macro"));
+    assert!(matches!(expansion.value.source_map.map_up(0), Some(Origin::MacroBody { .. })));
     let parse = db.parse(HirFileId::Macro(macro_file));
     let root = parse.root().expect("macro expansion should parse to a syntax root");
     let unit =
@@ -257,5 +257,78 @@ fn macro_files_at_offset_returns_available_expansions() {
     let macro_call_loc = db.lookup_intern_macro_call(macro_file_loc.call);
     assert_eq!(macro_call_loc.model_file, TOP);
     let expansion = db.macro_expansion(macro_files[0]);
-    assert!(expansion.text.contains("from_macro"));
+    assert!(expansion.value.text.contains("from_macro"));
+}
+
+#[test]
+fn macro_expansion_reports_missing_trace_call() {
+    let db = db_with_root_text("`define EMPTY\n`EMPTY\n");
+    let trace_call = TraceMacroCallId(u32::MAX);
+    let macro_call = db.intern_macro_call(MacroCallLoc { model_file: TOP, trace_call });
+    let macro_file = db.intern_macro_file(MacroFileLoc { call: macro_call });
+
+    let expansion = db.macro_expansion(macro_file);
+
+    assert_eq!(expansion.value.text, "");
+    assert_eq!(
+        expansion.err.as_ref().map(ExpandError::kind),
+        Some(&ExpandErrorKind::MissingTraceCall { trace_call })
+    );
+}
+
+#[test]
+fn macro_expansion_reports_preproc_model_failure() {
+    let mut db = db_with_root_text("`define EMPTY\n`EMPTY\n");
+    db.set_file_kind_with_durability(TOP, SourceFileKind::LibraryMap, Durability::LOW);
+    let trace_call = TraceMacroCallId(0);
+    let macro_call = db.intern_macro_call(MacroCallLoc { model_file: TOP, trace_call });
+    let macro_file = db.intern_macro_file(MacroFileLoc { call: macro_call });
+
+    let expansion = db.macro_expansion(macro_file);
+
+    assert_eq!(expansion.value.text, "");
+    assert_eq!(
+        expansion.err.as_ref().map(ExpandError::kind),
+        Some(&ExpandErrorKind::SourcePreprocModel(SourcePreprocQueryError::UnsupportedFileKind(
+            SourceFileKind::LibraryMap
+        )))
+    );
+}
+
+#[test]
+fn expansion_text_reports_missing_emitted_token() {
+    let db = db_with_root_text("`define ONE 1\n`ONE\n");
+    let mapped = db.source_preproc_model(TOP);
+    let mapped = mapped.as_ref().as_ref().expect("preproc model should be available");
+    let missing = SourceEmittedTokenId::new(mapped.model.emitted_tokens().len());
+
+    let expansion =
+        expansion_text_for_range(&mapped.model, SourceEmittedTokenRange { start: missing, len: 1 });
+
+    assert_eq!(expansion.value, "");
+    assert_eq!(
+        expansion.err.as_ref().map(ExpandError::kind),
+        Some(&ExpandErrorKind::MissingEmittedToken { token: missing })
+    );
+}
+
+#[test]
+fn expansion_source_map_reports_missing_trace_token() {
+    let db = db_with_root_text("`define ONE 1\n`ONE\n");
+    let mapped = db.source_preproc_model(TOP);
+    let mapped = mapped.as_ref().as_ref().expect("preproc model should be available");
+    let parsed = db.parsed_compilation_unit(TOP);
+    let trace = parsed.preprocessor_trace.as_ref().expect("preprocessor trace should be available");
+    let missing = SourceEmittedTokenId::new(trace.emitted_tokens.len());
+
+    let err = ExpansionSourceMap::from_trace_range(
+        &db,
+        TOP,
+        trace,
+        &mapped.source_map,
+        SourceEmittedTokenRange { start: missing, len: 1 },
+    )
+    .expect_err("a missing trace token should fail source-map construction");
+
+    assert_eq!(err, ExpansionSourceMapError::MissingTraceToken { token: missing });
 }

--- a/crates/hir/src/preproc/tests/expansion_display.rs
+++ b/crates/hir/src/preproc/tests/expansion_display.rs
@@ -19,7 +19,7 @@ endmodule
     ));
 
     let expansion = db.macro_expansion(macro_file);
-    assert_eq!(expansion.text, "\nlogic generated;");
+    assert_eq!(expansion.value.text, "\nlogic generated;");
 }
 
 #[test]
@@ -38,11 +38,11 @@ endmodule
     let expansion = db.macro_expansion(macro_file);
 
     assert!(
-        expansion.text.contains("\n  always_ff")
-            && expansion.text.contains("\n    q <= 1;")
-            && expansion.text.contains("\n  end"),
+        expansion.value.text.contains("\n  always_ff")
+            && expansion.value.text.contains("\n    q <= 1;")
+            && expansion.value.text.contains("\n  end"),
         "expansion text should preserve emitted token trivia: {:?}",
-        expansion.text
+        expansion.value.text
     );
 }
 
@@ -103,9 +103,9 @@ endmodule
 
     let macro_file = single_macro_file_at(&db, TOP, offset(root_text, "`ONE"));
     let expansion = db.macro_expansion(macro_file);
-    assert!(expansion.text.contains("12"));
-    assert!(expansion.text.contains("'d"));
-    assert!(expansion.text.contains("1"));
+    assert!(expansion.value.text.contains("12"));
+    assert!(expansion.value.text.contains("'d"));
+    assert!(expansion.value.text.contains("1"));
 }
 
 #[test]
@@ -120,7 +120,7 @@ fn preproc_escaped_identifier_expansion_text_is_available() {
 
     let macro_file = single_macro_file_at(&db, TOP, offset(root_text, "`ESCAPED"));
     let expansion = db.macro_expansion(macro_file);
-    assert!(expansion.text.contains("\\escaped.name"));
+    assert!(expansion.value.text.contains("\\escaped.name"));
 }
 
 fn expansion_definition_name(definition: &MacroExpansionDefinition) -> &str {

--- a/crates/hir/src/preproc/tests/expansion_query.rs
+++ b/crates/hir/src/preproc/tests/expansion_query.rs
@@ -44,7 +44,7 @@ endmodule
     let obj = macro_file_expansion(&db, obj_file).expect("object-like macro expansion expected");
     assert_eq!(obj.call_file_id, TOP);
     assert_eq!(text_at_range(root_text, obj.call_range), "`OBJ");
-    assert_eq!(db.macro_expansion(obj_file).text.trim(), "8");
+    assert_eq!(db.macro_expansion(obj_file).value.text.trim(), "8");
 
     let wrap_file = single_macro_file_at(&db, TOP, offset(root_text, "`WRAP"));
     let wrap = macro_file_expansion(&db, wrap_file).expect("outer macro expansion expected");
@@ -54,7 +54,7 @@ endmodule
         &wrap.definition,
         MacroExpansionDefinition::Source(definition) if definition.name.as_str() == "WRAP"
     ));
-    assert_eq!(db.macro_expansion(wrap_file).text.trim(), "3");
+    assert_eq!(db.macro_expansion(wrap_file).value.text.trim(), "3");
 }
 
 #[test]
@@ -143,6 +143,8 @@ endmodule
         let macro_file = single_macro_file_at(&db, TOP, offset(root_text, name));
         let expansion = macro_file_expansion(&db, macro_file).expect("macro expansion expected");
         assert_eq!(text_at_range(root_text, expansion.call_range), call_text);
-        assert_eq!(db.macro_expansion(macro_file).text, "");
+        let result = db.macro_expansion(macro_file);
+        assert_eq!(result.value.text, "");
+        assert_eq!(result.err, None);
     }
 }

--- a/crates/ide/src/hover/macro_hover/expansion.rs
+++ b/crates/ide/src/hover/macro_hover/expansion.rs
@@ -63,7 +63,7 @@ pub(super) fn expanded_macro_hover(
                 return None;
             }
             let expansion = db.macro_expansion(macro_file);
-            Some(ExpandedMacro { metadata, text: expansion.text.clone() })
+            Some(ExpandedMacro { metadata, text: expansion.value.text.clone() })
         })
         .collect::<Vec<_>>();
     if expansions.is_empty() {

--- a/crates/ide/src/source_targets/preproc.rs
+++ b/crates/ide/src/source_targets/preproc.rs
@@ -72,7 +72,7 @@ fn preproc_hits_at_offset(
     let mut hits = Vec::new();
     for (expansion_index, macro_file) in macro_files.iter().enumerate() {
         let expansion = db.macro_expansion(*macro_file);
-        for source_hit in expansion.source_map.source_hits(file_id, offset) {
+        for source_hit in expansion.value.source_map.source_hits(file_id, offset) {
             let Some(hit) = preproc_hit_for_source_hit(db, expansion_index, source_hit) else {
                 continue;
             };


### PR DESCRIPTION
## Summary
- return partial macro expansion data through a structured `ExpandResult<T>`
- preserve preprocessor, trace, emitted-token, and source-map failure reasons
- keep legitimate zero-token expansions successful and migrate HIR/IDE consumers explicitly

## Root cause
`macro_expansion_query` flattened every failure in the preprocessor/model/trace chain into an empty, successful `ExpansionInfo`. Source-map construction also silently returned an empty map for invalid ranges.

## Verification
- `cargo test -p hir -p ide` (212 passed)
- `cargo clippy -p hir -p ide --all-targets -- -D warnings`