### PR TITLE
feat(ide): expand folding coverage and fix selection in preprocessor regions

### DIFF
--- a/crates/hir-def/src/region_tree.rs
+++ b/crates/hir-def/src/region_tree.rs
@@ -138,6 +138,10 @@ impl RegionTreeBuilder {
     }
 
     pub(crate) fn stage<'a>(&mut self, end_tok: Option<SyntaxToken<'a>>, context: SyntaxNode<'a>) {
+        // Scan the end token's trivia first: an `endregion` marker attached to
+        // the closing token must close its region, otherwise every open region
+        // would be force-closed below and the marker would be lost.
+        self.handle_tok(end_tok, context);
         if let Some(end) =
             end_tok.as_ref().and_then(|tok| tok.text_range_in(context)).map(|r| r.end())
         {
@@ -148,7 +152,6 @@ impl RegionTreeBuilder {
                 self.stack.pop();
             }
         }
-        self.handle_tok(end_tok, context);
     }
 
     pub(crate) fn finish(&mut self) -> RegionTree {

--- a/crates/ide/src/analysis.rs
+++ b/crates/ide/src/analysis.rs
@@ -27,7 +27,7 @@ use crate::{
     diagnostics,
     document_highlight::{self, DocumentHighlight, DocumentHighlightConfig},
     document_symbols::{self, DocumentSymbol},
-    folding_ranges::{self, Fold, FoldingConfig},
+    folding_ranges::{self, Fold},
     formatting::{self, FmtConfig},
     goto_declaration, goto_definition,
     hover::{self, HoverConfig},
@@ -286,12 +286,8 @@ impl Analysis {
         self.with_db(|db| selection_ranges::selection_ranges(db, position))
     }
 
-    pub fn folding_ranges(
-        &self,
-        file_id: FileId,
-        config: &FoldingConfig,
-    ) -> Cancellable<Vec<Fold>> {
-        self.with_db(|db| folding_ranges::folding_ranges(db, file_id, config))
+    pub fn folding_ranges(&self, file_id: FileId) -> Cancellable<Vec<Fold>> {
+        self.with_db(|db| folding_ranges::folding_ranges(db, file_id))
     }
 
     pub fn hover(

--- a/crates/ide/src/folding_ranges.rs
+++ b/crates/ide/src/folding_ranges.rs
@@ -1,23 +1,29 @@
-use base_db::source_db::SourceDb;
 use hir_def::{
     block::{BlockId, BlockSrc},
+    container::{SubroutineParent, SubroutineScope},
     db::HirDefDb,
-    module::ModuleId,
+    module::{
+        ModuleId,
+        generate::GenerateBlockId,
+        instantiation::{
+            Instance, InstanceId, InstanceSrc, Instantiation, InstantiationId, InstantiationSrc,
+        },
+    },
     region_tree::RegionTree,
-    source_map::SourceInfo,
+    source_map::{IsSrc, Lowered, LoweredData, SourceInfo, SourceMap},
     stmt::{Stmt, StmtKind, StmtSrc},
+    subroutine::{Subroutine, SubroutineSrc},
 };
 use la_arena::Arena;
-use memchr::memmem::Finder;
 use preproc_expand::{db::PreprocDb, file::HirFileId};
-use rustc_hash::FxHashSet;
 use syntax::{
-    SyntaxCursor, SyntaxCursorExt, SyntaxTrivia,
+    SyntaxKind, SyntaxTokenWithParent, SyntaxTrivia,
     has_text_range::HasTextRange,
     token::SyntaxTokenWithParentExt,
     trivia::{TriviaExt, TriviaKindExt},
 };
 use utils::{
+    get::{Get, GetRef},
     line_index::{LineIndex, TextRange},
     text_edit::TextSize,
 };
@@ -25,15 +31,10 @@ use vfs::FileId;
 
 use crate::db::{line_index_db::LineIndexDb, root_db::RootDb};
 
-#[derive(Debug, Clone, Copy)]
-pub struct FoldingConfig {
-    pub line_fold_only: bool,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FoldKind {
     Comment,
-    Imports, // TODO: fold macros
+    Imports,
     Region,
     Module,
     Config,
@@ -48,18 +49,20 @@ pub enum FoldKind {
     Instance,
     Stmt,
     Block,
+    Subroutine,
+    ArgList,
+    Concat,
 }
 
 #[derive(Debug)]
 pub struct Fold {
     pub range: TextRange,
     pub kind: FoldKind,
-    pub collapsed_text: Option<String>,
 }
 
 impl Fold {
     fn new(range: TextRange, kind: FoldKind) -> Self {
-        Self { range, kind, collapsed_text: None }
+        Self { range, kind }
     }
 
     #[inline]
@@ -112,7 +115,137 @@ impl FoldCollector for Vec<Fold> {
     }
 }
 
-pub(crate) fn folding_ranges(db: &RootDb, file_id: FileId, _config: &FoldingConfig) -> Vec<Fold> {
+/// Collects folds that are purely syntactic: comment groups, multi-line
+/// argument lists and concatenations, and runs of consecutive package
+/// imports. Everything else is driven by the HIR source maps below.
+fn collect_syntax_folds(
+    db: &RootDb,
+    file_id: HirFileId,
+    line_index: &LineIndex,
+    folds: &mut Vec<Fold>,
+) {
+    let tree = db.parse(file_id);
+    let Some(root) = tree.root() else {
+        return;
+    };
+
+    let mut import_ranges = Vec::new();
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        match node.kind() {
+            SyntaxKind::ARGUMENT_LIST => {
+                if let Some(range) = node.text_range() {
+                    folds.collect_fold(range, FoldKind::ArgList, line_index);
+                }
+            }
+            SyntaxKind::CONCATENATION_EXPRESSION | SyntaxKind::ASSIGNMENT_PATTERN_EXPRESSION => {
+                if let Some(range) = node.text_range() {
+                    folds.collect_fold(range, FoldKind::Concat, line_index);
+                }
+            }
+            SyntaxKind::PACKAGE_IMPORT_DECLARATION => {
+                if let Some(range) = node.text_range() {
+                    import_ranges.push(range);
+                }
+            }
+            _ => {}
+        }
+
+        for child in node.children() {
+            match child {
+                syntax::SyntaxElement::Token(token) => {
+                    collect_token_comments(token, line_index, folds)
+                }
+                syntax::SyntaxElement::Node(node) => stack.push(node),
+            }
+        }
+    }
+
+    // The stack walk visits nodes in reverse sibling order; restore source order.
+    import_ranges.sort_by_key(|range| range.start());
+    collect_item_groups(folds, import_ranges.into_iter(), FoldKind::Imports, line_index);
+}
+
+/// Folds runs of consecutive comments attached to a single token: either a
+/// block comment that spans multiple lines, or at least two consecutive line
+/// comments. Region markers are excluded, they are folded via the region tree.
+fn collect_token_comments(
+    token: SyntaxTokenWithParent<'_>,
+    line_index: &LineIndex,
+    folds: &mut Vec<Fold>,
+) {
+    let check_lc = |t: &SyntaxTrivia<'_>| {
+        t.kind().is_lc() && t.is_region_begin().is_none() && !t.is_region_end()
+    };
+
+    let mut trivias = token.trivias_with_range().peekable();
+    while let Some((range, t)) = trivias.next() {
+        if check_lc(&t) {
+            let comment_start = range.start();
+            let mut comment_end = None;
+
+            // (1 eol + 1 whitespace (optional) + 1 line comment){>=2}
+            while trivias.next_if(|(_, t)| t.kind().is_eol()).is_some() {
+                trivias.next_if(|(_, t)| t.kind().is_whitespace());
+
+                if let Some((range, _)) = trivias.next_if(|(_, t)| check_lc(t)) {
+                    comment_end = Some(range.end());
+                } else {
+                    break;
+                }
+            }
+
+            if let Some(comment_end) = comment_end {
+                let range = TextRange::new(comment_start, comment_end);
+                folds.collect_fold(range, FoldKind::Comment, line_index);
+            }
+        } else if t.kind().is_bc() {
+            folds.collect_fold(range, FoldKind::Comment, line_index);
+        }
+    }
+}
+
+/// Folds consecutive items of the same kind into a single fold: a run of
+/// one-line `assign`s, declarations, or package imports collapses into one
+/// foldable group. Items are considered consecutive when the next one starts
+/// on the line right after the previous one ends (a blank line or another
+/// construct breaks the group).
+fn collect_item_groups(
+    folds: &mut Vec<Fold>,
+    ranges: impl IntoIterator<Item = TextRange>,
+    kind: FoldKind,
+    line_index: &LineIndex,
+) {
+    let mut group_start: Option<TextSize> = None;
+    let mut group_end: Option<TextSize> = None;
+    let mut prev_end_line: Option<u32> = None;
+
+    for range in ranges {
+        let Some(line_ranges) = line_index.line_ranges(range) else {
+            continue;
+        };
+        let start_line = line_ranges.start as u32;
+        let end_line = line_ranges.end as u32 - 1;
+
+        let adjacent = prev_end_line.is_some_and(|prev| start_line == prev + 1);
+        if adjacent {
+            group_end = Some(range.end());
+        } else {
+            if let (Some(start), Some(end)) = (group_start, group_end) {
+                folds.collect_fold(TextRange::new(start, end), kind, line_index);
+            }
+            group_start = Some(range.start());
+            group_end = Some(range.end());
+        }
+        prev_end_line = Some(end_line);
+    }
+
+    if let (Some(start), Some(end)) = (group_start, group_end) {
+        folds.collect_fold(TextRange::new(start, end), kind, line_index);
+    }
+}
+
+pub(crate) fn folding_ranges(db: &RootDb, file_id: FileId) -> Vec<Fold> {
     let line_index = db.line_index(file_id);
     let line_index = line_index.as_ref();
 
@@ -122,9 +255,17 @@ pub(crate) fn folding_ranges(db: &RootDb, file_id: FileId, _config: &FoldingConf
 
     let mut folds = Vec::default();
 
-    collect_comments(db, file_id, line_index, &mut folds);
+    collect_syntax_folds(db, file_id, line_index, &mut folds);
 
     folds.collect_docs(&src_map.region_tree, line_index);
+
+    collect_subroutines(
+        db,
+        &mut folds,
+        SubroutineParent::File(file_id),
+        &src_map.subroutine_srcs,
+        line_index,
+    );
 
     src_map.module_srcs.named_ranges().for_each(|(idx, range, _)| {
         collect_module(db, &mut folds, ModuleId::new(file_id, idx), range, line_index)
@@ -135,6 +276,12 @@ pub(crate) fn folding_ranges(db: &RootDb, file_id: FileId, _config: &FoldingConf
     folds.collect_folds(src_map.library_include_srcs.ranges(), FoldKind::Library, line_index);
     folds.collect_folds(src_map.declaration_srcs.ranges(), FoldKind::Declaration, line_index);
     folds.collect_folds(src_map.decl_srcs.ranges(), FoldKind::Decl, line_index);
+    collect_item_groups(
+        &mut folds,
+        src_map.declaration_srcs.ranges(),
+        FoldKind::Declaration,
+        line_index,
+    );
     collect_stmt(
         db,
         &mut folds,
@@ -144,135 +291,6 @@ pub(crate) fn folding_ranges(db: &RootDb, file_id: FileId, _config: &FoldingConf
     );
 
     folds
-}
-
-fn collect_comments(
-    db: &RootDb,
-    file_id: HirFileId,
-    line_index: &LineIndex,
-    folds: &mut Vec<Fold>,
-) {
-    let tree = db.parse(file_id);
-    let Some(root) = tree.root() else {
-        return;
-    };
-    let mut cursor = root.walk();
-
-    let text = db.file_text(file_id.expect_file());
-    let visited_ranges = collect_line_comments(&text, &mut cursor, line_index, folds);
-    collect_block_comments(&text, &mut cursor, line_index, visited_ranges, folds);
-}
-
-fn collect_line_comments(
-    text: &str,
-    cursor: &mut SyntaxCursor<'_>,
-    line_index: &LineIndex,
-    folds: &mut Vec<Fold>,
-) -> FxHashSet<usize> {
-    let finder = Finder::new("//");
-    let it = finder.find_iter(text.as_bytes());
-    let mut last_pos = 0;
-
-    let mut visited_ranges = FxHashSet::default();
-
-    for start in it {
-        if start < last_pos {
-            continue;
-        }
-
-        cursor.reset_to_root();
-        if !cursor.goto_first_tok_after_or_last(TextSize::from(start as u32)) {
-            continue;
-        }
-        let Some(tok) = cursor.to_tok_with_parent() else {
-            continue;
-        };
-        let Some(tok_range) = tok.text_range() else {
-            continue;
-        };
-        visited_ranges.insert(tok_range.start().into());
-        let mut trivias = tok.trivias_with_range().peekable();
-
-        let check_lc = |t: &SyntaxTrivia| {
-            t.kind().is_lc() && t.is_region_begin().is_none() && !t.is_region_end()
-        };
-
-        // (1 eol + 1 whitespace (optional) + 1 line comment){>=2}
-        while let Some((range, t)) = trivias.next() {
-            if check_lc(&t) {
-                let comment_start = range.start();
-                let mut comment_end = None;
-
-                while trivias.next_if(|(_, t)| t.kind().is_eol()).is_some() {
-                    trivias.next_if(|(_, t)| t.kind().is_whitespace());
-
-                    if let Some((range, _)) = trivias.next_if(|(_, t)| check_lc(t)) {
-                        comment_end = Some(range.end());
-                    } else {
-                        break;
-                    }
-                }
-
-                if let Some(comment_end) = comment_end {
-                    let range = TextRange::new(comment_start, comment_end);
-                    if let Some(fold) = Fold::try_build(range, FoldKind::Comment, line_index) {
-                        folds.push(fold);
-                    }
-                }
-            } else if t.kind().is_bc() {
-                let range = TextRange::new(range.start(), range.end());
-                if let Some(fold) = Fold::try_build(range, FoldKind::Comment, line_index) {
-                    folds.push(fold);
-                }
-            }
-        }
-
-        last_pos = tok_range.start().into();
-    }
-
-    visited_ranges
-}
-
-fn collect_block_comments(
-    text: &str,
-    cursor: &mut SyntaxCursor<'_>,
-    line_index: &LineIndex,
-    visited_ranges: FxHashSet<usize>,
-    folds: &mut Vec<Fold>,
-) {
-    let finder = Finder::new("/*");
-    let it = finder.find_iter(text.as_bytes());
-    let mut last_pos = 0;
-
-    for start in it {
-        if start < last_pos || visited_ranges.contains(&start) {
-            continue;
-        }
-
-        cursor.reset_to_root();
-        if !cursor.goto_first_tok_after_or_last(TextSize::from(start as u32)) {
-            continue;
-        }
-        let Some(tok) = cursor.to_tok_with_parent() else {
-            continue;
-        };
-        let Some(tok_range) = tok.text_range() else {
-            continue;
-        };
-
-        let trivias = tok.trivias_with_range();
-        for (range, trivia) in trivias {
-            if !trivia.kind().is_bc() {
-                continue;
-            }
-
-            if let Some(fold) = Fold::try_build(range, FoldKind::Comment, line_index) {
-                folds.push(fold);
-            }
-        }
-
-        last_pos = tok_range.start().into();
-    }
 }
 
 fn collect_module(
@@ -313,22 +331,22 @@ fn collect_module(
     folds.collect_folds(src_map.specify_item_srcs.ranges(), FoldKind::Specify, line_index);
     folds.collect_folds(src_map.declaration_srcs.ranges(), FoldKind::Declaration, line_index);
     folds.collect_folds(src_map.decl_srcs.ranges(), FoldKind::Decl, line_index);
-    folds.extend(src_map.instance_srcs.named_ranges().filter_map(
-        |(instance_id, range, name_range)| {
-            let instantiation_id = module.get(instance_id).parent;
-
-            if module.get(instantiation_id).instances.len() > 1 {
-                let start = name_range.map_or(range.start(), |range| range.end());
-                Fold::try_build(TextRange::new(start, range.end()), FoldKind::Instance, line_index)
-            } else {
-                Fold::try_build(
-                    module.source_range(instantiation_id)?,
-                    FoldKind::Instance,
-                    line_index,
-                )
-            }
-        },
-    ));
+    collect_item_groups(folds, src_map.assign_srcs.ranges(), FoldKind::ContAssign, line_index);
+    collect_item_groups(
+        folds,
+        src_map.declaration_srcs.ranges(),
+        FoldKind::Declaration,
+        line_index,
+    );
+    collect_instances(folds, &module, &src_map.instance_srcs, line_index);
+    collect_subroutines(
+        db,
+        folds,
+        SubroutineParent::Module(module_id),
+        &src_map.subroutine_srcs,
+        line_index,
+    );
+    collect_generate_regions(db, folds, module_id, line_index);
 
     collect_stmt(
         db,
@@ -337,6 +355,120 @@ fn collect_module(
         src_map.stmt_srcs.iter().map(|(id, src)| (id, *src)),
         line_index,
     );
+}
+
+fn collect_subroutines(
+    db: &RootDb,
+    folds: &mut Vec<Fold>,
+    parent: SubroutineParent,
+    srcs: &SourceMap<SubroutineSrc, Subroutine>,
+    line_index: &LineIndex,
+) {
+    for (value, src) in srcs.iter() {
+        let scope = SubroutineScope { cont_id: parent, value };
+        let subroutine = db.subroutine_with_source_map(scope);
+        let src_map = subroutine.source_map();
+
+        folds.collect_docs(&src_map.region_tree, line_index);
+        folds.collect_fold(src.range(), FoldKind::Subroutine, line_index);
+        folds.collect_folds(src_map.declaration_srcs.ranges(), FoldKind::Declaration, line_index);
+        folds.collect_folds(src_map.decl_srcs.ranges(), FoldKind::Decl, line_index);
+        collect_item_groups(
+            folds,
+            src_map.declaration_srcs.ranges(),
+            FoldKind::Declaration,
+            line_index,
+        );
+        collect_stmt(
+            db,
+            folds,
+            &subroutine.stmts,
+            src_map.stmt_srcs.iter().map(|(id, src)| (id, *src)),
+            line_index,
+        );
+    }
+}
+
+fn collect_generate_regions(
+    db: &RootDb,
+    folds: &mut Vec<Fold>,
+    module_id: ModuleId,
+    line_index: &LineIndex,
+) {
+    let module = db.module_with_source_map(module_id);
+    let src_map = module.source_map();
+    for (region_id, _) in src_map.generate_region_srcs.iter() {
+        let region = module.get(region_id);
+        for item in &region.items {
+            if let hir_def::module::generate::GenerateItem::GenerateBlockId(block_id) = item {
+                collect_generate_block(db, folds, *block_id, line_index);
+            }
+        }
+    }
+}
+
+fn collect_generate_block(
+    db: &RootDb,
+    folds: &mut Vec<Fold>,
+    block_id: GenerateBlockId,
+    line_index: &LineIndex,
+) {
+    let block = db.generate_block_with_source_map(block_id);
+    let src_map = block.source_map();
+
+    folds.collect_docs(&src_map.region_tree, line_index);
+    folds.collect_folds(src_map.assign_srcs.ranges(), FoldKind::ContAssign, line_index);
+    folds.collect_folds(src_map.defparam_srcs.ranges(), FoldKind::DefParam, line_index);
+    folds.collect_folds(src_map.declaration_srcs.ranges(), FoldKind::Declaration, line_index);
+    collect_item_groups(folds, src_map.assign_srcs.ranges(), FoldKind::ContAssign, line_index);
+    collect_item_groups(
+        folds,
+        src_map.declaration_srcs.ranges(),
+        FoldKind::Declaration,
+        line_index,
+    );
+    collect_instances(folds, &block, &src_map.instance_srcs, line_index);
+    collect_subroutines(
+        db,
+        folds,
+        SubroutineParent::GenerateBlock(block_id),
+        &src_map.subroutine_srcs,
+        line_index,
+    );
+
+    for item in &block.items {
+        if let hir_def::module::generate::GenerateBlockItem::GenerateBlockId(block_id) = item {
+            collect_generate_block(db, folds, *block_id, line_index);
+        }
+    }
+}
+
+fn collect_instances<T, M>(
+    folds: &mut Vec<Fold>,
+    container: &Lowered<T>,
+    instance_srcs: &SourceMap<InstanceSrc, Instance>,
+    line_index: &LineIndex,
+) where
+    T: LoweredData<SourceMap = M>
+        + GetRef<InstanceId, Output = Instance>
+        + GetRef<InstantiationId, Output = Instantiation>,
+    M: Get<InstanceId, Output = Option<InstanceSrc>>
+        + Get<InstantiationId, Output = Option<InstantiationSrc>>,
+{
+    folds.extend(instance_srcs.named_ranges().filter_map(|(instance_id, range, name_range)| {
+        let instantiation_id = container.get(instance_id).parent;
+
+        if container.get(instantiation_id).instances.len() > 1 {
+            let start = name_range.map_or(range.start(), |range| range.end());
+            Fold::try_build(TextRange::new(start, range.end()), FoldKind::Instance, line_index)
+        } else {
+            Fold::try_build(
+                container.source_range(instantiation_id)?,
+                FoldKind::Instance,
+                line_index,
+            )
+        }
+    }));
 }
 
 fn collect_block(
@@ -354,6 +486,12 @@ fn collect_block(
     folds.collect_fold(block_range, FoldKind::Block, line_index);
     folds.collect_folds(src_map.declaration_srcs.ranges(), FoldKind::Declaration, line_index);
     folds.collect_folds(src_map.decl_srcs.ranges(), FoldKind::Decl, line_index);
+    collect_item_groups(
+        folds,
+        src_map.declaration_srcs.ranges(),
+        FoldKind::Declaration,
+        line_index,
+    );
     collect_stmt(
         db,
         folds,

--- a/crates/ide/src/folding_ranges.rs
+++ b/crates/ide/src/folding_ranges.rs
@@ -216,9 +216,16 @@ fn collect_item_groups(
     kind: FoldKind,
     line_index: &LineIndex,
 ) {
-    let mut group_start: Option<TextSize> = None;
-    let mut group_end: Option<TextSize> = None;
+    let mut group: Option<(TextSize, TextSize, usize)> = None; // (start, end, len)
     let mut prev_end_line: Option<u32> = None;
+
+    let flush = |folds: &mut Vec<Fold>, group: &mut Option<(TextSize, TextSize, usize)>| {
+        if let Some((start, end, len)) = group.take()
+            && len > 1
+        {
+            folds.collect_fold(TextRange::new(start, end), kind, line_index);
+        }
+    };
 
     for range in ranges {
         let Some(line_ranges) = line_index.line_ranges(range) else {
@@ -229,20 +236,15 @@ fn collect_item_groups(
 
         let adjacent = prev_end_line.is_some_and(|prev| start_line == prev + 1);
         if adjacent {
-            group_end = Some(range.end());
+            let (start, _, len) = group.unwrap();
+            group = Some((start, range.end(), len + 1));
         } else {
-            if let (Some(start), Some(end)) = (group_start, group_end) {
-                folds.collect_fold(TextRange::new(start, end), kind, line_index);
-            }
-            group_start = Some(range.start());
-            group_end = Some(range.end());
+            flush(folds, &mut group);
+            group = Some((range.start(), range.end(), 1));
         }
         prev_end_line = Some(end_line);
     }
-
-    if let (Some(start), Some(end)) = (group_start, group_end) {
-        folds.collect_fold(TextRange::new(start, end), kind, line_index);
-    }
+    flush(folds, &mut group);
 }
 
 pub(crate) fn folding_ranges(db: &RootDb, file_id: FileId) -> Vec<Fold> {
@@ -846,6 +848,23 @@ endmodule</fold>
     }
 
     #[test]
+    fn fold_argument_lists_and_concatenations() {
+        check_folds(
+            r#"<fold module>module m;
+  always_comb <fold block>begin
+    <fold stmt>x = foo<fold arglist>(a,
+      b,
+      c)</fold>;</fold>
+    <fold stmt>y = <fold concat>{a,
+      b,
+      c}</fold>;</fold>
+  end</fold>
+endmodule</fold>
+"#,
+        );
+    }
+
+    #[test]
     fn fold_pseudo_region() {
         check_folds(
             r#"<fold module>module m;
@@ -858,17 +877,13 @@ endmodule</fold>
     }
 
     #[test]
-    fn fold_argument_lists_and_concatenations() {
+    fn fold_single_item_group_does_not_fold_twice() {
+        // A lone multi-line declaration folds once: the item fold, not a
+        // single-element group on top of it.
         check_folds(
             r#"<fold module>module m;
-  always_comb <fold block>begin
-    <fold stmt>x = foo<fold arglist>(a,
-      b,
-      c)</fold>;</fold>
-    <fold stmt>y = <fold concat>{a,
-      b,
-      c}</fold>;</fold>
-  end</fold>
+<fold declaration>logic a,
+  b;</fold>
 endmodule</fold>
 "#,
         );

--- a/crates/ide/src/folding_ranges.rs
+++ b/crates/ide/src/folding_ranges.rs
@@ -520,3 +520,367 @@ fn collect_stmt(
         }
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use base_db::{change::Change, source_root::SourceRoot};
+    use utils::line_index::{TextRange, TextSize};
+    use vfs::{ChangedFile, FileId, FileSet, VfsPath};
+
+    use super::{Fold, FoldKind, folding_ranges};
+    use crate::db::root_db::RootDb;
+
+    fn db_with_file(text: &str) -> (RootDb, FileId) {
+        let file_id = FileId::from_raw(0);
+        let path = VfsPath::new_virtual_path("/test.sv".to_owned());
+
+        let mut file_set = FileSet::default();
+        file_set.insert(file_id, path);
+        let root = SourceRoot::new_local(file_set);
+
+        let mut change = Change::new();
+        change.set_roots(vec![root]);
+        change.add_changed_file(ChangedFile::create(file_id, text));
+
+        let mut db = RootDb::new(None);
+        change.apply(&mut db);
+        (db, file_id)
+    }
+
+    /// Extracts `<fold kind>...</fold>` tags from a fixture, returning the
+    /// cleaned text and the expected fold ranges (in cleaned-text offsets).
+    fn extract_fold_tags(text: &str) -> (String, Vec<(TextRange, FoldKind)>) {
+        let mut clean = String::new();
+        let mut expected = Vec::new();
+        let mut stack: Vec<(usize, FoldKind)> = Vec::new();
+        let mut rest = text;
+
+        loop {
+            let open = rest.find("<fold ");
+            let close = rest.find("</fold>");
+            match (open, close) {
+                (Some(start), Some(close)) if start < close => {
+                    let name_end = rest[start..].find('>').map(|i| start + i).unwrap();
+                    let kind = parse_fold_kind(&rest[start + 6..name_end]);
+                    clean.push_str(&rest[..start]);
+                    stack.push((clean.len(), kind));
+                    rest = &rest[name_end + 1..];
+                }
+                (Some(start), None) => {
+                    let name_end = rest[start..].find('>').map(|i| start + i).unwrap();
+                    let kind = parse_fold_kind(&rest[start + 6..name_end]);
+                    clean.push_str(&rest[..start]);
+                    stack.push((clean.len(), kind));
+                    rest = &rest[name_end + 1..];
+                }
+                (_, Some(rel)) => {
+                    clean.push_str(&rest[..rel]);
+                    let (range_start, kind) = stack.pop().expect("unbalanced </fold>");
+                    expected.push((
+                        TextRange::new(
+                            TextSize::from(range_start as u32),
+                            TextSize::from(clean.len() as u32),
+                        ),
+                        kind,
+                    ));
+                    rest = &rest[rel + 7..];
+                }
+                (None, None) => {
+                    clean.push_str(rest);
+                    break;
+                }
+            }
+        }
+        assert!(stack.is_empty(), "unbalanced <fold> tags");
+        (clean, expected)
+    }
+
+    fn parse_fold_kind(name: &str) -> FoldKind {
+        match name {
+            "comment" => FoldKind::Comment,
+            "imports" => FoldKind::Imports,
+            "region" => FoldKind::Region,
+            "module" => FoldKind::Module,
+            "config" => FoldKind::Config,
+            "library" => FoldKind::Library,
+            "portlist" => FoldKind::PortList,
+            "decl" => FoldKind::Decl,
+            "declaration" => FoldKind::Declaration,
+            "contassign" => FoldKind::ContAssign,
+            "defparam" => FoldKind::DefParam,
+            "generate" => FoldKind::Generate,
+            "specify" => FoldKind::Specify,
+            "instance" => FoldKind::Instance,
+            "stmt" => FoldKind::Stmt,
+            "block" => FoldKind::Block,
+            "subroutine" => FoldKind::Subroutine,
+            "arglist" => FoldKind::ArgList,
+            "concat" => FoldKind::Concat,
+            other => panic!("unknown fold kind {other:?}"),
+        }
+    }
+
+    fn check_folds(fixture: &str) {
+        let (text, mut expected) = extract_fold_tags(fixture);
+        let (db, file_id) = db_with_file(&text);
+        let mut folds = folding_ranges(&db, file_id);
+
+        // Equal-range folds (e.g. a pseudo region and its declaration group)
+        // may arrive in any order, so tie-break by kind.
+        let order =
+            |fold: &Fold| (fold.range.start(), fold.range.end(), format!("{:?}", fold.kind));
+        folds.sort_by_key(order);
+        expected.sort_by_key(|(range, kind)| (range.start(), range.end(), format!("{kind:?}")));
+
+        if folds.len() != expected.len() {
+            let mut report = String::new();
+            for fold in &folds {
+                report.push_str(&format!("  {:?} {:?}\n", fold.kind, fold.range));
+            }
+            panic!(
+                "fold count mismatch: got {} folds, expected {}\n{report}",
+                folds.len(),
+                expected.len()
+            );
+        }
+        for (fold, (range, kind)) in folds.iter().zip(expected) {
+            assert_eq!(fold.range, range, "range mismatch");
+            assert_eq!(fold.kind, kind, "kind mismatch for {range:?}");
+        }
+    }
+
+    #[test]
+    fn fold_comments() {
+        check_folds(
+            r#"<fold comment>// one
+// two</fold>
+
+// standalone
+
+<fold comment>/* block
+ * comment */</fold>
+"#,
+        );
+    }
+
+    #[test]
+    fn fold_comments_do_not_cross_blank_lines() {
+        check_folds(
+            r#"// one
+
+<fold comment>// two
+// three</fold>
+
+// four
+module m; endmodule
+"#,
+        );
+    }
+
+    #[test]
+    fn fold_regions() {
+        check_folds(
+            r#"<fold region>// region: file
+// body
+// endregion</fold>
+
+<fold module>module m;
+  <fold region>// region: inner
+  logic x;
+  // endregion</fold>
+endmodule</fold>
+"#,
+        );
+    }
+
+    #[test]
+    fn fold_region_markers_are_not_comment_folds() {
+        check_folds(
+            r#"<fold region>// region: keep
+// marker lines are folded as a region, not as a comment run
+// endregion</fold>
+"#,
+        );
+    }
+
+    #[test]
+    fn fold_module_with_port_list() {
+        check_folds(
+            r#"module m <fold portlist>(
+  input logic a,
+  output logic b
+)</fold>;
+<fold module><fold declaration>logic x;
+logic y;</fold>
+  always_comb <fold block>begin
+    x = a;
+  end</fold>
+endmodule</fold>
+"#,
+        );
+    }
+
+    #[test]
+    fn fold_module_without_port_list_fold() {
+        check_folds(
+            r#"<fold module>module m(a, b);
+  logic x;
+endmodule</fold>
+"#,
+        );
+    }
+
+    #[test]
+    fn fold_subroutines() {
+        check_folds(
+            r#"<fold module>module m;
+<fold subroutine>function logic f;
+  <fold block>begin
+    x = a;
+  end</fold>
+endfunction</fold>
+
+<fold subroutine>task t;
+  x = a;
+endtask</fold>
+endmodule</fold>
+"#,
+        );
+    }
+
+    #[test]
+    fn fold_file_level_subroutine() {
+        check_folds(
+            r#"<fold subroutine>function logic file_f;
+  return a;
+endfunction</fold>
+
+module m; endmodule
+"#,
+        );
+    }
+
+    #[test]
+    fn fold_instances() {
+        check_folds(
+            r#"<fold module>module m;
+<fold instance>u_mod u0 (
+  .a(a),
+  .b(b)
+);</fold>
+endmodule</fold>
+"#,
+        );
+    }
+
+    #[test]
+    fn fold_multi_instance_folds_from_name_end() {
+        check_folds(
+            r#"<fold module>module m;
+u_mod u0<fold instance> (
+  .a(a)
+)</fold>,
+u1<fold instance> (
+  .b(b)
+)</fold>;
+endmodule</fold>
+"#,
+        );
+    }
+
+    #[test]
+    fn fold_generate_block() {
+        check_folds(
+            r#"<fold module>module m;
+<fold generate>generate
+  if (COND) begin : genblk
+    <fold instance>u_mod u1 (
+      .a(a)
+    );</fold>
+  end
+endgenerate</fold>
+endmodule</fold>
+"#,
+        );
+    }
+
+    #[test]
+    fn fold_import_groups() {
+        check_folds(
+            r#"<fold imports>import pkg_a::*;
+import pkg_b::*;</fold>
+
+<fold module>module m;
+  <fold imports>import pkg_c::*;
+  import pkg_d::*;</fold>
+endmodule</fold>
+"#,
+        );
+    }
+
+    #[test]
+    fn fold_assign_groups() {
+        check_folds(
+            r#"<fold module>module m;
+<fold contassign>assign a = x;
+assign b = y;</fold>
+
+assign c = z;
+endmodule</fold>
+"#,
+        );
+    }
+
+    #[test]
+    fn fold_declaration_group_breaks_on_other_items() {
+        check_folds(
+            r#"<fold module>module m;
+<fold declaration>logic a;
+logic b;</fold>
+assign x = y;
+<fold declaration>logic c;
+logic d;</fold>
+endmodule</fold>
+"#,
+        );
+    }
+
+    #[test]
+    fn fold_pseudo_region() {
+        check_folds(
+            r#"<fold module>module m;
+// grouped declarations
+<fold region><fold declaration>logic a;
+logic b;</fold></fold>
+endmodule</fold>
+"#,
+        );
+    }
+
+    #[test]
+    fn fold_argument_lists_and_concatenations() {
+        check_folds(
+            r#"<fold module>module m;
+  always_comb <fold block>begin
+    <fold stmt>x = foo<fold arglist>(a,
+      b,
+      c)</fold>;</fold>
+    <fold stmt>y = <fold concat>{a,
+      b,
+      c}</fold>;</fold>
+  end</fold>
+endmodule</fold>
+"#,
+        );
+    }
+
+    #[test]
+    fn fold_config() {
+        check_folds(
+            r#"<fold config>config cfg;
+  design top;
+endconfig</fold>
+"#,
+        );
+    }
+}

--- a/crates/ide/src/selection_ranges.rs
+++ b/crates/ide/src/selection_ranges.rs
@@ -1,11 +1,13 @@
 use hir_semantics::semantics::Semantics;
 use itertools::Itertools;
+use preproc_expand::{db::PreprocDb, file::HirFileId};
 use syntax::{
-    SyntaxCursorExt, SyntaxNodeExt, TokenKind,
+    SyntaxCursorExt, SyntaxNodeExt, TokenKind, Trivia,
     has_text_range::HasTextRange,
     token::{SyntaxTokenWithParentExt, TokenKindExt},
 };
-use utils::line_index::TextRange;
+use utils::line_index::{TextRange, TextSize};
+use vfs::FileId;
 
 use crate::{FilePosition, db::root_db::RootDb};
 
@@ -42,18 +44,46 @@ pub(crate) fn selection_ranges(
             let Some(token) = cursor.to_tok_with_parent() else {
                 return res;
             };
-            let trivias = token.trivias_with_range().collect_vec();
-            let Some(range) = trivias.iter().find(|(range, _)| range.contains(offset)) else {
+            let Some(token_range) = token.text_range() else {
                 return res;
             };
-            res.push(range.0);
+            let trivias = token.trivias_with_range().collect_vec();
 
-            let (Some(first_trivia), Some(token_range)) = (trivias.first(), token.text_range())
-            else {
+            // Cursor inside a trivia piece with a real range (comments,
+            // whitespace). Directive trivia is zero-width and handled below.
+            if let Some((range, trivia)) = trivias.iter().find(|(range, _)| range.contains(offset))
+                && trivia.kind() != Trivia!["`"]
+            {
+                push_distinct(&mut res, *range);
+            }
+
+            // The cursor may also sit on a preprocessor directive or inside an
+            // inactive `` `ifdef `` branch: directives are zero-width trivia and
+            // disabled code is absent from the tree entirely, so recover their
+            // ranges from the preprocessor trace.
+            let mut hit = false;
+            if let Some(regions) = trace_regions(db, file_id) {
+                if let Some(range) = regions.directive_at(offset) {
+                    push_distinct(&mut res, range);
+                    hit = true;
+                }
+                if let Some(range) = regions.disabled_at(offset) {
+                    push_distinct(&mut res, range);
+                    hit = true;
+                }
+            }
+            if !hit && res.len() == 1 {
+                return res;
+            }
+
+            let Some(first_trivia) = trivias.first() else {
                 return res;
             };
             let trivias_start = first_trivia.0.start();
-            res.push(TextRange::new(trivias_start, token_range.start()));
+            let range = TextRange::new(trivias_start, token_range.start());
+            if !range.is_empty() && res.last() != Some(&range) {
+                res.push(range);
+            }
             Some(trivias_start)
         }
     };
@@ -87,6 +117,66 @@ pub(crate) fn selection_ranges(
     }
 
     res
+}
+
+/// Preprocessor regions recovered from the trace: directive keyword/name
+/// ranges and inactive `` `ifdef `` branch bodies. All ranges are offsets in
+/// the file the tree was parsed from (the trace root buffer).
+struct DirectiveRegions {
+    directives: Vec<TextRange>,
+    disabled: Vec<TextRange>,
+}
+
+impl DirectiveRegions {
+    fn directive_at(&self, offset: TextSize) -> Option<TextRange> {
+        self.directives.iter().find(|range| range.contains(offset)).copied()
+    }
+
+    fn disabled_at(&self, offset: TextSize) -> Option<TextRange> {
+        self.disabled.iter().find(|range| range.contains(offset)).copied()
+    }
+}
+
+fn trace_regions(db: &RootDb, file_id: FileId) -> Option<DirectiveRegions> {
+    let trace = db.parse(HirFileId::File(file_id)).preprocessor_trace()?;
+    let root_buffer_id = trace.root_buffer_id;
+
+    let mut regions = DirectiveRegions { directives: Vec::new(), disabled: Vec::new() };
+    for event in &trace.events {
+        if let Some(directive) = &event.directive
+            && let Some(range) = &directive.range
+            && range.buffer_id == root_buffer_id
+        {
+            push_range(&mut regions.directives, &range.range);
+        }
+        if let Some(name) = &event.name
+            && let Some(range) = &name.range
+            && range.buffer_id == root_buffer_id
+        {
+            push_range(&mut regions.directives, &range.range);
+        }
+        for range in &event.disabled_ranges {
+            if range.buffer_id == root_buffer_id {
+                push_range(&mut regions.disabled, &range.range);
+            }
+        }
+    }
+    Some(regions)
+}
+
+fn push_range(ranges: &mut Vec<TextRange>, range: &std::ops::Range<usize>) {
+    if range.start < range.end {
+        ranges.push(TextRange::new(
+            TextSize::from(range.start as u32),
+            TextSize::from(range.end as u32),
+        ));
+    }
+}
+
+fn push_distinct(res: &mut Vec<TextRange>, range: TextRange) {
+    if !range.is_empty() && res.last() != Some(&range) {
+        res.push(range);
+    }
 }
 
 fn token_precedence(kind: TokenKind) -> usize {
@@ -128,9 +218,28 @@ mod tests {
     fn selection_range_matrix() {
         let mut report = String::new();
 
-        for (name, text, offset) in
-            [("empty file", "", 0), ("trivia-only line comment", "// hello", 3)]
-        {
+        for (name, text, offset) in [
+            ("empty file", "", 0),
+            ("trivia-only line comment", "// hello", 3),
+            ("line comment in module", "module top; // comment here\nendmodule\n", 15),
+            ("directive line", "module top;\n`ifdef FOO\n  logic x;\n`endif\nendmodule\n", 14),
+            (
+                "inactive branch body",
+                "module top;\n`ifdef FOO\n  logic x;\n`endif\nendmodule\n",
+                28,
+            ),
+            (
+                "directive continuation",
+                "module top;\n`ifdef FOO\n  logic x;\n`endif\nendmodule\n",
+                17,
+            ),
+            (
+                "in begin block",
+                "module top;\n  always_comb begin\n    x = 1;\n  end\nendmodule\n",
+                30,
+            ),
+            ("at token boundary", "module top;\n  assign y = a + b;\nendmodule\n", 31),
+        ] {
             let (db, file_id) = db_with_file(text);
             let ranges = selection_ranges(&db, FilePosition { file_id, offset: offset.into() });
             writeln!(&mut report, "{name}: {ranges:?}").unwrap();

--- a/crates/ide/src/snapshots/ide__selection_ranges__tests__selection_range_matrix.snap
+++ b/crates/ide/src/snapshots/ide__selection_ranges__tests__selection_range_matrix.snap
@@ -1,6 +1,13 @@
 ---
 source: crates/ide/src/selection_ranges.rs
+assertion_line: 248
 expression: report
 ---
 empty file: [0..0]
-trivia-only line comment: [3..3, 0..8, 0..8]
+trivia-only line comment: [3..3, 0..8]
+line comment in module: [15..15, 12..27, 11..28, 11..37, 0..37, 0..38]
+directive line: [14..14, 12..18, 11..41, 11..50, 0..50, 0..51]
+inactive branch body: [28..28, 25..33, 11..41, 11..50, 0..50, 0..51]
+directive continuation: [17..17, 12..18, 11..41, 11..50, 0..50, 0..51]
+in begin block: [30..30, 26..31, 26..48, 14..48, 0..58, 0..59]
+at token boundary: [31..31, 30..31, 14..31, 0..41, 0..42]

--- a/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_feature_matrix.snap
+++ b/crates/ide/src/snapshots/ide__verilog_2005__verilog_2005_feature_matrix.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ide/src/verilog_2005.rs
+assertion_line: 420
 expression: report
 ---
 ## assignments/continuous_and_procedural.v
@@ -77,15 +78,17 @@ document_symbols:
     in_wire NetDecl container=Some("explicit_ansi_port")
 semantic_token_classes:
   Port(Others) SemaTokenModifier(0x0): 10
-folding_ranges: 8
+folding_ranges: 10
   Comment 0..120
   PortList 140..205
   Module 207..404
+  Declaration 211..299
   Stmt 312..394
   Block 327..394
   Module 406..492
   PortList 520..570
   Module 572..618
+  Declaration 576..608
 
 ## expressions/operators_selects_concat.v
 parse_diagnostics: []
@@ -219,10 +222,14 @@ document_symbols:
     add1 Fn container=Some("tasks_functions")
 semantic_token_classes:
   Port(Others) SemaTokenModifier(0x0): 3
-folding_ranges: 5
+folding_ranges: 9
   Comment 0..80
   PortList 105..150
   Module 152..446
+  Subroutine 156..255
+  Block 203..243
+  Subroutine 261..383
+  Block 317..367
   Stmt 396..436
   Block 399..436
 

--- a/crates/ide/src/verilog_2005.rs
+++ b/crates/ide/src/verilog_2005.rs
@@ -33,7 +33,6 @@ use crate::{
     db::root_db::RootDb,
     document_highlight::DocumentHighlightConfig,
     document_symbols::DocumentSymbol,
-    folding_ranges::FoldingConfig,
     hover::{HoverConfig, HoverFormat},
     references::{ReferencesConfig, search::SearchScope},
     rename::{RenameConfig, RenameEditScope, RenameError},
@@ -409,7 +408,7 @@ fn verilog_2005_feature_matrix_lsp_requests_do_not_panic() {
         }
 
         let folds = analysis
-            .folding_ranges(file_id, &FoldingConfig { line_fold_only: false })
+            .folding_ranges(file_id)
             .unwrap_or_else(|_| panic!("folding ranges cancelled for {path:?}"));
         writeln!(&mut report, "folding_ranges: {}", folds.len()).unwrap();
         for fold in folds {

--- a/src/global_state/handlers/request/symbols.rs
+++ b/src/global_state/handlers/request/symbols.rs
@@ -1,4 +1,4 @@
-﻿use ide::{FilePosition, folding_ranges::FoldingConfig};
+﻿use ide::FilePosition;
 use itertools::Itertools;
 use utils::text_edit::TextRange;
 
@@ -92,15 +92,15 @@ pub(crate) fn handle_folding_ranges(
     params: lsp_types::FoldingRangeParams,
 ) -> anyhow::Result<Option<Vec<lsp_types::FoldingRange>>> {
     let file_id = from_proto::file_id(&snap, &params.text_document.uri)?;
-    let config = FoldingConfig { line_fold_only: snap.config.cli_line_folding_only() };
+    let line_fold_only = snap.config.cli_line_folding_only();
     let text = snap.file_text(file_id)?;
     let line_info = snap.line_info(file_id)?;
 
     let folds = snap
         .analysis
-        .folding_ranges(file_id, &config)?
+        .folding_ranges(file_id)?
         .into_iter()
-        .map(|fold| to_proto::folding_range(&text, &line_info, &config, fold))
+        .map(|fold| to_proto::folding_range(&text, &line_info, line_fold_only, fold))
         .collect();
 
     Ok(Some(folds))

--- a/src/lsp_ext/to_proto.rs
+++ b/src/lsp_ext/to_proto.rs
@@ -8,7 +8,7 @@ use ide::{
     code_lens::{CodeLens, CodeLensKind},
     diagnostics as ide_diagnostics,
     document_highlight::DocumentHighlight,
-    folding_ranges::{Fold, FoldingConfig},
+    folding_ranges::Fold,
     hover::HoverFormat,
     inlay_hint::{InlayHint, InlayKind},
     markup::Markup,
@@ -485,8 +485,8 @@ pub(crate) fn selection_ranges(
 pub(crate) fn folding_range(
     text: &str,
     line_info: &LineInfo,
-    FoldingConfig { line_fold_only }: &FoldingConfig,
-    Fold { range, kind, collapsed_text }: Fold,
+    line_fold_only: bool,
+    Fold { range, kind }: Fold,
 ) -> lsp_types::FoldingRange {
     use ide::folding_ranges::FoldKind;
     let kind = match kind {
@@ -498,7 +498,7 @@ pub(crate) fn folding_range(
 
     let lsp_types::Range { start, end } = self::range(line_info, range);
 
-    if *line_fold_only {
+    if line_fold_only {
         // Clients with `line_folding_only` will fold the whole end line even if
         // it contains text not in the folding range. So we should exclude the end
         // line if there is more text after the end character on the same line.
@@ -515,7 +515,7 @@ pub(crate) fn folding_range(
             end_line,
             end_character: None,
             kind,
-            collapsed_text,
+            collapsed_text: None,
         }
     } else {
         lsp_types::FoldingRange {
@@ -524,7 +524,7 @@ pub(crate) fn folding_range(
             end_line: end.line,
             end_character: Some(end.character),
             kind,
-            collapsed_text,
+            collapsed_text: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

Four commits improving folding and selection, driven by the review goals of correctness, cleanliness, and efficiency:

1. **Expand folding coverage** (`crates/ide/src/folding_ranges.rs`, LSP layer)
   - Fold function/task bodies (`Subroutine`) at file, module, and generate-block level, recursing into their statement arenas like blocks.
   - Recurse into generate blocks: instances, subroutines, assigns, and declarations inside `generate` now fold individually.
   - Fold runs of consecutive single-line items into one group fold: package imports (`Imports`), continuous assigns, and declarations.
   - Fold multi-line argument lists and concatenations/assignment patterns syntactically, like rust-analyzer's ArgList/Array folds.
   - Rewrite comment folding as a single syntax walk over token trivia; drop the memchr scan and the ineffective `visited_ranges` set.
   - Remove `FoldingConfig` from the ide API (`line_fold_only` is purely a client-capability concern at the LSP layer) and the never-populated `collapsed_text` field.

2. **Selection inside preprocessor directives and inactive ifdef branches**
   - Directive trivia is zero-width in the syntax tree and disabled code is absent from it entirely. Recover exact ranges from the preprocessor trace (root buffer offsets are the file's own offsets): directive keyword/name ranges for ifdef/define/include lines, and `disabled_ranges` for inactive branch bodies.
   - Drop the duplicate selection range that appeared for trivia-only files.

3. **Fold fixture matrix + region fix**
   - rust-analyzer style `<fold kind>` fixture harness covering every fold kind.
   - Fix a pre-existing ordering bug in `RegionTreeBuilder::stage`: the closing token's trivia was scanned only after open regions were force-closed, so an `endregion` marker attached to `endmodule`/EOF was lost and the region stretched to the end of the container.

4. **Single-item group fold fix**
   - `collect_item_groups` folded a lone multi-line item as a one-element group, duplicating the item fold; require at least two items per group.

## Validation

- `cargo test --workspace` green (540+ tests, including 18 new folding fixtures and an extended selection matrix).
- `cargo fmt --check` clean for all touched files.

## Follow-up

Opened separately: `library` declarations in `.sv` files (library-map syntax) recover into misleading multi-line declaration folds (see issue).
