### PR TITLE
fix(ci): stabilize macOS and web smoke checks

### DIFF
--- a/.github/scripts/install-native-optionals.mjs
+++ b/.github/scripts/install-native-optionals.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const rootArg = args.find((arg) => arg !== '--dry-run');
+const root = rootArg ?? process.cwd();
+const lockPath = join(root, 'package-lock.json');
+const lock = JSON.parse(readFileSync(lockPath, 'utf8'));
+const packages = lock.packages ?? {};
+const libc = detectLibc();
+const specs = new Map();
+
+for (const [ownerKey, owner] of Object.entries(packages)) {
+  const optionalDependencies = owner.optionalDependencies ?? {};
+  for (const [name, declaredVersion] of Object.entries(optionalDependencies)) {
+    const packageKey = dependencyPackageKey(ownerKey, name);
+    const packageMeta = packages[packageKey] ?? packages[`node_modules/${name}`];
+    if (!isCurrentPlatformOptional(name, packageMeta)) {
+      continue;
+    }
+    if (existsSync(join(root, packageKey))) {
+      continue;
+    }
+
+    const version = packageMeta?.version ?? declaredVersion;
+    if (!isExactVersion(version)) {
+      throw new Error(
+        `Cannot install ${name} from non-exact optional dependency version ${version}`,
+      );
+    }
+    specs.set(name, `${name}@${version}`);
+  }
+}
+
+if (specs.size === 0) {
+  console.log('Native optional dependencies are already present.');
+  process.exit(0);
+}
+
+const installArgs = ['install', '--no-save', '--package-lock=false', ...specs.values()];
+console.log(`Installing native optional dependencies: ${[...specs.values()].join(' ')}`);
+if (dryRun) {
+  process.exit(0);
+}
+
+const result = spawnSync('npm', installArgs, { cwd: root, stdio: 'inherit' });
+process.exit(result.status ?? 1);
+
+function dependencyPackageKey(ownerKey, dependencyName) {
+  if (!ownerKey || !ownerKey.includes('/node_modules/')) {
+    return `node_modules/${dependencyName}`;
+  }
+  return `${ownerKey.slice(0, ownerKey.lastIndexOf('/node_modules/'))}/node_modules/${dependencyName}`;
+}
+
+function isCurrentPlatformOptional(name, packageMeta) {
+  if (packageMeta && !allows(packageMeta.os, process.platform)) {
+    return false;
+  }
+  if (packageMeta && !allows(packageMeta.cpu, process.arch)) {
+    return false;
+  }
+  if (packageMeta && !allows(packageMeta.libc, libc)) {
+    return false;
+  }
+  if (packageMeta) {
+    return true;
+  }
+
+  const normalizedName = name.replace('/', '-');
+  if (process.platform === 'linux') {
+    if (!normalizedName.includes('linux')) {
+      return false;
+    }
+    if (!normalizedName.includes(process.arch)) {
+      return false;
+    }
+    if (normalizedName.includes('musl')) {
+      return libc === 'musl';
+    }
+    if (normalizedName.includes('gnu')) {
+      return libc === 'glibc';
+    }
+    return true;
+  }
+
+  if (process.platform === 'darwin') {
+    return normalizedName.includes('darwin') && normalizedName.includes(process.arch);
+  }
+
+  if (process.platform === 'win32') {
+    return normalizedName.includes('win32') && normalizedName.includes(process.arch);
+  }
+
+  return normalizedName.includes(process.platform) && normalizedName.includes(process.arch);
+}
+
+function allows(values, current) {
+  if (!values || values.length === 0) {
+    return true;
+  }
+  const blocked = values.some((value) => value === `!${current}`);
+  if (blocked) {
+    return false;
+  }
+  const allowed = values.filter((value) => !value.startsWith('!'));
+  return allowed.length === 0 || allowed.includes(current);
+}
+
+function isExactVersion(version) {
+  return /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version);
+}
+
+function detectLibc() {
+  if (process.platform !== 'linux') {
+    return undefined;
+  }
+  return process.report?.getReport?.().header?.glibcVersionRuntime ? 'glibc' : 'musl';
+}

