### PR TITLE
fix(hir): preserve unsupported lowering states

### DIFF
--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -444,7 +444,12 @@ impl HirDisplay for UnaryOp {
 impl HirDisplay for InContainer<&Expr> {
     fn hir_fmt(&self, f: &mut HirFormatter<'_>) -> Result<(), HirDisplayError> {
         match self.value {
-            Expr::Missing => f.write_str(""),
+            Expr::Missing => f.write_str("<missing>"),
+            Expr::Invalid => f.write_str("<invalid>"),
+            Expr::Unsupported(kind) => {
+                write!(f.f, "<unsupported {kind:?}>")?;
+                Ok(())
+            }
             Expr::Binary { op, lhs, rhs } => {
                 self.with_value(*lhs).hir_fmt(f)?;
                 f.write_str(" ")?;
@@ -572,15 +577,19 @@ impl HirDisplay for InContainer<&Expr> {
                 if let Some(slice) = slice {
                     self.with_value(*slice).hir_fmt(f)?;
                 }
+                f.write_str("{")?;
                 let mut first = true;
-                for expr in concats.iter() {
+                for stream in concats.iter() {
                     if !first {
                         f.write_str(", ")?;
                     }
-                    self.with_value(*expr).hir_fmt(f)?;
+                    self.with_value(stream.expr).hir_fmt(f)?;
+                    if let Some(range) = stream.range {
+                        self.with_value(range).hir_fmt(f)?;
+                    }
                     first = false;
                 }
-                f.write_str("}")
+                f.write_str("}}")
             }
             Expr::Unary { op, expr } => {
                 op.hir_fmt(f)?;

--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -584,8 +584,11 @@ impl HirDisplay for InContainer<&Expr> {
                         f.write_str(", ")?;
                     }
                     self.with_value(stream.expr).hir_fmt(f)?;
-                    if let Some(range) = stream.range {
-                        self.with_value(range).hir_fmt(f)?;
+                    if let Some(with_range) = &stream.with_range {
+                        f.write_str(" with ")?;
+                        if let Some(selector) = with_range.selector {
+                            self.with_value(selector).hir_fmt(f)?;
+                        }
                     }
                     first = false;
                 }

--- a/crates/hir/src/hir_def/expr.rs
+++ b/crates/hir/src/hir_def/expr.rs
@@ -157,9 +157,14 @@ pub enum StreamOp {
     Left,
 }
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct StreamRange {
+    pub selector: Option<Selector>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct StreamExpr {
     pub expr: ExprId,
-    pub range: Option<Selector>,
+    pub with_range: Option<StreamRange>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
@@ -378,10 +383,12 @@ impl LowerExprCtx<'_> {
             .children()
             .map(|stream| StreamExpr {
                 expr: self.lower_expr(stream.expression()),
-                range: stream
-                    .with_range()
-                    .and_then(|with_range| with_range.range().selector())
-                    .map(|selector| self.lower_selector(selector)),
+                with_range: stream.with_range().map(|with_range| StreamRange {
+                    selector: with_range
+                        .range()
+                        .selector()
+                        .map(|selector| self.lower_selector(selector)),
+                }),
             })
             .collect();
         Some(Expr::Stream { op, slice, concats })

--- a/crates/hir/src/hir_def/expr.rs
+++ b/crates/hir/src/hir_def/expr.rs
@@ -156,6 +156,11 @@ pub enum StreamOp {
     // <<
     Left,
 }
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct StreamExpr {
+    pub expr: ExprId,
+    pub range: Option<Selector>,
+}
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct Assign {
@@ -168,6 +173,8 @@ pub struct Assign {
 pub enum Expr {
     #[default]
     Missing,
+    Invalid,
+    Unsupported(SyntaxKind),
 
     Binary {
         op: BinaryOp,
@@ -222,7 +229,7 @@ pub enum Expr {
     Stream {
         op: StreamOp,
         slice: Option<ExprId>,
-        concats: Box<[ExprId]>,
+        concats: Box<[StreamExpr]>,
     },
     Unary {
         op: UnaryOp,
@@ -303,14 +310,11 @@ impl LowerExprCtx<'_> {
     }
 
     pub(crate) fn lower_expr(&mut self, expr: ast::Expression) -> ExprId {
-        if let Some(hir_expr) = self.lower_expr_inner(expr) {
-            alloc_idx_and_src! {
+        let hir_expr = self.lower_expr_inner(expr).unwrap_or(Expr::Invalid);
+        alloc_idx_and_src! {
             self.file_id;
-                hir_expr => self.exprs,
-                expr => self.expr_srcs,
-            }
-        } else {
-            self.alloc_missing()
+            hir_expr => self.exprs,
+            expr => self.expr_srcs,
         }
     }
 
@@ -329,7 +333,8 @@ impl LowerExprCtx<'_> {
             CastExpression(expr) => self.lower_cast_expr(expr),
             SignedCastExpression(expr) => self.lower_cast_signed_expr(expr),
             PostfixUnaryExpression(expr) => self.lower_postfix_unary_expr(expr),
-            _ => None,
+            BadExpression(_) => Some(Expr::Invalid),
+            unsupported => Some(Expr::Unsupported(unsupported.syntax().kind())),
         }
     }
 
@@ -346,7 +351,7 @@ impl LowerExprCtx<'_> {
             StreamingConcatenationExpression(expr) => self.lower_stream_concat_expr(expr),
             ConcatenationExpression(expr) => self.lower_concat_expr(expr),
             ParenthesizedExpression(expr) => self.lower_expr_inner(expr.expression()),
-            _ => None,
+            unsupported => Some(Expr::Unsupported(unsupported.syntax().kind())),
         }
     }
 
@@ -368,9 +373,17 @@ impl LowerExprCtx<'_> {
         };
         let slice = expr.slice_size().map(|size| self.lower_expr(size));
 
-        // TODO: handle with-range
-        let concats =
-            expr.expressions().children().map(|expr| self.lower_expr(expr.expression())).collect();
+        let concats = expr
+            .expressions()
+            .children()
+            .map(|stream| StreamExpr {
+                expr: self.lower_expr(stream.expression()),
+                range: stream
+                    .with_range()
+                    .and_then(|with_range| with_range.range().selector())
+                    .map(|selector| self.lower_selector(selector)),
+            })
+            .collect();
         Some(Expr::Stream { op, slice, concats })
     }
 

--- a/crates/hir/src/hir_def/module.rs
+++ b/crates/hir/src/hir_def/module.rs
@@ -1,4 +1,7 @@
-use clocking::{ClockingBlockDef, ClockingBlockId, ClockingBlockSrc, LowerClocking};
+use clocking::{
+    ClockingBlockDef, ClockingBlockId, ClockingBlockSrc, DefaultClockingRef, DefaultClockingRefSrc,
+    LowerClocking,
+};
 use continuous_assgin::{
     ContAssign, ContAssignId, ContAssignSrc, LowerContAssign, impl_lower_cont_assign,
 };
@@ -101,6 +104,7 @@ define_container! {
         structs: [StructDef],
         subroutines: [Subroutine],
         modports: [ModportDef],
+        default_clocking: Option<DefaultClockingRef>,
         clocking_blocks: [ClockingBlockDef],
         checkers: [CheckerDef],
         covergroups: [CovergroupDef],
@@ -147,6 +151,7 @@ define_container! {
         struct_srcs: [StructDef | StructSrc],
         subroutine_srcs: [Subroutine | SubroutineSrc],
         modport_srcs: [ModportDef | ModportSrc],
+        default_clocking_src: Option<DefaultClockingRefSrc>,
         clocking_block_srcs: [ClockingBlockDef | ClockingBlockSrc],
         checker_srcs: [CheckerDef | CheckerSrc],
         covergroup_srcs: [CovergroupDef | CovergroupSrc],
@@ -629,7 +634,10 @@ impl LowerModuleCtx<'_> {
                 | gen_item @ LoopGenerate(_) => self.lower_direct_generate_region(gen_item).into(),
 
                 // Timing and clocking
-                TimeUnitsDeclaration(_) | DefaultClockingReference(_) | ClockingItem(_) => {
+                TimeUnitsDeclaration(_) | ClockingItem(_) => continue,
+                DefaultClockingReference(reference) => {
+                    self.lower_default_clocking_reference(reference);
+                    self.region_tree.handle_node(member.syntax());
                     continue;
                 }
                 ClockingDeclaration(clocking) => self.lower_clocking_declaration(clocking).into(),

--- a/crates/hir/src/hir_def/module/clocking.rs
+++ b/crates/hir/src/hir_def/module/clocking.rs
@@ -11,22 +11,27 @@ use utils::text_edit::TextRange;
 
 use super::{LowerModuleCtx, port::PortDirection};
 use crate::{
-    hir_def::{Ident, alloc_idx_and_src, lower_ident_opt},
+    hir_def::{
+        Ident, alloc_idx_and_src,
+        expr::timing_control::{EventExprId, LowerEventExpr},
+        lower_ident_opt,
+    },
     source_map::{FromSourceAst, IsNamedSrc, IsSrc, SourceAst, root_token_in},
 };
 
-// slang AST survey:
-// - `ClockingDeclaration` is a module/interface/program/package member with
-//   `block_name`, `event`, `items`, and `end_block_name`.
-// - A `ClockingItem` owns `ClockingDirection` plus a separated list of
-//   `AttributeSpec`; slang exposes each clocking signal name through
-//   `AttributeSpec::name()`.
-// - `DefaultClockingReference` and clocking-event semantics are intentionally
-//   not lowered in this batch.
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Hash)]
+pub enum ClockingBlockKind {
+    #[default]
+    Regular,
+    Default,
+    Global,
+}
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ClockingBlockDef {
     pub name: Option<Ident>,
+    pub kind: ClockingBlockKind,
+    pub event: EventExprId,
     pub signals: SmallVec<[ClockingSignal; 4]>,
 }
 
@@ -41,6 +46,51 @@ pub struct ClockingSignal {
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub struct ClockingSignalId(pub u32);
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct DefaultClockingRef {
+    pub name: Option<Ident>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub struct DefaultClockingRefSrc {
+    pub node: SyntaxNodePtr,
+    pub name: Option<SyntaxTokenPtr>,
+}
+
+impl IsSrc for DefaultClockingRefSrc {
+    #[inline]
+    fn kind(&self) -> SyntaxKind {
+        self.node.kind()
+    }
+
+    #[inline]
+    fn range(&self) -> TextRange {
+        self.node.range()
+    }
+}
+
+impl IsNamedSrc for DefaultClockingRefSrc {
+    #[inline]
+    fn name_kind(&self) -> Option<TokenKind> {
+        self.name.map(|name| name.kind())
+    }
+
+    #[inline]
+    fn name_range(&self) -> Option<TextRange> {
+        self.name.map(|name| name.range())
+    }
+}
+
+impl<'a> FromSourceAst<'a, ast::DefaultClockingReference<'a>> for DefaultClockingRefSrc {
+    fn from_source_ast(reference: SourceAst<ast::DefaultClockingReference<'a>>) -> Self {
+        let reference = reference.into_inner();
+        let syntax = reference.syntax();
+        let name = reference
+            .name()
+            .and_then(|name| root_token_in(syntax, name).map(SyntaxTokenPtr::from_token));
+        Self { node: AstNodeExt::to_ptr(&reference), name }
+    }
+}
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct ClockingBlockSrc {
@@ -88,6 +138,7 @@ pub(crate) trait LowerClocking {
         &mut self,
         clocking: ast::ClockingDeclaration<'_>,
     ) -> ClockingBlockId;
+    fn lower_default_clocking_reference(&mut self, reference: ast::DefaultClockingReference<'_>);
 }
 
 impl LowerClocking for LowerModuleCtx<'_> {
@@ -96,12 +147,25 @@ impl LowerClocking for LowerModuleCtx<'_> {
         clocking: ast::ClockingDeclaration<'_>,
     ) -> ClockingBlockId {
         let name = lower_ident_opt(clocking.block_name());
+        let kind = match clocking.global_or_default().map(|token| token.kind()) {
+            Some(TokenKind::DEFAULT_KEYWORD) => ClockingBlockKind::Default,
+            Some(TokenKind::GLOBAL_KEYWORD) => ClockingBlockKind::Global,
+            _ => ClockingBlockKind::Regular,
+        };
+        let event = self.event_expr_ctx().lower_event_expr(clocking.event());
         let signals = lower_clocking_signals(clocking);
         alloc_idx_and_src! {
             self.file_id;
-            ClockingBlockDef { name, signals } => self.module.clocking_blocks,
+            ClockingBlockDef { name, kind, event, signals } => self.module.clocking_blocks,
             clocking => self.module_source_map.clocking_block_srcs,
         }
+    }
+
+    fn lower_default_clocking_reference(&mut self, reference: ast::DefaultClockingReference<'_>) {
+        self.module.default_clocking =
+            Some(DefaultClockingRef { name: lower_ident_opt(reference.name()) });
+        self.module_source_map.default_clocking_src =
+            SourceAst::new(self.file_id, reference).map(DefaultClockingRefSrc::from_source_ast);
     }
 }
 

--- a/crates/hir/src/hir_def/stmt.rs
+++ b/crates/hir/src/hir_def/stmt.rs
@@ -38,6 +38,9 @@ pub type StmtId = Idx<Stmt>;
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
 pub enum StmtKind {
     #[default]
+    Missing,
+    Invalid,
+    Unsupported(SyntaxKind),
     Empty,
 
     Expr(ExprId),
@@ -241,17 +244,7 @@ impl LowerStmtCtx<'_> {
 
             EmptyStatement(_) => StmtKind::Empty,
 
-            // SystemVerilog-only statement forms are intentionally skipped by the Verilog model.
-            ConcurrentAssertionStatement(_)
-            | CheckerInstanceStatement(_)
-            | DisableForkStatement(_)
-            | ForeachLoopStatement(_)
-            | ImmediateAssertionStatement(_)
-            | RandCaseStatement(_)
-            | RandSequenceStatement(_)
-            | VoidCastedCallStatement(_)
-            | WaitForkStatement(_)
-            | WaitOrderStatement(_) => StmtKind::Empty,
+            unsupported => StmtKind::Unsupported(unsupported.syntax().kind()),
         };
 
         Stmt { label, kind }
@@ -366,7 +359,7 @@ impl LowerStmtCtx<'_> {
         match stmt.repeat_or_while().map(|tok| tok.kind()) {
             Some(TokenKind::REPEAT_KEYWORD) => StmtKind::Repeat(expr, body),
             Some(TokenKind::WHILE_KEYWORD) | None => StmtKind::While(expr, body),
-            _ => StmtKind::Empty,
+            _ => StmtKind::Invalid,
         }
     }
 
@@ -389,7 +382,7 @@ impl LowerStmtCtx<'_> {
             TokenKind::CONTINUE_KEYWORD => Some(JumpKind::Continue),
             _ => None,
         }) else {
-            return StmtKind::Empty;
+            return StmtKind::Invalid;
         };
         StmtKind::Jump(kind)
     }
@@ -475,7 +468,7 @@ impl LowerStmtCtx<'_> {
     }
 
     fn alloc_missing(&mut self) -> StmtId {
-        self.stmts.alloc(Stmt { label: None, kind: StmtKind::Empty })
+        self.stmts.alloc(Stmt { label: None, kind: StmtKind::Missing })
     }
 }
 

--- a/crates/hir/src/scope.rs
+++ b/crates/hir/src/scope.rs
@@ -688,7 +688,7 @@ mod tests {
     use smol_str::SmolStr;
     use triomphe::Arc;
     use utils::{
-        get::GetRef,
+        get::{Get, GetRef},
         paths::{AbsPathBuf, Utf8PathBuf},
     };
     use vfs::{AnchoredPath, FileId, FileSet, VfsPath};
@@ -1048,13 +1048,93 @@ endmodule
     }
 
     #[test]
-    fn module_scope_exposes_clocking_blocks() {
+    fn valid_unlowered_expression_is_not_parser_missing() {
         let db = db_with_root_text(
             r#"
-module m(input clk, input a);
-  clocking cb @(posedge clk);
-    input #1ps a;
-  endclocking
+module m;
+  int x = '{default: 0};
+endmodule
+"#,
+        );
+
+        let module_id = db
+            .unit_scope()
+            .module_ids(&db, &ident("m"))
+            .unique()
+            .expect("module should resolve uniquely");
+        let (module, source_map) = db.module_with_source_map(module_id);
+        let (expr_id, expr) =
+            module.exprs.iter().next().expect("initializer expression should lower");
+
+        assert_eq!(
+            expr,
+            &crate::hir_def::expr::Expr::Unsupported(
+                syntax::SyntaxKind::ASSIGNMENT_PATTERN_EXPRESSION
+            ),
+            "valid but unsupported syntax must carry an explicit diagnostic kind"
+        );
+        assert!(
+            source_map.get(expr_id).is_some(),
+            "valid but unsupported syntax must retain its source"
+        );
+    }
+
+    #[test]
+    fn parser_missing_and_empty_statements_are_distinct() {
+        let db = db_with_root_text(
+            r#"
+module m;
+  initial ;
+endmodule
+"#,
+        );
+
+        let module_id = db
+            .unit_scope()
+            .module_ids(&db, &ident("m"))
+            .unique()
+            .expect("module should resolve uniquely");
+        let (module, source_map) = db.module_with_source_map(module_id);
+        let (empty_id, _) = module
+            .stmts
+            .iter()
+            .find(|(_, stmt)| matches!(stmt.kind, crate::hir_def::stmt::StmtKind::Empty))
+            .expect("empty statement should lower");
+        assert!(source_map.get(empty_id).is_some());
+
+        let mut stmts = Default::default();
+        let mut stmt_srcs = Default::default();
+        let mut event_exprs = Default::default();
+        let mut event_expr_srcs = Default::default();
+        let mut exprs = Default::default();
+        let mut expr_srcs = Default::default();
+        let mut decls = Default::default();
+        let mut decl_srcs = Default::default();
+        let missing_id = crate::hir_def::stmt::LowerStmtCtx {
+            db: &db,
+            file_id: TOP.into(),
+            cont_id: ScopeId::File(TOP.into()),
+            stmts: &mut stmts,
+            stmt_srcs: &mut stmt_srcs,
+            event_exprs: &mut event_exprs,
+            event_expr_srcs: &mut event_expr_srcs,
+            exprs: &mut exprs,
+            expr_srcs: &mut expr_srcs,
+            decls: &mut decls,
+            decl_srcs: &mut decl_srcs,
+        }
+        .lower_stmt_opt(None);
+
+        assert!(matches!(stmts[missing_id].kind, crate::hir_def::stmt::StmtKind::Missing));
+        assert!(stmt_srcs.get(missing_id).is_none());
+    }
+
+    #[test]
+    fn streaming_with_range_is_preserved() {
+        let db = db_with_root_text(
+            r#"
+module m(input logic [3:0] a);
+  logic [3:0] x = {<<{a with [3:0]}};
 endmodule
 "#,
         );
@@ -1065,9 +1145,54 @@ endmodule
             .unique()
             .expect("module should resolve uniquely");
         let module = db.module(module_id);
+        let stream = module
+            .exprs
+            .iter()
+            .find_map(|(_, expr)| match expr {
+                crate::hir_def::expr::Expr::Stream { concats, .. } => Some(concats),
+                _ => None,
+            })
+            .expect("streaming concatenation should lower");
+
+        assert_eq!(stream.len(), 1);
+        assert!(matches!(stream[0].range, Some(crate::hir_def::expr::Selector::Range(_, _))));
+    }
+
+    #[test]
+    fn module_scope_exposes_clocking_blocks() {
+        let db = db_with_root_text(
+            r#"
+module m(input clk, input a);
+  clocking cb @(posedge clk);
+    input #1ps a;
+  endclocking
+  default clocking cb;
+endmodule
+"#,
+        );
+
+        let module_id = db
+            .unit_scope()
+            .module_ids(&db, &ident("m"))
+            .unique()
+            .expect("module should resolve uniquely");
+        let (module, source_map) = db.module_with_source_map(module_id);
         let (clocking_block_id, clocking_block) =
             module.clocking_blocks.iter().next().expect("clocking block should lower");
         assert_eq!(clocking_block.name.as_deref(), Some("cb"));
+        assert!(matches!(
+            module.event_exprs[clocking_block.event],
+            crate::hir_def::expr::timing_control::EventExpr::Atom {
+                sensitivity: Some(crate::hir_def::expr::timing_control::Sensitivity::Posedge),
+                ..
+            }
+        ));
+        assert!(source_map.get(clocking_block.event).is_some());
+        assert_eq!(
+            module.default_clocking.as_ref().and_then(|reference| reference.name.as_deref()),
+            Some("cb")
+        );
+        assert!(source_map.default_clocking_src.is_some());
         assert_eq!(clocking_block.signals.len(), 1);
         assert_eq!(clocking_block.signals[0].name.as_str(), "a");
 

--- a/crates/hir/src/scope.rs
+++ b/crates/hir/src/scope.rs
@@ -707,6 +707,7 @@ mod tests {
         container::{InContainer, ScopeId},
         db::{HirDb, HirDbStorage, InternDbStorage},
         def_id::DefId,
+        display::HirDisplay,
         hir_def::Ident,
         semantics::pathres::resolve_name,
         symbol::{DefKind, DefOriginLoc, NameContext, Resolution},
@@ -1155,7 +1156,75 @@ endmodule
             .expect("streaming concatenation should lower");
 
         assert_eq!(stream.len(), 1);
-        assert!(matches!(stream[0].range, Some(crate::hir_def::expr::Selector::Range(_, _))));
+        assert!(matches!(
+            stream[0].with_range.as_ref().and_then(|range| range.selector),
+            Some(crate::hir_def::expr::Selector::Range(_, _))
+        ));
+    }
+
+    #[test]
+    fn streaming_with_range_display_preserves_with_keyword() {
+        let db = db_with_root_text(
+            r#"
+module m(input logic [3:0] a);
+  logic [3:0] x = {<<{a with [3:0]}};
+endmodule
+"#,
+        );
+
+        let module_id = db
+            .unit_scope()
+            .module_ids(&db, &ident("m"))
+            .unique()
+            .expect("module should resolve uniquely");
+        let module = db.module(module_id);
+        let (stream_id, _) = module
+            .exprs
+            .iter()
+            .find(|(_, expr)| matches!(expr, crate::hir_def::expr::Expr::Stream { .. }))
+            .expect("streaming concatenation should lower");
+
+        assert_eq!(
+            InContainer::new(module_id.into(), stream_id).display_source(&db).unwrap(),
+            "{<<{a with [3:0]}}"
+        );
+    }
+
+    #[test]
+    fn invalid_streaming_with_range_is_preserved() {
+        let db = db_with_root_text(
+            r#"
+module m(input logic [3:0] a);
+  logic [3:0] x = {<<{a, a with [], a with [3:0]}};
+endmodule
+"#,
+        );
+
+        let module_id = db
+            .unit_scope()
+            .module_ids(&db, &ident("m"))
+            .unique()
+            .expect("module should resolve uniquely");
+        let module = db.module(module_id);
+        let stream = module
+            .exprs
+            .iter()
+            .find_map(|(_, expr)| match expr {
+                crate::hir_def::expr::Expr::Stream { concats, .. } => Some(concats),
+                _ => None,
+            })
+            .expect("streaming concatenation should lower");
+
+        assert_eq!(stream.len(), 3);
+        assert!(stream[0].with_range.is_none(), "an omitted with range must remain absent");
+        assert!(
+            stream[1].with_range.as_ref().is_some_and(|range| range.selector.is_none()),
+            "the present but invalid with range must retain a missing selector"
+        );
+        assert!(matches!(
+            stream[2].with_range.as_ref().and_then(|range| range.selector),
+            Some(crate::hir_def::expr::Selector::Range(_, _))
+        ));
     }
 
     #[test]

--- a/crates/ide/src/document_symbols.rs
+++ b/crates/ide/src/document_symbols.rs
@@ -459,7 +459,10 @@ fn build_stmt<Arn, SrcMap>(
             build_stmt(db, collector, *stmt, arena, src_map);
         }
 
-        StmtKind::Empty
+        StmtKind::Missing
+        | StmtKind::Invalid
+        | StmtKind::Unsupported(_)
+        | StmtKind::Empty
         | StmtKind::Expr(_)
         | StmtKind::Jump(_)
         | StmtKind::EventTrigger(_)

--- a/crates/ide/src/verilog_2005.rs
+++ b/crates/ide/src/verilog_2005.rs
@@ -3716,7 +3716,10 @@ endmodule
                         stmt_tree_has(db, stmts, *clause, matches_kind)
                     }
                 }),
-                StmtKind::Empty
+                StmtKind::Missing
+                | StmtKind::Invalid
+                | StmtKind::Unsupported(_)
+                | StmtKind::Empty
                 | StmtKind::Expr(_)
                 | StmtKind::Jump(_)
                 | StmtKind::EventTrigger(_)


### PR DESCRIPTION
## Summary

- distinguish parser recovery, invalid syntax, and unsupported HIR lowering states
- retain source mappings and syntax kinds for unsupported expressions and statements
- lower streaming `with` ranges plus clocking events, modifiers, and default references
- update downstream statement consumers and add regression coverage

## Verification

- `cargo test -p hir` (96 passed)
- `cargo test -p ide document_symbols` (1 passed)
- `cargo check --workspace --all-targets`
- `cargo test -p hir valid_unlowered_expression_is_not_parser_missing`