### PR TITLE
fix(ci): stabilize LSP test readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,13 +114,7 @@ jobs:
           cache-workspace-crates: true
           cache-on-failure: true
       - name: Test
-        shell: bash
-        run: |
-          if [ "${{ runner.os }}" = "macOS" ]; then
-            cargo test --workspace -- --test-threads=1
-          else
-            cargo test --workspace
-          fi
+        run: cargo test --workspace
 
   vscode-extension:
     name: VS Code Checks

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -57,6 +57,7 @@ use crate::{
 type TempDir = TestDir;
 
 const LSP_TEST_TIMEOUT: Duration = Duration::from_secs(30);
+
 const DEFAULT_TEST_CONFIG: &str = "sources = [\"**\"]\ninclude_dirs = [\".\"]\n";
 const SYNTAX_ONLY_TEST_CONFIG: &str = "\
 # Syntax-only startup config. Keep these arrays empty to avoid scanning the workspace.
@@ -88,6 +89,7 @@ fn recv_lsp_message_until(
 fn handle_test_server_request(client: &Connection, request: Request, context: &str) {
     if request.method == lsp_types::request::WorkDoneProgressCreate::METHOD
         || request.method == lsp_types::request::WorkspaceDiagnosticRefresh::METHOD
+        || request.method == lsp_types::request::RegisterCapability::METHOD
     {
         client
             .sender
@@ -106,6 +108,12 @@ fn spawn_default_test_server(
     thread::spawn(move || main_loop::main_loop(config, server, lsp_types::TraceValue::Off))
 }
 
+fn enable_test_watched_files_capability(client_caps: &mut ClientCapabilities) {
+    let workspace = client_caps.workspace.get_or_insert_with(Default::default);
+    let watched_files = workspace.did_change_watched_files.get_or_insert_with(Default::default);
+    watched_files.dynamic_registration = Some(true);
+}
+
 fn test_server_config(
     root_path: AbsPathBuf,
     client_caps: ClientCapabilities,
@@ -116,10 +124,11 @@ fn test_server_config(
 
 fn test_server_config_with_i18n(
     root_path: AbsPathBuf,
-    client_caps: ClientCapabilities,
+    mut client_caps: ClientCapabilities,
     user_config: UserConfig,
     i18n: I18n,
 ) -> config::Config {
+    enable_test_watched_files_capability(&mut client_caps);
     let opt = Opt {
         process_name: "vide-test".to_string(),
         log: "error".to_string(),
@@ -277,14 +286,7 @@ fn shutdown_test_server(
                 if notification.method == lsp_types::notification::PublishDiagnostics::METHOD => {}
             Message::Notification(notification)
                 if notification.method == ProjectStatusNotification::METHOD => {}
-            Message::Request(request)
-                if request.method == lsp_types::request::WorkspaceDiagnosticRefresh::METHOD =>
-            {
-                client
-                    .sender
-                    .send(Message::Response(lsp_server::Response::new_ok(request.id, ())))
-                    .unwrap();
-            }
+            Message::Request(request) => handle_test_server_request(client, request, "shutdown"),
             other => panic!("unexpected message while shutting down test server: {other:?}"),
         }
     }

--- a/src/tests/diagnostics.rs
+++ b/src/tests/diagnostics.rs
@@ -145,7 +145,7 @@ fn pull_capable_client_does_not_receive_duplicate_publish_diagnostics() {
                 let _ = serde_json::from_value::<ProgressParams>(notification.params).unwrap();
             }
             Message::Request(request) => {
-                panic!("unexpected server request during diagnostics test: {request:?}");
+                handle_test_server_request(&client, request, "diagnostics test")
             }
             _ => {}
         }
@@ -216,7 +216,7 @@ fn legacy_client_receives_publish_diagnostics() {
             Message::Notification(notification)
                 if notification.method == lsp_types::notification::Progress::METHOD => {}
             Message::Request(request) => {
-                panic!("unexpected server request during diagnostics test: {request:?}");
+                handle_test_server_request(&client, request, "diagnostics test")
             }
             _ => {}
         }
@@ -293,7 +293,7 @@ endmodule
             Message::Notification(notification)
                 if notification.method == lsp_types::notification::Progress::METHOD => {}
             Message::Request(request) => {
-                panic!("unexpected server request during diagnostics test: {request:?}");
+                handle_test_server_request(&client, request, "diagnostics test")
             }
             _ => {}
         }
@@ -1256,20 +1256,12 @@ fn deleted_workspace_file_requests_diagnostic_refresh() {
             Message::Request(request)
                 if request.method == lsp_types::request::WorkspaceDiagnosticRefresh::METHOD =>
             {
-                client
-                    .sender
-                    .send(Message::Response(lsp_server::Response::new_ok(request.id, ())))
-                    .unwrap();
+                handle_test_server_request(&client, request, "workspace diagnostic refresh");
                 saw_refresh = true;
                 break;
             }
-            Message::Request(request)
-                if request.method == lsp_types::request::WorkDoneProgressCreate::METHOD =>
-            {
-                client
-                    .sender
-                    .send(Message::Response(lsp_server::Response::new_ok(request.id, ())))
-                    .unwrap();
+            Message::Request(request) => {
+                handle_test_server_request(&client, request, "workspace diagnostic refresh")
             }
             Message::Notification(notification)
                 if notification.method == lsp_types::notification::Progress::METHOD => {}
@@ -1379,20 +1371,12 @@ fn watched_dependency_change_refreshes_workspace_diagnostics() {
             Message::Request(request)
                 if request.method == lsp_types::request::WorkspaceDiagnosticRefresh::METHOD =>
             {
-                client
-                    .sender
-                    .send(Message::Response(lsp_server::Response::new_ok(request.id, ())))
-                    .unwrap();
+                handle_test_server_request(&client, request, "workspace diagnostic refresh");
                 saw_refresh = true;
                 break;
             }
-            Message::Request(request)
-                if request.method == lsp_types::request::WorkDoneProgressCreate::METHOD =>
-            {
-                client
-                    .sender
-                    .send(Message::Response(lsp_server::Response::new_ok(request.id, ())))
-                    .unwrap();
+            Message::Request(request) => {
+                handle_test_server_request(&client, request, "workspace diagnostic refresh")
             }
             Message::Notification(notification)
                 if notification.method == lsp_types::notification::Progress::METHOD => {}
@@ -1401,22 +1385,30 @@ fn watched_dependency_change_refreshes_workspace_diagnostics() {
     }
     assert!(saw_refresh, "changing a watched dependency should refresh pulled diagnostics");
 
-    let second_report = request_workspace_diagnostic_report(&client, 2, Vec::new());
+    let second_report = request_workspace_diagnostic_report_until(
+        &client,
+        2,
+        |report| {
+            report.items.iter().any(|item| {
+                let lsp_types::WorkspaceDocumentDiagnosticReport::Full(full) = item else {
+                    return false;
+                };
+                full.uri == top_uri && full.full_document_diagnostic_report.items.is_empty()
+            })
+        },
+        "refreshed watched dependency workspace diagnostics",
+    );
+    let mut saw_cleared_top = false;
     for item in second_report.items {
         if let lsp_types::WorkspaceDocumentDiagnosticReport::Full(full) = item
             && full.uri == top_uri
         {
-            assert!(
-                full.full_document_diagnostic_report.items.is_empty(),
-                "top.sv diagnostics should refresh after watched dependency edit: {:?}",
-                full.full_document_diagnostic_report.items
-            );
-            shutdown_test_server(&client, server_thread);
-            return;
+            saw_cleared_top = full.full_document_diagnostic_report.items.is_empty();
         }
     }
+    assert!(saw_cleared_top, "top.sv diagnostics should refresh after watched dependency edit");
 
-    panic!("workspace diagnostics should include top.sv after watched dependency edit");
+    shutdown_test_server(&client, server_thread);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- run Rust workspace tests in CI without the macOS-only `--test-threads=1` fallback
- configure the test client for watched-file dynamic registration instead of relying on server-side OS watchers
- wait for refreshed workspace diagnostics after watched dependency edits before asserting cleared diagnostics

## Verification
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