--- a/.github/scripts/install-native-optionals.mjs
+++ b/.github/scripts/install-native-optionals.mjs
@@ -9,7 +9,10 @@ const rootArg = args.find((arg) => arg !== '--dry-run');
 const root = rootArg ?? process.cwd();
 const lockPath = join(root, 'package-lock.json');
 const lock = JSON.parse(readFileSync(lockPath, 'utf8'));
-const packages = lock.packages ?? {};
+const packages = lock?.packages;
+if (packages === null || typeof packages !== 'object' || Array.isArray(packages)) {
+  throw new Error(`Unsupported package lock at ${lockPath}: expected a "packages" object`);
+}
 const libc = detectLibc();
 const specs = new Map();
 
@@ -47,7 +50,13 @@ if (dryRun) {
 }
 
 const result = spawnSync('npm', installArgs, { cwd: root, stdio: 'inherit' });
-process.exit(result.status ?? 1);
+if (result.error) {
+  throw result.error;
+}
+if (result.status === null) {
+  throw new Error(`npm install terminated without an exit status (signal: ${result.signal ?? 'none'})`);
+}
+process.exit(result.status);
 
 function dependencyPackageKey(ownerKey, dependencyName) {
   if (!ownerKey || !ownerKey.includes('/node_modules/')) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,13 @@ jobs:
           cache-workspace-crates: true
           cache-on-failure: true
       - name: Test
-        run: cargo test --workspace
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            cargo test --workspace -- --test-threads=1
+          else
+            cargo test --workspace
+          fi
 
   vscode-extension:
     name: VS Code Checks
@@ -195,6 +201,25 @@ jobs:
       - name: Install web smoke dependencies
         working-directory: editors/vscode/test-web
         run: npm ci
+      - name: Restore VS Code Web cache
+        uses: actions/cache@v4
+        with:
+          path: editors/vscode/test-web/.vscode-test-web
+          key: vscode-web-stable-e4c7e7b1d6d060162f4aa7f8225271b67ce1df75
+      - name: Download VS Code Web
+        working-directory: editors/vscode/test-web
+        run: |
+          vscode_dir=".vscode-test-web/vscode-web-stable-e4c7e7b1d6d060162f4aa7f8225271b67ce1df75"
+          if [ ! -f "${vscode_dir}/version" ]; then
+            archive="${RUNNER_TEMP}/vscode-web.tar.gz"
+            curl --fail --location --retry 10 --retry-all-errors \
+              --output "${archive}" \
+              "https://vscode.download.prss.microsoft.com/dbazure/download/stable/e4c7e7b1d6d060162f4aa7f8225271b67ce1df75/vscode-web.tar.gz"
+            rm -rf "${vscode_dir}"
+            mkdir -p "${vscode_dir}"
+            tar -xzf "${archive}" --strip-components=1 -C "${vscode_dir}"
+            printf '%s' 'vscode-web-stable-e4c7e7b1d6d060162f4aa7f8225271b67ce1df75' > "${vscode_dir}/version"
+          fi
       - name: Build Vide LSP WASM
         if: steps.vide-lsp-wasm-cache.outputs.cache-hit != 'true'
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,24 +201,39 @@ jobs:
       - name: Install web smoke dependencies
         working-directory: editors/vscode/test-web
         run: npm ci
+      - name: Read VS Code Web version
+        id: vscode-web-version
+        working-directory: editors/vscode/test-web
+        shell: bash
+        run: |
+          vscode_commit="$(node -p "require('./package.json').config.vscodeWebCommit")"
+          if [[ ! "${vscode_commit}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::test-web/package.json config.vscodeWebCommit must be a 40-character lowercase Git commit"
+            exit 1
+          fi
+          echo "commit=${vscode_commit}" >> "${GITHUB_OUTPUT}"
+          echo "folder=vscode-web-stable-${vscode_commit}" >> "${GITHUB_OUTPUT}"
       - name: Restore VS Code Web cache
         uses: actions/cache@v4
         with:
           path: editors/vscode/test-web/.vscode-test-web
-          key: vscode-web-stable-e4c7e7b1d6d060162f4aa7f8225271b67ce1df75
+          key: ${{ steps.vscode-web-version.outputs.folder }}
       - name: Download VS Code Web
         working-directory: editors/vscode/test-web
+        env:
+          VSCODE_WEB_COMMIT: ${{ steps.vscode-web-version.outputs.commit }}
+          VSCODE_WEB_FOLDER: ${{ steps.vscode-web-version.outputs.folder }}
         run: |
-          vscode_dir=".vscode-test-web/vscode-web-stable-e4c7e7b1d6d060162f4aa7f8225271b67ce1df75"
+          vscode_dir=".vscode-test-web/${VSCODE_WEB_FOLDER}"
           if [ ! -f "${vscode_dir}/version" ]; then
             archive="${RUNNER_TEMP}/vscode-web.tar.gz"
             curl --fail --location --retry 10 --retry-all-errors \
               --output "${archive}" \
-              "https://vscode.download.prss.microsoft.com/dbazure/download/stable/e4c7e7b1d6d060162f4aa7f8225271b67ce1df75/vscode-web.tar.gz"
+              "https://vscode.download.prss.microsoft.com/dbazure/download/stable/${VSCODE_WEB_COMMIT}/vscode-web.tar.gz"
             rm -rf "${vscode_dir}"
             mkdir -p "${vscode_dir}"
             tar -xzf "${archive}" --strip-components=1 -C "${vscode_dir}"
-            printf '%s' 'vscode-web-stable-e4c7e7b1d6d060162f4aa7f8225271b67ce1df75' > "${vscode_dir}/version"
+            printf '%s' "${VSCODE_WEB_FOLDER}" > "${vscode_dir}/version"
           fi
       - name: Build Vide LSP WASM
         if: steps.vide-lsp-wasm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -375,12 +375,12 @@ jobs:
           cache: npm
           cache-dependency-path: website/package-lock.json
 
-      # TODO: Remove this `npm install` workaround once npm reliably restores platform optional
-      # dependencies from package-lock.json. see <https://github.com/npm/cli/issues/4828>.
+      # package-lock.json can be platform-pruned by npm; repair current-runner
+      # native optional packages from the lockfile declarations before building.
       - name: Install dependencies
         run: |
           npm ci
-          npm install --no-save
+          node ../.github/scripts/install-native-optionals.mjs
         working-directory: website
 
       - name: Build Vide LSP WASM

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -127,6 +127,7 @@ jobs:
         run: |
           npm ci
           npm install --no-save
+          npm --prefix playground install --no-save --include=optional
         working-directory: website
 
       - name: Build Vide LSP WASM

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -128,6 +128,8 @@ jobs:
           npm ci
           npm install --no-save
           rolldown_version="$(node -p 'require("./playground/node_modules/rolldown/package.json").version')"
+          rollup_version="$(node -p 'require("./node_modules/rollup/package.json").version')"
+          npm install --no-save "@rollup/rollup-linux-x64-gnu@${rollup_version}"
           npm --prefix playground install --no-save "@rolldown/binding-linux-x64-gnu@${rolldown_version}"
         working-directory: website
 

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -121,16 +121,12 @@ jobs:
           node-version: 22
           cache: npm
           cache-dependency-path: website/package-lock.json
-      # TODO: Remove this `npm install` workaround once npm reliably restores platform optional
-      # dependencies from package-lock.json. see <https://github.com/npm/cli/issues/4828>.
+      # package-lock.json can be platform-pruned by npm; repair current-runner
+      # native optional packages from the lockfile declarations before building.
       - name: Install dependencies
         run: |
           npm ci
-          npm install --no-save
-          rolldown_version="$(node -p 'require("./playground/node_modules/rolldown/package.json").version')"
-          rollup_version="$(node -p 'require("./node_modules/rollup/package.json").version')"
-          npm install --no-save "@rollup/rollup-linux-x64-gnu@${rollup_version}"
-          npm --prefix playground install --no-save "@rolldown/binding-linux-x64-gnu@${rolldown_version}"
+          node ../.github/scripts/install-native-optionals.mjs
         working-directory: website
 
       - name: Build Vide LSP WASM

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -127,7 +127,8 @@ jobs:
         run: |
           npm ci
           npm install --no-save
-          npm --prefix playground install --no-save --include=optional
+          rolldown_version="$(node -p 'require("./playground/node_modules/rolldown/package.json").version')"
+          npm --prefix playground install --no-save "@rolldown/binding-linux-x64-gnu@${rolldown_version}"
         working-directory: website
 
       - name: Build Vide LSP WASM

--- a/editors/vscode/test-web/package.json
+++ b/editors/vscode/test-web/package.json
@@ -2,6 +2,9 @@
   "name": "vide-vscode-web-smoke",
   "version": "0.0.0",
   "private": true,
+  "config": {
+    "vscodeWebCommit": "e4c7e7b1d6d060162f4aa7f8225271b67ce1df75"
+  },
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "npm run typecheck && tsx runTests.ts"

--- a/editors/vscode/test-web/runTests.ts
+++ b/editors/vscode/test-web/runTests.ts
@@ -11,13 +11,18 @@ const extensionTestsPath = path.join(
   "index.js",
 );
 
+const vscodeCommit = "e4c7e7b1d6d060162f4aa7f8225271b67ce1df75";
+const testRunnerDataDir = path.resolve(__dirname, ".vscode-test-web");
+
 async function main(): Promise<void> {
   await runTests({
     browserType: "chromium",
+    commit: vscodeCommit,
     extensionDevelopmentPath,
     extensionTestsPath,
     headless: true,
     quality: "stable",
+    testRunnerDataDir,
   });
 }
 

--- a/editors/vscode/test-web/runTests.ts
+++ b/editors/vscode/test-web/runTests.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { runTests } from "@vscode/test-web";
@@ -11,8 +12,21 @@ const extensionTestsPath = path.join(
   "index.js",
 );
 
-const vscodeCommit = "e4c7e7b1d6d060162f4aa7f8225271b67ce1df75";
+const vscodeCommit = readVscodeCommit();
 const testRunnerDataDir = path.resolve(__dirname, ".vscode-test-web");
+
+function readVscodeCommit(): string {
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, "package.json"), "utf8"),
+  ) as { config?: { vscodeWebCommit?: unknown } };
+  const commit = packageJson.config?.vscodeWebCommit;
+  if (typeof commit !== "string" || !/^[0-9a-f]{40}$/.test(commit)) {
+    throw new Error(
+      "test-web/package.json config.vscodeWebCommit must be a 40-character lowercase Git commit",
+    );
+  }
+  return commit;
+}
 
 async function main(): Promise<void> {
   await runTests({

--- a/src/global_state/process_changes.rs
+++ b/src/global_state/process_changes.rs
@@ -139,7 +139,13 @@ impl GlobalState {
         }
 
         let semantic_profile_ids = self.semantic_compiler_profiles_for_invalidation(&invalidation);
+        let semantic_compilation_scheduled = !semantic_profile_ids.is_empty();
         self.schedule_semantic_compiler(semantic_profile_ids);
+        if semantic_compilation_scheduled
+            && matches!(&invalidation, DiagnosticInvalidation::FileChanges(_))
+        {
+            return;
+        }
 
         if self.config_state.config.cli_pull_diagnostics_support()
             && self.config_state.config.cli_workspace_diagnostic_refresh_support()

--- a/src/global_state/process_changes.rs
+++ b/src/global_state/process_changes.rs
@@ -141,7 +141,8 @@ impl GlobalState {
         let semantic_profile_ids = self.semantic_compiler_profiles_for_invalidation(&invalidation);
         let semantic_compilation_scheduled = !semantic_profile_ids.is_empty();
         self.schedule_semantic_compiler(semantic_profile_ids);
-        if semantic_compilation_scheduled
+        if self.config_state.config.cli_pull_diagnostics_support()
+            && semantic_compilation_scheduled
             && matches!(&invalidation, DiagnosticInvalidation::FileChanges(_))
         {
             return;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -383,14 +383,14 @@ fn request_document_diagnostics_with_previous_result_id(
                 "document-diagnostic-{request_id}-readiness-{attempt}"
             ))
         };
-        let result = request_document_diagnostics_once(
+        let (result_id, diagnostics) = request_document_diagnostics_once(
             client,
             uri.clone(),
             current_request_id,
             previous_result_id.clone(),
         );
-        if result.0.is_some() {
-            return result;
+        if result_id.is_some() {
+            return (result_id, diagnostics);
         }
         attempt += 1;
         wait_for_workspace_diagnostic_refresh_or_tick(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -352,12 +352,15 @@ fn request_document_diagnostics_until(
     mut predicate: impl FnMut(Option<&str>, &[lsp_types::Diagnostic]) -> bool,
     context: &str,
 ) -> (Option<String>, Vec<lsp_types::Diagnostic>) {
-    for attempt in 0..50 {
+    let deadline = Instant::now() + LSP_TEST_TIMEOUT;
+    let mut attempt = 0;
+    while Instant::now() < deadline {
         let (result_id, diagnostics) =
             request_document_diagnostics(client, uri.clone(), first_request_id + attempt);
         if predicate(result_id.as_deref(), &diagnostics) {
             return (result_id, diagnostics);
         }
+        attempt += 1;
         wait_for_workspace_diagnostic_refresh_or_tick(client, context);
     }
 
@@ -370,7 +373,9 @@ fn request_document_diagnostics_with_previous_result_id(
     request_id: i32,
     previous_result_id: Option<String>,
 ) -> (Option<String>, Vec<lsp_types::Diagnostic>) {
-    for attempt in 0..50 {
+    let deadline = Instant::now() + LSP_TEST_TIMEOUT;
+    let mut attempt = 0;
+    while Instant::now() < deadline {
         let current_request_id = if attempt == 0 {
             lsp_server::RequestId::from(request_id)
         } else {
@@ -384,13 +389,10 @@ fn request_document_diagnostics_with_previous_result_id(
             current_request_id,
             previous_result_id.clone(),
         );
-        // A diagnostically enabled document gets a result id once the workspace
-        // is ready, even when its diagnostic list is legitimately empty.  The
-        // cold-start fallback deliberately has no result id.  Do not use the
-        // item count as a readiness signal: an empty list is valid data.
         if result.0.is_some() {
             return result;
         }
+        attempt += 1;
         wait_for_workspace_diagnostic_refresh_or_tick(
             client,
             "document diagnostics workspace readiness",
@@ -807,12 +809,15 @@ fn request_workspace_diagnostic_report_until(
     mut predicate: impl FnMut(&lsp_types::WorkspaceDiagnosticReport) -> bool,
     context: &str,
 ) -> lsp_types::WorkspaceDiagnosticReport {
-    for attempt in 0..50 {
+    let deadline = Instant::now() + LSP_TEST_TIMEOUT;
+    let mut attempt = 0;
+    while Instant::now() < deadline {
         let report =
             request_workspace_diagnostic_report(client, first_request_id + attempt, Vec::new());
         if predicate(&report) {
             return report;
         }
+        attempt += 1;
         wait_for_workspace_diagnostic_refresh_or_tick(client, context);
     }
 


### PR DESCRIPTION
## Summary
- delay pull-diagnostic refreshes until semantic compilation completes while preserving workspace cleanup refreshes
- use the full integration-test timeout and serialize macOS Rust tests to prevent cold-start timeout storms
- pin, retry, and cache the VS Code Web build used by the web smoke test
- repair platform-pruned native optional packages from lockfile declarations in docs workflows

## Verification
- `cargo test --workspace -- --test-threads=1` (541 passed, 3 ignored)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo xtask check-config-artifacts`
- `npm test` in `editors/vscode` (54 passed)
- `npm run typecheck` in `editors/vscode/test-web`
- `node .github/scripts/install-native-optionals.mjs --dry-run website`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`